### PR TITLE
feat(api): centralize GraphQL auth/authz via gqlgen middleware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ bootstrap-token: bootstrap-tools ## Login and print/cache a bootstrap bearer tok
 		exit 2; \
 	fi
 	@mkdir -p "$$(dirname "$${BOOTSTRAP_TOKEN_CACHE}")"
-	@query='mutation Login($$username: String!, $$password: String!) { login(input: { username: $$username, password: $$password }) { session { token } } }'; \
+	@query='mutation Login($$username: String!, $$password: String!) { login(input: { username: $$username, password: $$password }) { token { accessToken } } }'; \
 	payload=$$(jq -n --arg query "$$query" --arg username "$${ADMIN_USERNAME}" --arg password "$${ADMIN_PASSWORD}" '{query: $$query, variables: {username: $$username, password: $$password}}'); \
 	response=$$(curl --silent --show-error --connect-timeout 5 -H 'Content-Type: application/json' --data "$$payload" "$${API_URL}") || { \
 		echo "Failed to reach GitStore API at $${API_URL}. Start it with make compose or make dev."; \
@@ -239,7 +239,7 @@ bootstrap-token: bootstrap-tools ## Login and print/cache a bootstrap bearer tok
 		echo "Hint: verify ADMIN_USERNAME and ADMIN_PASSWORD match the hash in gitstore-api/.env (run 'make gen-admin-password ADMIN_PASSWORD=<password>' to regenerate)."; \
 		exit 1; \
 	fi; \
-	token=$$(echo "$$response" | jq -er '.data.login.session.token // empty') || { \
+	token=$$(echo "$$response" | jq -er '.data.login.token.accessToken // empty') || { \
 		echo "Login response did not contain a token. Check ADMIN_USERNAME, ADMIN_PASSWORD, and API_URL."; \
 		echo "Hint: run 'make gen-admin-password ADMIN_PASSWORD=<password>' to regenerate the password hash in gitstore-api/.env."; \
 		exit 1; \
@@ -257,7 +257,7 @@ bootstrap-namespace: bootstrap-tools ## Create only the bootstrap namespace.
 			echo "ADMIN_PASSWORD is required unless BOOTSTRAP_TOKEN is provided or $${BOOTSTRAP_TOKEN_CACHE} exists"; \
 			exit 2; \
 		fi; \
-		query='mutation Login($$username: String!, $$password: String!) { login(input: { username: $$username, password: $$password }) { session { token } } }'; \
+		query='mutation Login($$username: String!, $$password: String!) { login(input: { username: $$username, password: $$password }) { token { accessToken } } }'; \
 		payload=$$(jq -n --arg query "$$query" --arg username "$${ADMIN_USERNAME}" --arg password "$${ADMIN_PASSWORD}" '{query: $$query, variables: {username: $$username, password: $$password}}'); \
 		response=$$(curl --silent --show-error --connect-timeout 5 -H 'Content-Type: application/json' --data "$$payload" "$${API_URL}") || { \
 			echo "Failed to reach GitStore API at $${API_URL}. Start it with make compose or make dev."; \
@@ -268,7 +268,7 @@ bootstrap-namespace: bootstrap-tools ## Create only the bootstrap namespace.
 			echo "Hint: verify ADMIN_USERNAME and ADMIN_PASSWORD match the hash in gitstore-api/.env (run 'make gen-admin-password ADMIN_PASSWORD=<password>' to regenerate)."; \
 			exit 1; \
 		fi; \
-		token=$$(echo "$$response" | jq -er '.data.login.session.token // empty') || { \
+		token=$$(echo "$$response" | jq -er '.data.login.token.accessToken // empty') || { \
 			echo "Login response did not contain a token."; \
 			echo "Hint: run 'make gen-admin-password ADMIN_PASSWORD=<password>' to regenerate the password hash in gitstore-api/.env."; \
 			exit 1; \
@@ -295,7 +295,7 @@ bootstrap-repository: bootstrap-tools ## Create only the bootstrap repository; n
 			echo "ADMIN_PASSWORD is required unless BOOTSTRAP_TOKEN is provided or $${BOOTSTRAP_TOKEN_CACHE} exists"; \
 			exit 2; \
 		fi; \
-		query='mutation Login($$username: String!, $$password: String!) { login(input: { username: $$username, password: $$password }) { session { token } } }'; \
+		query='mutation Login($$username: String!, $$password: String!) { login(input: { username: $$username, password: $$password }) { token { accessToken } } }'; \
 		payload=$$(jq -n --arg query "$$query" --arg username "$${ADMIN_USERNAME}" --arg password "$${ADMIN_PASSWORD}" '{query: $$query, variables: {username: $$username, password: $$password}}'); \
 		response=$$(curl --silent --show-error --connect-timeout 5 -H 'Content-Type: application/json' --data "$$payload" "$${API_URL}") || { \
 			echo "Failed to reach GitStore API at $${API_URL}. Start it with make compose or make dev."; \
@@ -306,7 +306,7 @@ bootstrap-repository: bootstrap-tools ## Create only the bootstrap repository; n
 			echo "Hint: verify ADMIN_USERNAME and ADMIN_PASSWORD match the hash in gitstore-api/.env (run 'make gen-admin-password ADMIN_PASSWORD=<password>' to regenerate)."; \
 			exit 1; \
 		fi; \
-		token=$$(echo "$$response" | jq -er '.data.login.session.token // empty') || { \
+		token=$$(echo "$$response" | jq -er '.data.login.token.accessToken // empty') || { \
 			echo "Login response did not contain a token."; \
 			echo "Hint: run 'make gen-admin-password ADMIN_PASSWORD=<password>' to regenerate the password hash in gitstore-api/.env."; \
 			exit 1; \

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,20 +21,23 @@ Public read access depends on resolver and deployment policy. Protected mutation
 Authorization: Bearer <token>
 ```
 
-First-party login is GraphQL-only via the `login(input:)` mutation.
+GitStore delegates OAuth2/OIDC federation to external identity providers. The GraphQL `login`
+mutation is a local-provider convenience (for example `static-admin`) and returns an OIDC-style
+token payload. External providers such as `oidc-jwt` are expected to authenticate out-of-band and
+present a token to GitStore for verification.
 
 Login:
 
 ```graphql
 mutation Login {
   login(input: { username: "admin", password: "<password>" }) {
-    session {
-      token
-      expiresAt
-      user {
-        username
-        isAdmin
-      }
+    token {
+      accessToken
+      tokenType
+      expiresIn
+      refreshToken
+      scope
+      idToken
     }
   }
 }
@@ -44,10 +47,14 @@ Refresh:
 
 ```graphql
 mutation RefreshToken {
-  refreshToken(input: {}) {
-    session {
-      token
-      expiresAt
+  refreshToken(input: { refreshToken: "<refresh-token>" }) {
+    token {
+      accessToken
+      tokenType
+      expiresIn
+      refreshToken
+      scope
+      idToken
     }
   }
 }
@@ -62,6 +69,8 @@ mutation Logout {
   }
 }
 ```
+
+`scope` requests are currently unsupported for local providers; send no scope to avoid a validation error.
 
 ## Operation Summary
 
@@ -89,9 +98,9 @@ mutation Logout {
 
 | Operation | Purpose |
 |---|---|
-| `login(input: LoginInput!)` | Create a JWT session |
+| `login(input: LoginInput!)` | Create an OIDC-style token response for local providers |
 | `logout(input: LogoutInput!)` | End the current session |
-| `refreshToken(input: RefreshTokenInput!)` | Refresh a JWT session |
+| `refreshToken(input: RefreshTokenInput!)` | Exchange a refresh token for a new OIDC-style token response |
 | `createNamespace(input: CreateNamespaceInput!)` | Create a namespace |
 | `deleteNamespace(input: DeleteNamespaceInput!)` | Delete an empty namespace |
 | `createRepository(input: CreateRepositoryInput!)` | Create a repository in a namespace |

--- a/docs/implementation/pluggable_auth_architecture.md
+++ b/docs/implementation/pluggable_auth_architecture.md
@@ -1153,6 +1153,8 @@ BasicAuthenticator → RepoResolver → GitHttpAuthorizer → [PushContextInsert
 **Deliverable:** GraphQL authentication moved from Gin route middleware to gqlgen operation middleware (`AroundOperations`) via `GraphQLAuthenticator`. A new `GraphQLAuthorizer` operation middleware provides a centralized GraphQL security seam and enforces authentication for non-login mutations. Principal and raw bearer token propagation now occur in GraphQL middleware context instead of Gin route hooks.
 **Affected packages:** `gitstore-api/internal/app/`, `gitstore-api/internal/middleware/security/`, `gitstore-api/cmd/server/`
 **Test strategy:** Unit tests for GraphQL middleware decision paths (valid bearer, invalid bearer, anonymous mutation deny, login allow) plus GraphQL handler test for invalid bearer rejection.
+**Auth responsibility boundary:** GraphQL authn/authz checks for mutation access and namespace policy decisions (`namespace.create.organization`, `namespace.delete.{own,any}`) run in gqlgen middleware (`AroundOperations` + `AroundFields`). Resolver/service layers keep business validation and datastore rules only.
+**Justified exceptions:** `login` intentionally performs credential verification inside its resolver because credentials are GraphQL input payloads (not request headers). `logout`/`refreshToken` resolvers keep token lifecycle execution (revoke/refresh calls), while authentication gating and bearer-token presence requirements are enforced by middleware.
 **Rollback trigger:** GraphQL login or authenticated mutation flows regress, or unauthenticated mutations are no longer blocked.
 
 ### Phase 7 — OIDC JWT provider

--- a/docs/implementation/pluggable_auth_architecture.md
+++ b/docs/implementation/pluggable_auth_architecture.md
@@ -1148,14 +1148,21 @@ BasicAuthenticator → RepoResolver → GitHttpAuthorizer → [PushContextInsert
 **Test strategy:** Unit tests for each middleware (`TestBasicAuthTransientError`, `TestBasicAuthCredentialRejection`, `TestBasicAuthAllow`, `TestRepoResolverNotFound`, `TestGitHttpAuthorizerReadOnly`, `TestPushContextInserter`, `TestReceivePackAttachesPushContext`); Rust unit tests for pack/blob size enforcement and push_context validation; integration tests verify full hook pipeline with `HookContext` propagation.
 **Rollback trigger:** Legitimate push/fetch from an authenticated client fails.
 
-### Phase 6 — OIDC JWT provider
+### Phase 6 — GraphQL auth/authz middleware centralization ✅ COMPLETE
+**Milestone:** `auth-framework-graphql-v1`
+**Deliverable:** GraphQL authentication moved from Gin route middleware to gqlgen operation middleware (`AroundOperations`) via `GraphQLAuthenticator`. A new `GraphQLAuthorizer` operation middleware provides a centralized GraphQL security seam and enforces authentication for non-login mutations. Principal and raw bearer token propagation now occur in GraphQL middleware context instead of Gin route hooks.
+**Affected packages:** `gitstore-api/internal/app/`, `gitstore-api/internal/middleware/security/`, `gitstore-api/cmd/server/`
+**Test strategy:** Unit tests for GraphQL middleware decision paths (valid bearer, invalid bearer, anonymous mutation deny, login allow) plus GraphQL handler test for invalid bearer rejection.
+**Rollback trigger:** GraphQL login or authenticated mutation flows regress, or unauthenticated mutations are no longer blocked.
+
+### Phase 7 — OIDC JWT provider
 **Milestone:** `auth-framework-v2`
 **Deliverable:** `OIDCJWTProvider`; `go-oidc/v3` added to `go.mod`; local-secure profile end-to-end tested.
 **Affected packages:** `gitstore-api/internal/auth/provider/oidcjwt/`, `go.mod`
 **Test strategy:** Unit test with a mock JWKS server; integration test with a real local IdP (e.g., Dex running in Docker Compose test profile); test key rotation forced-refresh behavior.
 **Rollback trigger:** OIDC provider causes 500s on valid tokens, or breaks the static-admin fallback in the chain.
 
-### Phase 7 — OPA production AuthZ provider
+### Phase 8 — OPA production AuthZ provider
 **Milestone:** `auth-framework-v3`
 **Deliverable:** `OPAProvider` calling the OPA sidecar HTTP API; production `.env` profile wires `GITSTORE_AUTH__AUTHZ__PROVIDER=opa`; Rego policy equivalent to `policy.yaml` bundled.
 **Affected packages:** `gitstore-api/internal/auth/provider/opa/`, production deployment config

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -376,24 +376,40 @@ curl -s http://localhost:4000/graphql \
 
 Use GraphQL mutations for authentication, namespaces, and repositories. The Make bootstrap targets wrap these calls for the common local workflow.
 
-First-party login is GraphQL-only via the `login(input:)` mutation.
+GitStore delegates OAuth2/OIDC federation to external identity providers. The GraphQL
+`login(input:)` mutation is a convenience flow for local providers (for example `static-admin`).
 
 Login:
 
 ```graphql
 mutation Login {
   login(input: { username: "admin", password: "<password>" }) {
-    session {
-      token
-      expiresAt
-      user {
-        username
-        isAdmin
-      }
+    token {
+      accessToken
+      tokenType
+      expiresIn
+      refreshToken
     }
   }
 }
 ```
+
+Refresh:
+
+```graphql
+mutation RefreshToken {
+  refreshToken(input: { refreshToken: "<refresh-token>" }) {
+    token {
+      accessToken
+      tokenType
+      expiresIn
+      refreshToken
+    }
+  }
+}
+```
+
+`scope` requests are currently unsupported by local providers.
 
 Create a namespace and repository manually when you need custom provisioning. See [API Reference](api-reference.md#mutation-operations) for the exact inputs.
 

--- a/gitstore-api/cmd/server/main_test.go
+++ b/gitstore-api/cmd/server/main_test.go
@@ -247,3 +247,30 @@ func TestGraphQLHandlerRejectsNamespaceMutationWithoutBearerToken(t *testing.T) 
 	require.NotEmpty(t, response.Errors)
 	assert.Contains(t, response.Errors[0].Message, "authentication required")
 }
+
+func TestGraphQLHandlerRejectsMutationWithInvalidBearerToken(t *testing.T) {
+	store, err := memdb.New()
+	require.NoError(t, err)
+
+	handler, err := app.NewGraphQLHandler(store, &mockGitWriter{}, zap.NewNop(), newTestGraphQLRegistry(t), nil, apiruntime.NewSequenceIDGenerator())
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{
+		"query": "mutation { createNamespace(input: { identifier: \"alice\", tier: USER }) { namespace { identifier } } }"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.NotEmpty(t, response.Errors)
+	assert.Contains(t, response.Errors[0].Message, "invalid or expired credentials")
+}

--- a/gitstore-api/cmd/server/main_test.go
+++ b/gitstore-api/cmd/server/main_test.go
@@ -116,7 +116,7 @@ func TestGraphQLHandlerAcceptsBearerTokenForNamespaceMutation(t *testing.T) {
 	require.NoError(t, err)
 
 	loginReq := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{
-		"query": "mutation { login(input: { username: \"admin\", password: \"admin123\" }) { session { token user { username isAdmin } } } }"
+		"query": "mutation { login(input: { username: \"admin\", password: \"admin123\" }) { token { accessToken tokenType } } }"
 	}`))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginW := httptest.NewRecorder()
@@ -127,13 +127,10 @@ func TestGraphQLHandlerAcceptsBearerTokenForNamespaceMutation(t *testing.T) {
 	var loginResponse struct {
 		Data struct {
 			Login struct {
-				Session struct {
-					Token string `json:"token"`
-					User  struct {
-						Username string `json:"username"`
-						IsAdmin  bool   `json:"isAdmin"`
-					} `json:"user"`
-				} `json:"session"`
+				Token struct {
+					AccessToken string `json:"accessToken"`
+					TokenType   string `json:"tokenType"`
+				} `json:"token"`
 			} `json:"login"`
 		} `json:"data"`
 		Errors []struct {
@@ -142,15 +139,14 @@ func TestGraphQLHandlerAcceptsBearerTokenForNamespaceMutation(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(loginW.Body.Bytes(), &loginResponse))
 	require.Empty(t, loginResponse.Errors)
-	require.NotEmpty(t, loginResponse.Data.Login.Session.Token)
-	assert.Equal(t, "admin", loginResponse.Data.Login.Session.User.Username)
-	assert.True(t, loginResponse.Data.Login.Session.User.IsAdmin)
+	require.NotEmpty(t, loginResponse.Data.Login.Token.AccessToken)
+	assert.Equal(t, "Bearer", loginResponse.Data.Login.Token.TokenType)
 
 	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{
 		"query": "mutation { createNamespace(input: { identifier: \"alice\", tier: USER }) { clientMutationId namespace { identifier createdBy } } }"
 	}`))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+loginResponse.Data.Login.Session.Token)
+	req.Header.Set("Authorization", "Bearer "+loginResponse.Data.Login.Token.AccessToken)
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
@@ -215,7 +211,7 @@ func TestGraphQLHandlerRejectsLoginWithInvalidCredentials(t *testing.T) {
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{
-		"query": "mutation { login(input: { username: \"admin\", password: \"wrong\" }) { session { token } } }"
+		"query": "mutation { login(input: { username: \"admin\", password: \"wrong\" }) { token { accessToken } } }"
 	}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/gitstore-api/cmd/server/main_test.go
+++ b/gitstore-api/cmd/server/main_test.go
@@ -98,6 +98,16 @@ func newTestGraphQLRegistry(t *testing.T) *authpkg.ProviderRegistry {
 	)
 }
 
+func TestGraphQLHandlerRequiresAuthZProvider(t *testing.T) {
+	registry := newTestGraphQLRegistry(t)
+	registry.Swap(registry.AuthN(), nil, nil)
+
+	handler, err := app.NewGraphQLHandler(nil, nil, zap.NewNop(), registry, nil, nil)
+	require.Error(t, err)
+	assert.Nil(t, handler)
+	assert.Contains(t, err.Error(), "authn and authz provider registry is required")
+}
+
 func TestGraphQLHandlerAcceptsBearerTokenForNamespaceMutation(t *testing.T) {
 	store, err := memdb.New()
 	require.NoError(t, err)

--- a/gitstore-api/internal/app/server.go
+++ b/gitstore-api/internal/app/server.go
@@ -174,8 +174,8 @@ func NewServer(cfg *config.Config, log *zap.Logger) (*Server, error) {
 
 // NewGraphQLHandler builds a GraphQL HTTP handler.
 func NewGraphQLHandler(store datastore.Datastore, writer resolver.GitWriter, log *zap.Logger, registry *auth.ProviderRegistry, clock apiruntime.Clock, ids apiruntime.IDGenerator) (*gin.Engine, error) {
-	if registry == nil || registry.AuthN() == nil {
-		return nil, fmt.Errorf("app: auth provider registry is required")
+	if registry == nil || registry.AuthN() == nil || registry.AuthZ() == nil {
+		return nil, fmt.Errorf("app: authn and authz provider registry is required")
 	}
 	rootResolver, err := resolver.NewResolver(resolver.ResolverDeps{
 		Store:       store,

--- a/gitstore-api/internal/app/server.go
+++ b/gitstore-api/internal/app/server.go
@@ -207,11 +207,17 @@ func NewGraphQLHandler(store datastore.Datastore, writer resolver.GitWriter, log
 		Cache: lru.New[string](100),
 	})
 
+	authenticateMiddleware := security.NewAuthenticate(registry, log)
+	authorizeMiddleware := security.NewAuthorize(registry, log)
+	gqlServer.AroundOperations(authenticateMiddleware.GraphQLAuthenticator)
+	gqlServer.AroundOperations(authorizeMiddleware.GraphQLAuthorizer)
+
 	gqlHandler := gin.HandlerFunc(func(c *gin.Context) {
+		ctx := security.ContextWithRemoteAddr(c.Request.Context(), c.RemoteIP())
+		c.Request = c.Request.WithContext(ctx)
 		gqlServer.ServeHTTP(c.Writer, c.Request)
 	})
 
-	authenticateMiddleware := security.NewAuthenticate(registry, log)
 	rateLimitMiddleware := security.NewRateLimit(10, 20)
 	requestIdMiddleware := middleware.NewRequestId(ids)
 
@@ -221,10 +227,7 @@ func NewGraphQLHandler(store datastore.Datastore, writer resolver.GitWriter, log
 	r.Use(security.CorsConfiguration())
 	r.Use(rateLimitMiddleware.RateLimiter)
 	r.GET("/playground", playgroundHandler)
-	routerGroup := r.Group("/")
-	routerGroup.Use(authenticateMiddleware.Authenticator)
-	routerGroup.Use(security.SecureHeaders)
-	routerGroup.POST("/graphql", gqlHandler)
+	r.POST("/graphql", security.SecureHeaders, gqlHandler)
 	return r, nil
 }
 

--- a/gitstore-api/internal/app/server.go
+++ b/gitstore-api/internal/app/server.go
@@ -180,7 +180,6 @@ func NewGraphQLHandler(store datastore.Datastore, writer resolver.GitWriter, log
 	rootResolver, err := resolver.NewResolver(resolver.ResolverDeps{
 		Store:       store,
 		GitWriter:   writer,
-		AuthZ:       registry.AuthZ(),
 		Registry:    registry,
 		Logger:      log,
 		Clock:       clock,

--- a/gitstore-api/internal/app/server.go
+++ b/gitstore-api/internal/app/server.go
@@ -207,9 +207,10 @@ func NewGraphQLHandler(store datastore.Datastore, writer resolver.GitWriter, log
 	})
 
 	authenticateMiddleware := security.NewAuthenticate(registry, log)
-	authorizeMiddleware := security.NewAuthorize(registry, log)
+	authorizeMiddleware := security.NewAuthorizeWithStore(registry, store, log)
 	gqlServer.AroundOperations(authenticateMiddleware.GraphQLAuthenticator)
 	gqlServer.AroundOperations(authorizeMiddleware.GraphQLAuthorizer)
+	gqlServer.AroundFields(authorizeMiddleware.GraphQLFieldAuthorizer)
 
 	gqlHandler := gin.HandlerFunc(func(c *gin.Context) {
 		ctx := security.ContextWithRemoteAddr(c.Request.Context(), c.RemoteIP())

--- a/gitstore-api/internal/auth/provider/staticadmin/provider.go
+++ b/gitstore-api/internal/auth/provider/staticadmin/provider.go
@@ -32,6 +32,20 @@ type StaticAdminProvider struct {
 	logger       *zap.Logger
 }
 
+// refreshClaims keeps the token's real expiration available for the refresh
+// grace-window check while preventing the JWT validator from rejecting an
+// otherwise valid, recently expired token. The exp claim is still required.
+type refreshClaims struct {
+	jwt.RegisteredClaims
+}
+
+func (c refreshClaims) GetExpirationTime() (*jwt.NumericDate, error) {
+	if c.ExpiresAt == nil {
+		return nil, nil
+	}
+	return jwt.NewNumericDate(time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)), nil
+}
+
 func New(cfg config.AuthConfig, logger *zap.Logger) (*StaticAdminProvider, error) {
 	username := cfg.Admin.Username
 	if username == "" {
@@ -186,14 +200,16 @@ func (p *StaticAdminProvider) RevokeSession(_ context.Context, jti string, expir
 }
 
 func (p *StaticAdminProvider) RefreshSession(_ context.Context, oldToken string) (string, time.Time, error) {
-	// Parse ignoring expiry to allow refreshing recently-expired tokens.
-	claims := &jwt.RegisteredClaims{}
+	// Validate signature and every registered claim except the actual expiration
+	// instant. refreshClaims still requires exp to be present, and the real value
+	// is checked against refreshGrace below.
+	claims := &refreshClaims{}
 	_, err := jwt.ParseWithClaims(oldToken, claims, func(t *jwt.Token) (any, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return p.jwtSecret, nil
-	}, jwt.WithoutClaimsValidation())
+	}, jwt.WithLeeway(2*time.Minute), jwt.WithIssuer(p.jwtIssuer), jwt.WithExpirationRequired())
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("staticadmin: refresh: %w", auth.ErrInvalidToken)
 	}

--- a/gitstore-api/internal/auth/provider/staticadmin/provider.go
+++ b/gitstore-api/internal/auth/provider/staticadmin/provider.go
@@ -195,7 +195,7 @@ func (p *StaticAdminProvider) RefreshSession(_ context.Context, oldToken string)
 		return p.jwtSecret, nil
 	}, jwt.WithoutClaimsValidation())
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("staticadmin: refresh: %w", err)
+		return "", time.Time{}, fmt.Errorf("staticadmin: refresh: %w", auth.ErrInvalidToken)
 	}
 
 	// Enforce grace window: reject tokens that expired longer ago than refreshGrace.

--- a/gitstore-api/internal/auth/provider/staticadmin/staticadmin_test.go
+++ b/gitstore-api/internal/auth/provider/staticadmin/staticadmin_test.go
@@ -234,3 +234,13 @@ func TestStaticAdmin_RefreshSession_BeyondGrace_Fails(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, authpkg.ErrTokenTooOld)
 }
+
+func TestStaticAdmin_RefreshSession_InvalidToken_Fails(t *testing.T) {
+	cfg := newTestConfig("admin", mustBcrypt(t, "testpass"), "test-secret-key", "gitstore")
+	p, err := New(cfg, zap.NewNop())
+	require.NoError(t, err)
+
+	_, _, err = p.RefreshSession(context.Background(), "not-a-jwt")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, authpkg.ErrInvalidToken)
+}

--- a/gitstore-api/internal/auth/provider/staticadmin/staticadmin_test.go
+++ b/gitstore-api/internal/auth/provider/staticadmin/staticadmin_test.go
@@ -8,9 +8,11 @@ import (
 	"encoding/base64"
 	"net/http"
 	"testing"
+	"time"
 
 	authpkg "github.com/gitstore-dev/gitstore/api/internal/auth"
 	"github.com/gitstore-dev/gitstore/api/internal/config"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -243,4 +245,42 @@ func TestStaticAdmin_RefreshSession_InvalidToken_Fails(t *testing.T) {
 	_, _, err = p.RefreshSession(context.Background(), "not-a-jwt")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, authpkg.ErrInvalidToken)
+}
+
+func TestStaticAdmin_RefreshSession_InvalidClaimsFail(t *testing.T) {
+	cfg := newTestConfig("admin", mustBcrypt(t, "testpass"), "test-secret-key", "gitstore")
+	p, err := New(cfg, zap.NewNop())
+	require.NoError(t, err)
+
+	now := time.Now()
+	tests := map[string]jwt.RegisteredClaims{
+		"wrong issuer": {
+			Subject:   "admin",
+			Issuer:    "old-gitstore",
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		"future not-before": {
+			Subject:   "admin",
+			Issuer:    "gitstore",
+			NotBefore: jwt.NewNumericDate(now.Add(10 * time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		"missing expiration": {
+			Subject:   "admin",
+			Issuer:    "gitstore",
+			NotBefore: jwt.NewNumericDate(now),
+		},
+	}
+
+	for name, claims := range tests {
+		t.Run(name, func(t *testing.T) {
+			token, signErr := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(cfg.JWT.Secret))
+			require.NoError(t, signErr)
+
+			_, _, refreshErr := p.RefreshSession(context.Background(), token)
+			require.Error(t, refreshErr)
+			assert.ErrorIs(t, refreshErr, authpkg.ErrInvalidToken)
+		})
+	}
 }

--- a/gitstore-api/internal/auth/types.go
+++ b/gitstore-api/internal/auth/types.go
@@ -19,6 +19,9 @@ var ErrTokenTooOld = errors.New("auth: token too old to refresh")
 // ErrTokenRevoked is returned when a token has been explicitly revoked.
 var ErrTokenRevoked = errors.New("auth: token has been revoked")
 
+// ErrInvalidToken is returned when a refresh token cannot be parsed or validated.
+var ErrInvalidToken = errors.New("auth: invalid token")
+
 // Outcome is the result of an auth decision.
 type Outcome uint8
 

--- a/gitstore-api/internal/graph/generated/auth.generated.go
+++ b/gitstore-api/internal/graph/generated/auth.generated.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"strconv"
 	"sync/atomic"
-	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
@@ -29,160 +28,36 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _AuthSession_token(ctx context.Context, field graphql.CollectedField, obj *model.AuthSession) (ret graphql.Marshaler) {
+func (ec *executionContext) _LoginPayload_token(ctx context.Context, field graphql.CollectedField, obj *model.LoginPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_AuthSession_token(ctx, field)
+			return ec.fieldContext_LoginPayload_token(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
 			return obj.Token, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
-			return ec.marshalNString2string(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *model.TokenResponse) graphql.Marshaler {
+			return ec.marshalNTokenResponse2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐTokenResponse(ctx, selections, v)
 		},
 		true,
 		true,
 	)
 }
-func (ec *executionContext) fieldContext_AuthSession_token(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("AuthSession", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
-func (ec *executionContext) _AuthSession_expiresAt(ctx context.Context, field graphql.CollectedField, obj *model.AuthSession) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_AuthSession_expiresAt(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ExpiresAt, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v time.Time) graphql.Marshaler {
-			return ec.marshalNDateTime2timeᚐTime(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_AuthSession_expiresAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("AuthSession", field, false, false, errors.New("field of type DateTime does not have child fields"))
-}
-
-func (ec *executionContext) _AuthSession_user(ctx context.Context, field graphql.CollectedField, obj *model.AuthSession) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_AuthSession_user(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.User, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *model.User) graphql.Marshaler {
-			return ec.marshalNUser2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐUser(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_AuthSession_user(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "AuthSession",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_User(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _LoginPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.LoginPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_LoginPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_LoginPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("LoginPayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
-func (ec *executionContext) _LoginPayload_session(ctx context.Context, field graphql.CollectedField, obj *model.LoginPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_LoginPayload_session(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.Session, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *model.AuthSession) graphql.Marshaler {
-			return ec.marshalOAuthSession2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐAuthSession(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_LoginPayload_session(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_LoginPayload_token(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "LoginPayload",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_AuthSession(ctx, field)
+			return ec.childFields_TokenResponse(ctx, field)
 		},
 	}
 	return fc, nil
-}
-
-func (ec *executionContext) _LogoutPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.LogoutPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_LogoutPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_LogoutPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("LogoutPayload", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _LogoutPayload_success(ctx context.Context, field graphql.CollectedField, obj *model.LogoutPayload) (ret graphql.Marshaler) {
@@ -208,16 +83,117 @@ func (ec *executionContext) fieldContext_LogoutPayload_success(_ context.Context
 	return graphql.NewScalarFieldContext("LogoutPayload", field, false, false, errors.New("field of type Boolean does not have child fields"))
 }
 
-func (ec *executionContext) _RefreshTokenPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.RefreshTokenPayload) (ret graphql.Marshaler) {
+func (ec *executionContext) _RefreshTokenPayload_token(ctx context.Context, field graphql.CollectedField, obj *model.RefreshTokenPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_RefreshTokenPayload_clientMutationId(ctx, field)
+			return ec.fieldContext_RefreshTokenPayload_token(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
+			return obj.Token, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.TokenResponse) graphql.Marshaler {
+			return ec.marshalNTokenResponse2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐTokenResponse(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_RefreshTokenPayload_token(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RefreshTokenPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_TokenResponse(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TokenResponse_accessToken(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenResponse_accessToken(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.AccessToken, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TokenResponse_accessToken(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _TokenResponse_tokenType(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenResponse_tokenType(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.TokenType, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TokenResponse_tokenType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _TokenResponse_expiresIn(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenResponse_expiresIn(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ExpiresIn, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int32) graphql.Marshaler {
+			return ec.marshalNInt2int32(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TokenResponse_expiresIn(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TokenResponse_refreshToken(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenResponse_refreshToken(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.RefreshToken, nil
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
@@ -227,40 +203,54 @@ func (ec *executionContext) _RefreshTokenPayload_clientMutationId(ctx context.Co
 		false,
 	)
 }
-func (ec *executionContext) fieldContext_RefreshTokenPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("RefreshTokenPayload", field, false, false, errors.New("field of type String does not have child fields"))
+func (ec *executionContext) fieldContext_TokenResponse_refreshToken(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _RefreshTokenPayload_session(ctx context.Context, field graphql.CollectedField, obj *model.RefreshTokenPayload) (ret graphql.Marshaler) {
+func (ec *executionContext) _TokenResponse_scope(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_RefreshTokenPayload_session(ctx, field)
+			return ec.fieldContext_TokenResponse_scope(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.Session, nil
+			return obj.Scope, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *model.AuthSession) graphql.Marshaler {
-			return ec.marshalOAuthSession2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐAuthSession(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
 		},
 		true,
 		false,
 	)
 }
-func (ec *executionContext) fieldContext_RefreshTokenPayload_session(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "RefreshTokenPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_AuthSession(ctx, field)
+func (ec *executionContext) fieldContext_TokenResponse_scope(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _TokenResponse_idToken(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenResponse_idToken(ctx, field)
 		},
-	}
-	return fc, nil
+		func(ctx context.Context) (any, error) {
+			return obj.IDToken, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_TokenResponse_idToken(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _User_username(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
@@ -324,20 +314,13 @@ func (ec *executionContext) unmarshalInputLoginInput(ctx context.Context, obj an
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "username", "password"}
+	fieldsInOrder := [...]string{"username", "password", "scope"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "username":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("username"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -352,6 +335,13 @@ func (ec *executionContext) unmarshalInputLoginInput(ctx context.Context, obj an
 				return it, err
 			}
 			it.Password = data
+		case "scope":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scope"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Scope = data
 		}
 	}
 	return it, nil
@@ -398,20 +388,27 @@ func (ec *executionContext) unmarshalInputRefreshTokenInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId"}
+	fieldsInOrder := [...]string{"refreshToken", "scope"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
+		case "refreshToken":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("refreshToken"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RefreshToken = data
+		case "scope":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scope"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.ClientMutationID = data
+			it.Scope = data
 		}
 	}
 	return it, nil
@@ -425,55 +422,6 @@ func (ec *executionContext) unmarshalInputRefreshTokenInput(ctx context.Context,
 
 // region    **************************** object.gotpl ****************************
 
-var authSessionImplementors = []string{"AuthSession"}
-
-func (ec *executionContext) _AuthSession(ctx context.Context, sel ast.SelectionSet, obj *model.AuthSession) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, authSessionImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	deferred := make(map[string]*graphql.FieldSet)
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("AuthSession")
-		case "token":
-			out.Values[i] = ec._AuthSession_token(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "expiresAt":
-			out.Values[i] = ec._AuthSession_expiresAt(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "user":
-			out.Values[i] = ec._AuthSession_user(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch(ctx)
-	if out.Invalids > 0 {
-		return graphql.Null
-	}
-
-	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
-
-	for label, dfs := range deferred {
-		ec.ProcessDeferredGroup(graphql.DeferredGroup{
-			Label:    label,
-			Path:     graphql.GetPath(ctx),
-			FieldSet: dfs,
-			Context:  ctx,
-		})
-	}
-
-	return out
-}
-
 var loginPayloadImplementors = []string{"LoginPayload"}
 
 func (ec *executionContext) _LoginPayload(ctx context.Context, sel ast.SelectionSet, obj *model.LoginPayload) graphql.Marshaler {
@@ -485,10 +433,11 @@ func (ec *executionContext) _LoginPayload(ctx context.Context, sel ast.Selection
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("LoginPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._LoginPayload_clientMutationId(ctx, field, obj)
-		case "session":
-			out.Values[i] = ec._LoginPayload_session(ctx, field, obj)
+		case "token":
+			out.Values[i] = ec._LoginPayload_token(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -523,8 +472,6 @@ func (ec *executionContext) _LogoutPayload(ctx context.Context, sel ast.Selectio
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("LogoutPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._LogoutPayload_clientMutationId(ctx, field, obj)
 		case "success":
 			out.Values[i] = ec._LogoutPayload_success(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -564,10 +511,66 @@ func (ec *executionContext) _RefreshTokenPayload(ctx context.Context, sel ast.Se
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("RefreshTokenPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._RefreshTokenPayload_clientMutationId(ctx, field, obj)
-		case "session":
-			out.Values[i] = ec._RefreshTokenPayload_session(ctx, field, obj)
+		case "token":
+			out.Values[i] = ec._RefreshTokenPayload_token(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var tokenResponseImplementors = []string{"TokenResponse"}
+
+func (ec *executionContext) _TokenResponse(ctx context.Context, sel ast.SelectionSet, obj *model.TokenResponse) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tokenResponseImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TokenResponse")
+		case "accessToken":
+			out.Values[i] = ec._TokenResponse_accessToken(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "tokenType":
+			out.Values[i] = ec._TokenResponse_tokenType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "expiresIn":
+			out.Values[i] = ec._TokenResponse_expiresIn(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "refreshToken":
+			out.Values[i] = ec._TokenResponse_refreshToken(ctx, field, obj)
+		case "scope":
+			out.Values[i] = ec._TokenResponse_scope(ctx, field, obj)
+		case "idToken":
+			out.Values[i] = ec._TokenResponse_idToken(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -696,21 +699,14 @@ func (ec *executionContext) marshalNRefreshTokenPayload2ᚖgithubᚗcomᚋgitsto
 	return ec._RefreshTokenPayload(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v *model.User) graphql.Marshaler {
+func (ec *executionContext) marshalNTokenResponse2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐTokenResponse(ctx context.Context, sel ast.SelectionSet, v *model.TokenResponse) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
 		}
 		return graphql.Null
 	}
-	return ec._User(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOAuthSession2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐAuthSession(ctx context.Context, sel ast.SelectionSet, v *model.AuthSession) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._AuthSession(ctx, sel, v)
+	return ec._TokenResponse(ctx, sel, v)
 }
 
 // endregion ***************************** type.gotpl *****************************

--- a/gitstore-api/internal/graph/generated/root_.generated.go
+++ b/gitstore-api/internal/graph/generated/root_.generated.go
@@ -33,12 +33,6 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
-	AuthSession struct {
-		ExpiresAt func(childComplexity int) int
-		Token     func(childComplexity int) int
-		User      func(childComplexity int) int
-	}
-
 	CatalogObjectReference struct {
 		APIVersion      func(childComplexity int) int
 		FieldPath       func(childComplexity int) int
@@ -264,13 +258,11 @@ type ComplexityRoot struct {
 	}
 
 	LoginPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Session          func(childComplexity int) int
+		Token func(childComplexity int) int
 	}
 
 	LogoutPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Success          func(childComplexity int) int
+		Success func(childComplexity int) int
 	}
 
 	MediaDefinition struct {
@@ -518,8 +510,7 @@ type ComplexityRoot struct {
 	}
 
 	RefreshTokenPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Session          func(childComplexity int) int
+		Token func(childComplexity int) int
 	}
 
 	RenameRepositoryPayload struct {
@@ -624,6 +615,15 @@ type ComplexityRoot struct {
 		Type func(childComplexity int) int
 	}
 
+	TokenResponse struct {
+		AccessToken  func(childComplexity int) int
+		ExpiresIn    func(childComplexity int) int
+		IDToken      func(childComplexity int) int
+		RefreshToken func(childComplexity int) int
+		Scope        func(childComplexity int) int
+		TokenType    func(childComplexity int) int
+	}
+
 	TransferRepositoryPayload struct {
 		ClientMutationID func(childComplexity int) int
 		Repository       func(childComplexity int) int
@@ -665,27 +665,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	ec := newExecutionContext(nil, e, nil)
 	_ = ec
 	switch typeName + "." + field {
-
-	case "AuthSession.expiresAt":
-		if e.ComplexityRoot.AuthSession.ExpiresAt == nil {
-			break
-		}
-
-		return e.ComplexityRoot.AuthSession.ExpiresAt(childComplexity), true
-
-	case "AuthSession.token":
-		if e.ComplexityRoot.AuthSession.Token == nil {
-			break
-		}
-
-		return e.ComplexityRoot.AuthSession.Token(childComplexity), true
-
-	case "AuthSession.user":
-		if e.ComplexityRoot.AuthSession.User == nil {
-			break
-		}
-
-		return e.ComplexityRoot.AuthSession.User(childComplexity), true
 
 	case "CatalogObjectReference.apiVersion":
 		if e.ComplexityRoot.CatalogObjectReference.APIVersion == nil {
@@ -1572,26 +1551,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.LabelSelectorRequirement.Values(childComplexity), true
 
-	case "LoginPayload.clientMutationId":
-		if e.ComplexityRoot.LoginPayload.ClientMutationID == nil {
+	case "LoginPayload.token":
+		if e.ComplexityRoot.LoginPayload.Token == nil {
 			break
 		}
 
-		return e.ComplexityRoot.LoginPayload.ClientMutationID(childComplexity), true
-
-	case "LoginPayload.session":
-		if e.ComplexityRoot.LoginPayload.Session == nil {
-			break
-		}
-
-		return e.ComplexityRoot.LoginPayload.Session(childComplexity), true
-
-	case "LogoutPayload.clientMutationId":
-		if e.ComplexityRoot.LogoutPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.LogoutPayload.ClientMutationID(childComplexity), true
+		return e.ComplexityRoot.LoginPayload.Token(childComplexity), true
 
 	case "LogoutPayload.success":
 		if e.ComplexityRoot.LogoutPayload.Success == nil {
@@ -2838,19 +2803,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Query.Repository(childComplexity, args["by"].(model.RepositoryBy)), true
 
-	case "RefreshTokenPayload.clientMutationId":
-		if e.ComplexityRoot.RefreshTokenPayload.ClientMutationID == nil {
+	case "RefreshTokenPayload.token":
+		if e.ComplexityRoot.RefreshTokenPayload.Token == nil {
 			break
 		}
 
-		return e.ComplexityRoot.RefreshTokenPayload.ClientMutationID(childComplexity), true
-
-	case "RefreshTokenPayload.session":
-		if e.ComplexityRoot.RefreshTokenPayload.Session == nil {
-			break
-		}
-
-		return e.ComplexityRoot.RefreshTokenPayload.Session(childComplexity), true
+		return e.ComplexityRoot.RefreshTokenPayload.Token(childComplexity), true
 
 	case "RenameRepositoryPayload.clientMutationId":
 		if e.ComplexityRoot.RenameRepositoryPayload.ClientMutationID == nil {
@@ -3230,6 +3188,48 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.StrategyDefinition.Type(childComplexity), true
 
+	case "TokenResponse.accessToken":
+		if e.ComplexityRoot.TokenResponse.AccessToken == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.AccessToken(childComplexity), true
+
+	case "TokenResponse.expiresIn":
+		if e.ComplexityRoot.TokenResponse.ExpiresIn == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.ExpiresIn(childComplexity), true
+
+	case "TokenResponse.idToken":
+		if e.ComplexityRoot.TokenResponse.IDToken == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.IDToken(childComplexity), true
+
+	case "TokenResponse.refreshToken":
+		if e.ComplexityRoot.TokenResponse.RefreshToken == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.RefreshToken(childComplexity), true
+
+	case "TokenResponse.scope":
+		if e.ComplexityRoot.TokenResponse.Scope == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.Scope(childComplexity), true
+
+	case "TokenResponse.tokenType":
+		if e.ComplexityRoot.TokenResponse.TokenType == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.TokenType(childComplexity), true
+
 	case "TransferRepositoryPayload.clientMutationId":
 		if e.ComplexityRoot.TransferRepositoryPayload.ClientMutationID == nil {
 			break
@@ -3442,35 +3442,40 @@ type User {
   isAdmin: Boolean!
 }
 
-"""
-Authentication session response
-"""
-type AuthSession {
-  """
-  JWT token for authentication
-  """
-  token: String!
+"""OIDC-compatible token response."""
+type TokenResponse {
+  """Access token used for authenticated API calls."""
+  accessToken: String!
+
+  """Token type. Always ` + "`" + `Bearer` + "`" + ` for GitStore-issued tokens."""
+  tokenType: String!
+
+  """Seconds until the access token expires."""
+  expiresIn: Int!
 
   """
-  Token expiration time (ISO 8601)
+  Refresh token used to obtain a new access token.
+  For local providers, this is currently a GitStore-issued token.
   """
-  expiresAt: DateTime!
+  refreshToken: String
 
   """
-  Authenticated user information
+  Granted scope set as a space-delimited string.
+  Scope requests are currently unsupported and this field is null.
   """
-  user: User!
+  scope: String
+
+  """
+  OIDC ID token when available.
+  GitStore local providers currently do not issue this field.
+  """
+  idToken: String
 }
 
 """
 Login mutation input (Relay pattern)
 """
 input LoginInput {
-  """
-  Client mutation ID for request tracking (Relay pattern)
-  """
-  clientMutationId: String
-
   """
   Username
   """
@@ -3480,6 +3485,12 @@ input LoginInput {
   Password
   """
   password: String!
+
+  """
+  Optional OAuth2 scope request.
+  Scope requests are currently unsupported by local providers.
+  """
+  scope: String
 }
 
 """
@@ -3487,14 +3498,9 @@ Login mutation payload (Relay pattern)
 """
 type LoginPayload {
   """
-  Client mutation ID for request tracking (Relay pattern)
+  OIDC-compatible token payload.
   """
-  clientMutationId: String
-
-  """
-  Authentication session (token + user info)
-  """
-  session: AuthSession
+  token: TokenResponse!
 }
 
 """
@@ -3502,6 +3508,7 @@ Logout mutation input (Relay pattern)
 """
 input LogoutInput {
   """
+  TODO: Is it safe to remove and empty Input?
   Client mutation ID for request tracking (Relay pattern)
   """
   clientMutationId: String
@@ -3511,11 +3518,6 @@ input LogoutInput {
 Logout mutation payload (Relay pattern)
 """
 type LogoutPayload {
-  """
-  Client mutation ID for request tracking (Relay pattern)
-  """
-  clientMutationId: String
-
   """
   Success indicator
   """
@@ -3527,9 +3529,15 @@ Refresh token mutation input (Relay pattern)
 """
 input RefreshTokenInput {
   """
-  Client mutation ID for request tracking (Relay pattern)
+  Refresh token used to issue a new access token.
   """
-  clientMutationId: String
+  refreshToken: String!
+
+  """
+  Optional OAuth2 scope request.
+  Scope requests are currently unsupported by local providers.
+  """
+  scope: String
 }
 
 """
@@ -3537,14 +3545,9 @@ Refresh token mutation payload (Relay pattern)
 """
 type RefreshTokenPayload {
   """
-  Client mutation ID for request tracking (Relay pattern)
+  OIDC-compatible token payload.
   """
-  clientMutationId: String
-
-  """
-  New authentication session
-  """
-  session: AuthSession
+  token: TokenResponse!
 }
 
 # Add authentication mutations to the Mutation type
@@ -4471,7 +4474,7 @@ Input for creating a new namespace.
 """
 input CreateNamespaceInput {
   """
-  Client mutation ID for request tracking (Relay pattern).
+  TODO: Remove, deprecated in relay
   """
   clientMutationId: String
 
@@ -4502,7 +4505,7 @@ Input for deleting a namespace.
 """
 input DeleteNamespaceInput {
   """
-  Client mutation ID for request tracking (Relay pattern).
+  TODO: Remove, deprecated in relay
   """
   clientMutationId: String
 
@@ -4519,7 +4522,7 @@ Payload returned after successfully creating a namespace.
 """
 type CreateNamespacePayload {
   """
-  Client mutation ID for request tracking (Relay pattern).
+  TODO: Remove, deprecated in relay
   """
   clientMutationId: String
 
@@ -4534,7 +4537,7 @@ Payload returned after successfully deleting a namespace.
 """
 type DeleteNamespacePayload {
   """
-  Client mutation ID for request tracking (Relay pattern).
+  TODO: Remove, deprecated in relay
   """
   clientMutationId: String
 
@@ -5655,18 +5658,6 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // Each function is generated once per unique object type, deduplicating the
 // switch statements that were previously inlined in every fieldContext_* function.
 
-func (ec *executionContext) childFields_AuthSession(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-	switch field.Name {
-	case "token":
-		return ec.fieldContext_AuthSession_token(ctx, field)
-	case "expiresAt":
-		return ec.fieldContext_AuthSession_expiresAt(ctx, field)
-	case "user":
-		return ec.fieldContext_AuthSession_user(ctx, field)
-	}
-	return nil, fmt.Errorf("no field named %q was found under type AuthSession", field.Name)
-}
-
 func (ec *executionContext) childFields_CatalogObjectReference(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
 	case "apiVersion":
@@ -6117,18 +6108,14 @@ func (ec *executionContext) childFields_LabelSelectorRequirement(ctx context.Con
 
 func (ec *executionContext) childFields_LoginPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_LoginPayload_clientMutationId(ctx, field)
-	case "session":
-		return ec.fieldContext_LoginPayload_session(ctx, field)
+	case "token":
+		return ec.fieldContext_LoginPayload_token(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type LoginPayload", field.Name)
 }
 
 func (ec *executionContext) childFields_LogoutPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_LogoutPayload_clientMutationId(ctx, field)
 	case "success":
 		return ec.fieldContext_LogoutPayload_success(ctx, field)
 	}
@@ -6549,10 +6536,8 @@ func (ec *executionContext) childFields_QuantityDefinition(ctx context.Context, 
 
 func (ec *executionContext) childFields_RefreshTokenPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_RefreshTokenPayload_clientMutationId(ctx, field)
-	case "session":
-		return ec.fieldContext_RefreshTokenPayload_session(ctx, field)
+	case "token":
+		return ec.fieldContext_RefreshTokenPayload_token(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type RefreshTokenPayload", field.Name)
 }
@@ -6761,6 +6746,24 @@ func (ec *executionContext) childFields_StrategyDefinition(ctx context.Context, 
 	return nil, fmt.Errorf("no field named %q was found under type StrategyDefinition", field.Name)
 }
 
+func (ec *executionContext) childFields_TokenResponse(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "accessToken":
+		return ec.fieldContext_TokenResponse_accessToken(ctx, field)
+	case "tokenType":
+		return ec.fieldContext_TokenResponse_tokenType(ctx, field)
+	case "expiresIn":
+		return ec.fieldContext_TokenResponse_expiresIn(ctx, field)
+	case "refreshToken":
+		return ec.fieldContext_TokenResponse_refreshToken(ctx, field)
+	case "scope":
+		return ec.fieldContext_TokenResponse_scope(ctx, field)
+	case "idToken":
+		return ec.fieldContext_TokenResponse_idToken(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type TokenResponse", field.Name)
+}
+
 func (ec *executionContext) childFields_TransferRepositoryPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
 	case "clientMutationId":
@@ -6791,16 +6794,6 @@ func (ec *executionContext) childFields_UpdateCollectionPayload(ctx context.Cont
 		return ec.fieldContext_UpdateCollectionPayload_conflict(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type UpdateCollectionPayload", field.Name)
-}
-
-func (ec *executionContext) childFields_User(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-	switch field.Name {
-	case "username":
-		return ec.fieldContext_User_username(ctx, field)
-	case "isAdmin":
-		return ec.fieldContext_User_isAdmin(ctx, field)
-	}
-	return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 }
 
 func (ec *executionContext) childFields_VariantSummaryDefinition(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {

--- a/gitstore-api/internal/graph/model/models_gen.go
+++ b/gitstore-api/internal/graph/model/models_gen.go
@@ -19,16 +19,6 @@ type Node interface {
 	GetID() string
 }
 
-// Authentication session response
-type AuthSession struct {
-	// JWT token for authentication
-	Token string `json:"token"`
-	// Token expiration time (ISO 8601)
-	ExpiresAt time.Time `json:"expiresAt"`
-	// Authenticated user information
-	User *User `json:"user"`
-}
-
 // A pointer to another catalogue resource.
 type CatalogObjectReference struct {
 	APIVersion      *string `json:"apiVersion,omitempty"`
@@ -326,7 +316,7 @@ type CreateCollectionPayload struct {
 
 // Input for creating a new namespace.
 type CreateNamespaceInput struct {
-	// Client mutation ID for request tracking (Relay pattern).
+	// TODO: Remove, deprecated in relay
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The human-readable identifier for the namespace.
 	// Must be globally unique across all tiers.
@@ -344,7 +334,7 @@ type CreateNamespaceInput struct {
 
 // Payload returned after successfully creating a namespace.
 type CreateNamespacePayload struct {
-	// Client mutation ID for request tracking (Relay pattern).
+	// TODO: Remove, deprecated in relay
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The newly created namespace.
 	Namespace *Namespace `json:"namespace"`
@@ -390,7 +380,7 @@ type DeleteCollectionPayload struct {
 
 // Input for deleting a namespace.
 type DeleteNamespaceInput struct {
-	// Client mutation ID for request tracking (Relay pattern).
+	// TODO: Remove, deprecated in relay
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The identifier of the namespace to delete.
 	// Deletion is blocked if any repositories exist within the namespace.
@@ -400,7 +390,7 @@ type DeleteNamespaceInput struct {
 
 // Payload returned after successfully deleting a namespace.
 type DeleteNamespacePayload struct {
-	// Client mutation ID for request tracking (Relay pattern).
+	// TODO: Remove, deprecated in relay
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The identifier of the deleted namespace.
 	DeletedIdentifier string `json:"deletedIdentifier"`
@@ -472,32 +462,30 @@ type LabelSelectorRequirement struct {
 
 // Login mutation input (Relay pattern)
 type LoginInput struct {
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Username
 	Username string `json:"username"`
 	// Password
 	Password string `json:"password"`
+	// Optional OAuth2 scope request.
+	// Scope requests are currently unsupported by local providers.
+	Scope *string `json:"scope,omitempty"`
 }
 
 // Login mutation payload (Relay pattern)
 type LoginPayload struct {
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// Authentication session (token + user info)
-	Session *AuthSession `json:"session,omitempty"`
+	// OIDC-compatible token payload.
+	Token *TokenResponse `json:"token"`
 }
 
 // Logout mutation input (Relay pattern)
 type LogoutInput struct {
+	// TODO: Is it safe to remove and empty Input?
 	// Client mutation ID for request tracking (Relay pattern)
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 }
 
 // Logout mutation payload (Relay pattern)
 type LogoutPayload struct {
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Success indicator
 	Success bool `json:"success"`
 }
@@ -868,16 +856,17 @@ type Query struct {
 
 // Refresh token mutation input (Relay pattern)
 type RefreshTokenInput struct {
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
+	// Refresh token used to issue a new access token.
+	RefreshToken string `json:"refreshToken"`
+	// Optional OAuth2 scope request.
+	// Scope requests are currently unsupported by local providers.
+	Scope *string `json:"scope,omitempty"`
 }
 
 // Refresh token mutation payload (Relay pattern)
 type RefreshTokenPayload struct {
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// New authentication session
-	Session *AuthSession `json:"session,omitempty"`
+	// OIDC-compatible token payload.
+	Token *TokenResponse `json:"token"`
 }
 
 type RenameRepositoryInput struct {
@@ -1059,6 +1048,25 @@ type SelectedOptionDefinition struct {
 type StrategyDefinition struct {
 	// Strategy identifier (e.g. fixed, percentage_discount, cost_plus).
 	Type string `json:"type"`
+}
+
+// OIDC-compatible token response.
+type TokenResponse struct {
+	// Access token used for authenticated API calls.
+	AccessToken string `json:"accessToken"`
+	// Token type. Always `Bearer` for GitStore-issued tokens.
+	TokenType string `json:"tokenType"`
+	// Seconds until the access token expires.
+	ExpiresIn int32 `json:"expiresIn"`
+	// Refresh token used to obtain a new access token.
+	// For local providers, this is currently a GitStore-issued token.
+	RefreshToken *string `json:"refreshToken,omitempty"`
+	// Granted scope set as a space-delimited string.
+	// Scope requests are currently unsupported and this field is null.
+	Scope *string `json:"scope,omitempty"`
+	// OIDC ID token when available.
+	// GitStore local providers currently do not issue this field.
+	IDToken *string `json:"idToken,omitempty"`
 }
 
 type TransferRepositoryInput struct {

--- a/gitstore-api/internal/graph/resolver/auth.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/auth.resolvers.go
@@ -7,15 +7,8 @@ package resolver
 
 import (
 	"context"
-	"encoding/base64"
-	"errors"
-	"fmt"
-	"net/http"
 
-	"github.com/gitstore-dev/gitstore/api/internal/auth"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
-	"github.com/vektah/gqlparser/v2/gqlerror"
-	"go.uber.org/zap"
 )
 
 // Login is the resolver for the login field.
@@ -23,133 +16,12 @@ func (r *mutationResolver) Login(ctx context.Context, input model.LoginInput) (*
 	return r.Resolver.Login(ctx, input)
 }
 
-// Login implements the login mutation on the base Resolver so it can be unit-tested directly.
-func (r *Resolver) Login(ctx context.Context, input model.LoginInput) (*model.LoginPayload, error) {
-	if r.registry == nil || r.registry.AuthN() == nil {
-		r.logger.Error("auth provider registry not configured")
-		return nil, gqlerror.Errorf("authentication service unavailable")
-	}
-
-	creds := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", input.Username, input.Password)))
-	req := auth.AuthRequest{
-		Header: http.Header{"Authorization": []string{"Basic " + creds}},
-	}
-
-	principal, decision, err := r.registry.AuthN().Authenticate(ctx, req)
-	if err != nil {
-		r.logger.Debug("login auth error", zap.Error(err))
-		return nil, gqlerror.Errorf("invalid username or password")
-	}
-	if decision.Outcome != auth.OutcomeAllow {
-		r.logger.Debug("login denied", zap.String("reason", decision.Reason))
-		return nil, gqlerror.Errorf("invalid username or password")
-	}
-
-	token, exp, err := r.registry.AuthN().IssueSession(ctx, principal.Subject)
-	if err != nil {
-		if errors.Is(err, auth.ErrNotSupported) {
-			r.logger.Error("no auth provider supports IssueSession")
-			return nil, gqlerror.Errorf("authentication service unavailable")
-		}
-		r.logger.Error("failed to issue session token", zap.String("subject", principal.Subject), zap.Error(err))
-		return nil, gqlerror.Errorf("internal server error")
-	}
-
-	r.logger.Debug("login succeeded", zap.String("subject", principal.Subject), zap.String("provider", decision.Provider))
-	return &model.LoginPayload{
-		Session: &model.AuthSession{
-			Token:     token,
-			ExpiresAt: exp,
-			User: &model.User{
-				Username: principal.Subject,
-				IsAdmin:  principal.IsAdmin(),
-			},
-		},
-	}, nil
-}
-
 // Logout is the resolver for the logout field.
 func (r *mutationResolver) Logout(ctx context.Context, input model.LogoutInput) (*model.LogoutPayload, error) {
 	return r.Resolver.Logout(ctx, input)
 }
 
-// Logout implements the logout mutation on the base Resolver so it can be unit-tested directly.
-func (r *Resolver) Logout(ctx context.Context, input model.LogoutInput) (*model.LogoutPayload, error) {
-	if r.registry == nil {
-		return nil, gqlerror.Errorf("authentication service unavailable")
-	}
-
-	// GraphQLAuthorizer already denies anonymous principals for non-login
-	// mutations; this check is defense-in-depth so Logout fails closed even
-	// if invoked without the operation middleware (e.g. direct resolver call).
-	principal := auth.PrincipalFromContext(ctx)
-	if principal == nil || principal.AuthMethod == "none" {
-		return nil, gqlerror.Errorf("authentication required")
-	}
-
-	// Empty TokenID means a Basic Auth session with no jti — nothing to revoke.
-	if principal.TokenID != "" {
-		err := r.registry.AuthN().RevokeSession(ctx, principal.TokenID, principal.ExpiresAt)
-		if err != nil {
-			if errors.Is(err, auth.ErrNotSupported) {
-				r.logger.Warn("logout not supported by active auth configuration")
-				return nil, gqlerror.Errorf("logout not supported by active auth configuration")
-			}
-			r.logger.Error("failed to revoke session", zap.String("subject", principal.Subject), zap.Error(err))
-			return nil, gqlerror.Errorf("internal server error")
-		}
-	}
-
-	r.logger.Debug("logout succeeded", zap.String("subject", principal.Subject))
-	return &model.LogoutPayload{Success: true}, nil
-}
-
 // RefreshToken is the resolver for the refreshToken field.
 func (r *mutationResolver) RefreshToken(ctx context.Context, input model.RefreshTokenInput) (*model.RefreshTokenPayload, error) {
 	return r.Resolver.RefreshToken(ctx, input)
-}
-
-// RefreshToken implements the refreshToken mutation on the base Resolver so it can be unit-tested directly.
-func (r *Resolver) RefreshToken(ctx context.Context, input model.RefreshTokenInput) (*model.RefreshTokenPayload, error) {
-	if r.registry == nil {
-		return nil, gqlerror.Errorf("authentication service unavailable")
-	}
-
-	rawToken := auth.RawTokenFromContext(ctx)
-	if rawToken == "" {
-		return nil, gqlerror.Errorf("refresh token requires bearer authentication")
-	}
-
-	newToken, exp, err := r.registry.AuthN().RefreshSession(ctx, rawToken)
-	if err != nil {
-		switch {
-		case errors.Is(err, auth.ErrNotSupported):
-			return nil, gqlerror.Errorf("token refresh not supported by active auth configuration")
-		case errors.Is(err, auth.ErrTokenTooOld):
-			return nil, gqlerror.Errorf("token too old to refresh, please log in again")
-		case errors.Is(err, auth.ErrTokenRevoked):
-			return nil, gqlerror.Errorf("token has been revoked")
-		default:
-			r.logger.Error("token refresh failed", zap.Error(err))
-			return nil, gqlerror.Errorf("internal server error")
-		}
-	}
-
-	principal := auth.PrincipalFromContext(ctx)
-	if principal == nil {
-		r.logger.Error("token refreshed but principal missing from context")
-		return nil, gqlerror.Errorf("internal server error")
-	}
-
-	r.logger.Debug("token refreshed", zap.String("subject", principal.Subject))
-	return &model.RefreshTokenPayload{
-		Session: &model.AuthSession{
-			Token:     newToken,
-			ExpiresAt: exp,
-			User: &model.User{
-				Username: principal.Subject,
-				IsAdmin:  principal.IsAdmin(),
-			},
-		},
-	}, nil
 }

--- a/gitstore-api/internal/graph/resolver/auth.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/auth.resolvers.go
@@ -79,10 +79,12 @@ func (r *Resolver) Logout(ctx context.Context, input model.LogoutInput) (*model.
 		return nil, gqlerror.Errorf("authentication service unavailable")
 	}
 
+	// GraphQLAuthorizer already denies anonymous principals for non-login
+	// mutations; this check is defense-in-depth so Logout fails closed even
+	// if invoked without the operation middleware (e.g. direct resolver call).
 	principal := auth.PrincipalFromContext(ctx)
-	if principal == nil {
-		r.logger.Error("logout principal missing from context")
-		return nil, gqlerror.Errorf("internal server error")
+	if principal == nil || principal.AuthMethod == "none" {
+		return nil, gqlerror.Errorf("authentication required")
 	}
 
 	// Empty TokenID means a Basic Auth session with no jti — nothing to revoke.

--- a/gitstore-api/internal/graph/resolver/auth.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/auth.resolvers.go
@@ -80,8 +80,9 @@ func (r *Resolver) Logout(ctx context.Context, input model.LogoutInput) (*model.
 	}
 
 	principal := auth.PrincipalFromContext(ctx)
-	if principal == nil || principal.AuthMethod == "none" {
-		return nil, gqlerror.Errorf("authentication required")
+	if principal == nil {
+		r.logger.Error("logout principal missing from context")
+		return nil, gqlerror.Errorf("internal server error")
 	}
 
 	// Empty TokenID means a Basic Auth session with no jti — nothing to revoke.
@@ -114,7 +115,7 @@ func (r *Resolver) RefreshToken(ctx context.Context, input model.RefreshTokenInp
 
 	rawToken := auth.RawTokenFromContext(ctx)
 	if rawToken == "" {
-		return nil, gqlerror.Errorf("authentication required")
+		return nil, gqlerror.Errorf("refresh token requires bearer authentication")
 	}
 
 	newToken, exp, err := r.registry.AuthN().RefreshSession(ctx, rawToken)

--- a/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
+++ b/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
@@ -107,16 +107,17 @@ func TestLogout_AuthenticatedBearer_ReturnsSuccess(t *testing.T) {
 	assert.True(t, payload.Success)
 }
 
-func TestLogout_UnauthenticatedCaller_ReturnsError(t *testing.T) {
+func TestLogout_AnonymousPrincipal_NoOpReturnsSuccess(t *testing.T) {
 	cfg := newTestConfig(t, "1h")
 	reg, _ := newTestRegistry(t, cfg)
 	r := newTestResolver(t, reg)
 
-	// Anonymous principal (AuthMethod == "none")
 	ctx := ctxWithPrincipal(authpkg.Anonymous())
 
-	_, err := r.Logout(ctx, model.LogoutInput{})
-	require.Error(t, err)
+	payload, err := r.Logout(ctx, model.LogoutInput{})
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	assert.True(t, payload.Success)
 }
 
 func TestLogout_NilPrincipal_ReturnsError(t *testing.T) {

--- a/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
+++ b/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
@@ -77,11 +77,6 @@ func ctxWithPrincipal(principal *authpkg.Principal) context.Context {
 	return authpkg.ContextWithPrincipal(context.Background(), principal)
 }
 
-func ctxWithPrincipalAndRawToken(principal *authpkg.Principal, rawToken string) context.Context {
-	ctx := authpkg.ContextWithPrincipal(context.Background(), principal)
-	return authpkg.ContextWithRawToken(ctx, rawToken)
-}
-
 // --- US1: Logout ---
 
 func TestLogout_AuthenticatedBearer_ReturnsSuccess(t *testing.T) {
@@ -158,16 +153,15 @@ func TestRefreshToken_ValidToken_ReturnsNewSession(t *testing.T) {
 	token, _, err := p.IssueToken("admin")
 	require.NoError(t, err)
 
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipalAndRawToken(principal, token)
-
-	payload, err := r.RefreshToken(ctx, model.RefreshTokenInput{})
+	payload, err := r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: token})
 	require.NoError(t, err)
 	require.NotNil(t, payload)
-	require.NotNil(t, payload.Session)
-	assert.NotEmpty(t, payload.Session.Token)
-	assert.NotEqual(t, token, payload.Session.Token, "refreshed token must differ from original")
-	assert.False(t, payload.Session.ExpiresAt.IsZero())
+	assert.NotEmpty(t, payload.Token.AccessToken)
+	assert.Equal(t, "Bearer", payload.Token.TokenType)
+	assert.Greater(t, payload.Token.ExpiresIn, int32(0))
+	require.NotNil(t, payload.Token.RefreshToken)
+	assert.NotEqual(t, token, payload.Token.AccessToken, "refreshed token must differ from original")
+	assert.Equal(t, payload.Token.AccessToken, *payload.Token.RefreshToken)
 }
 
 func TestRefreshToken_ExpiredWithinGrace_Succeeds(t *testing.T) {
@@ -178,13 +172,10 @@ func TestRefreshToken_ExpiredWithinGrace_Succeeds(t *testing.T) {
 	token, _, err := p.IssueToken("admin")
 	require.NoError(t, err)
 
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipalAndRawToken(principal, token)
-
-	payload, err := r.RefreshToken(ctx, model.RefreshTokenInput{})
+	payload, err := r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: token})
 	require.NoError(t, err)
 	require.NotNil(t, payload)
-	assert.NotEmpty(t, payload.Session.Token)
+	assert.NotEmpty(t, payload.Token.AccessToken)
 }
 
 func TestRefreshToken_ExpiredBeyondGrace_ReturnsError(t *testing.T) {
@@ -195,10 +186,7 @@ func TestRefreshToken_ExpiredBeyondGrace_ReturnsError(t *testing.T) {
 	token, _, err := p.IssueToken("admin")
 	require.NoError(t, err)
 
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipalAndRawToken(principal, token)
-
-	_, err = r.RefreshToken(ctx, model.RefreshTokenInput{})
+	_, err = r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: token})
 	require.Error(t, err)
 }
 
@@ -214,29 +202,39 @@ func TestRefreshToken_RevokedToken_ReturnsError(t *testing.T) {
 	err = p.RevokeSession(context.Background(), jti, exp)
 	require.NoError(t, err)
 
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipalAndRawToken(principal, token)
-
-	_, err = r.RefreshToken(ctx, model.RefreshTokenInput{})
+	_, err = r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: token})
 	require.Error(t, err)
 }
 
-func TestRefreshToken_NoRawToken_ReturnsError(t *testing.T) {
+func TestRefreshToken_EmptyRefreshToken_ReturnsError(t *testing.T) {
 	cfg := newTestConfig(t, "1h")
 	reg, _ := newTestRegistry(t, cfg)
 	r := newTestResolver(t, reg)
 
-	// No raw token in context — unauthenticated or Basic Auth session
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipal(principal)
-
-	_, err := r.RefreshToken(ctx, model.RefreshTokenInput{})
+	_, err := r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: ""})
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refresh token is required")
+}
+
+func TestRefreshToken_UnsupportedScope_ReturnsError(t *testing.T) {
+	cfg := newTestConfig(t, "1h")
+	reg, p := newTestRegistry(t, cfg)
+	r := newTestResolver(t, reg)
+
+	token, _, err := p.IssueToken("admin")
+	require.NoError(t, err)
+	scope := "catalog:read"
+	_, err = r.RefreshToken(context.Background(), model.RefreshTokenInput{
+		RefreshToken: token,
+		Scope:        &scope,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope requests are not supported")
 }
 
 // --- US3: Login migration ---
 
-func TestLogin_ValidCredentials_ReturnsSession(t *testing.T) {
+func TestLogin_ValidCredentials_ReturnsTokenPayload(t *testing.T) {
 	cfg := newTestConfig(t, "1h")
 	reg, _ := newTestRegistry(t, cfg)
 	r := newTestResolver(t, reg)
@@ -246,12 +244,13 @@ func TestLogin_ValidCredentials_ReturnsSession(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, payload)
-	require.NotNil(t, payload.Session)
-	assert.NotEmpty(t, payload.Session.Token)
-	assert.False(t, payload.Session.ExpiresAt.IsZero())
-	require.NotNil(t, payload.Session.User)
-	assert.Equal(t, "admin", payload.Session.User.Username)
-	assert.True(t, payload.Session.User.IsAdmin, "admin user must have isAdmin=true derived from principal roles")
+	assert.NotEmpty(t, payload.Token.AccessToken)
+	assert.Equal(t, "Bearer", payload.Token.TokenType)
+	assert.Greater(t, payload.Token.ExpiresIn, int32(0))
+	require.NotNil(t, payload.Token.RefreshToken)
+	assert.Equal(t, payload.Token.AccessToken, *payload.Token.RefreshToken)
+	assert.Nil(t, payload.Token.Scope)
+	assert.Nil(t, payload.Token.IDToken)
 }
 
 func TestLogin_InvalidPassword_ReturnsError(t *testing.T) {
@@ -261,6 +260,17 @@ func TestLogin_InvalidPassword_ReturnsError(t *testing.T) {
 
 	_, err := r.Login(context.Background(), model.LoginInput{Username: "admin", Password: "wrongpass"})
 	require.Error(t, err)
+}
+
+func TestLogin_UnsupportedScope_ReturnsError(t *testing.T) {
+	cfg := newTestConfig(t, "1h")
+	reg, _ := newTestRegistry(t, cfg)
+	r := newTestResolver(t, reg)
+	scope := "catalog:read"
+
+	_, err := r.Login(context.Background(), model.LoginInput{Username: "admin", Password: "testpass", Scope: &scope})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope requests are not supported")
 }
 
 func TestLogin_NilRegistry_ReturnsError(t *testing.T) {
@@ -304,9 +314,7 @@ func TestRefreshToken_NilRegistry_ReturnsError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipalAndRawToken(principal, "some.bearer.token")
-	_, err = r.RefreshToken(ctx, model.RefreshTokenInput{})
+	_, err = r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: "some.refresh.token"})
 	require.Error(t, err)
 }
 

--- a/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
+++ b/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
@@ -107,17 +107,16 @@ func TestLogout_AuthenticatedBearer_ReturnsSuccess(t *testing.T) {
 	assert.True(t, payload.Success)
 }
 
-func TestLogout_AnonymousPrincipal_NoOpReturnsSuccess(t *testing.T) {
+func TestLogout_AnonymousPrincipal_ReturnsError(t *testing.T) {
 	cfg := newTestConfig(t, "1h")
 	reg, _ := newTestRegistry(t, cfg)
 	r := newTestResolver(t, reg)
 
 	ctx := ctxWithPrincipal(authpkg.Anonymous())
 
-	payload, err := r.Logout(ctx, model.LogoutInput{})
-	require.NoError(t, err)
-	require.NotNil(t, payload)
-	assert.True(t, payload.Success)
+	_, err := r.Logout(ctx, model.LogoutInput{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication required")
 }
 
 func TestLogout_NilPrincipal_ReturnsError(t *testing.T) {

--- a/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
+++ b/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
@@ -232,6 +232,16 @@ func TestRefreshToken_UnsupportedScope_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "scope requests are not supported")
 }
 
+func TestRefreshToken_InvalidToken_ReturnsClientAuthError(t *testing.T) {
+	cfg := newTestConfig(t, "1h")
+	reg, _ := newTestRegistry(t, cfg)
+	r := newTestResolver(t, reg)
+
+	_, err := r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: "not-a-jwt"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid or expired refresh token")
+}
+
 // --- US3: Login migration ---
 
 func TestLogin_ValidCredentials_ReturnsTokenPayload(t *testing.T) {

--- a/gitstore-api/internal/graph/resolver/auth_service.go
+++ b/gitstore-api/internal/graph/resolver/auth_service.go
@@ -1,0 +1,133 @@
+package resolver
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/auth"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"go.uber.org/zap"
+)
+
+func tokenResponse(accessToken, refreshToken string, exp time.Time) *model.TokenResponse {
+	ttl := int32(time.Until(exp).Seconds())
+	if ttl < 0 {
+		ttl = 0
+	}
+	return &model.TokenResponse{
+		AccessToken:  accessToken,
+		TokenType:    "Bearer",
+		ExpiresIn:    ttl,
+		RefreshToken: &refreshToken,
+	}
+}
+
+// Login implements the login mutation on the base Resolver so it can be unit-tested directly.
+func (r *Resolver) Login(ctx context.Context, input model.LoginInput) (*model.LoginPayload, error) {
+	if r.registry == nil || r.registry.AuthN() == nil {
+		r.logger.Error("auth provider registry not configured")
+		return nil, gqlerror.Errorf("authentication service unavailable")
+	}
+	if input.Scope != nil && *input.Scope != "" {
+		return nil, gqlerror.Errorf("scope requests are not supported by active auth configuration")
+	}
+
+	creds := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", input.Username, input.Password)))
+	req := auth.AuthRequest{
+		Header: http.Header{"Authorization": []string{"Basic " + creds}},
+	}
+
+	principal, decision, err := r.registry.AuthN().Authenticate(ctx, req)
+	if err != nil {
+		r.logger.Debug("login auth error", zap.Error(err))
+		return nil, gqlerror.Errorf("invalid username or password")
+	}
+	if decision.Outcome != auth.OutcomeAllow {
+		r.logger.Debug("login denied", zap.String("reason", decision.Reason))
+		return nil, gqlerror.Errorf("invalid username or password")
+	}
+
+	token, exp, err := r.registry.AuthN().IssueSession(ctx, principal.Subject)
+	if err != nil {
+		if errors.Is(err, auth.ErrNotSupported) {
+			r.logger.Error("no auth provider supports IssueSession")
+			return nil, gqlerror.Errorf("authentication service unavailable")
+		}
+		r.logger.Error("failed to issue session token", zap.String("subject", principal.Subject), zap.Error(err))
+		return nil, gqlerror.Errorf("internal server error")
+	}
+
+	r.logger.Debug("login succeeded", zap.String("subject", principal.Subject), zap.String("provider", decision.Provider))
+	return &model.LoginPayload{
+		Token: tokenResponse(token, token, exp),
+	}, nil
+}
+
+// Logout implements the logout mutation on the base Resolver so it can be unit-tested directly.
+func (r *Resolver) Logout(ctx context.Context, input model.LogoutInput) (*model.LogoutPayload, error) {
+	if r.registry == nil {
+		return nil, gqlerror.Errorf("authentication service unavailable")
+	}
+
+	// GraphQLAuthorizer already denies anonymous principals for non-login
+	// mutations; this check is defense-in-depth so Logout fails closed even
+	// if invoked without the operation middleware (e.g. direct resolver call).
+	principal := auth.PrincipalFromContext(ctx)
+	if principal == nil || principal.AuthMethod == "none" {
+		return nil, gqlerror.Errorf("authentication required")
+	}
+
+	// Empty TokenID means a Basic Auth session with no jti — nothing to revoke.
+	if principal.TokenID != "" {
+		err := r.registry.AuthN().RevokeSession(ctx, principal.TokenID, principal.ExpiresAt)
+		if err != nil {
+			if errors.Is(err, auth.ErrNotSupported) {
+				r.logger.Warn("logout not supported by active auth configuration")
+				return nil, gqlerror.Errorf("logout not supported by active auth configuration")
+			}
+			r.logger.Error("failed to revoke session", zap.String("subject", principal.Subject), zap.Error(err))
+			return nil, gqlerror.Errorf("internal server error")
+		}
+	}
+
+	r.logger.Debug("logout succeeded", zap.String("subject", principal.Subject))
+	return &model.LogoutPayload{Success: true}, nil
+}
+
+// RefreshToken implements the refreshToken mutation on the base Resolver so it can be unit-tested directly.
+func (r *Resolver) RefreshToken(ctx context.Context, input model.RefreshTokenInput) (*model.RefreshTokenPayload, error) {
+	if r.registry == nil {
+		return nil, gqlerror.Errorf("authentication service unavailable")
+	}
+	if input.Scope != nil && *input.Scope != "" {
+		return nil, gqlerror.Errorf("scope requests are not supported by active auth configuration")
+	}
+	if input.RefreshToken == "" {
+		return nil, gqlerror.Errorf("refresh token is required")
+	}
+
+	newToken, exp, err := r.registry.AuthN().RefreshSession(ctx, input.RefreshToken)
+	if err != nil {
+		switch {
+		case errors.Is(err, auth.ErrNotSupported):
+			return nil, gqlerror.Errorf("token refresh not supported by active auth configuration")
+		case errors.Is(err, auth.ErrTokenTooOld):
+			return nil, gqlerror.Errorf("token too old to refresh, please log in again")
+		case errors.Is(err, auth.ErrTokenRevoked):
+			return nil, gqlerror.Errorf("token has been revoked")
+		default:
+			r.logger.Error("token refresh failed", zap.Error(err))
+			return nil, gqlerror.Errorf("internal server error")
+		}
+	}
+
+	r.logger.Debug("token refreshed")
+	return &model.RefreshTokenPayload{
+		Token: tokenResponse(newToken, newToken, exp),
+	}, nil
+}

--- a/gitstore-api/internal/graph/resolver/auth_service.go
+++ b/gitstore-api/internal/graph/resolver/auth_service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 package resolver
 
 import (

--- a/gitstore-api/internal/graph/resolver/auth_service.go
+++ b/gitstore-api/internal/graph/resolver/auth_service.go
@@ -116,6 +116,8 @@ func (r *Resolver) RefreshToken(ctx context.Context, input model.RefreshTokenInp
 		switch {
 		case errors.Is(err, auth.ErrNotSupported):
 			return nil, gqlerror.Errorf("token refresh not supported by active auth configuration")
+		case errors.Is(err, auth.ErrInvalidToken):
+			return nil, gqlerror.Errorf("invalid or expired refresh token")
 		case errors.Is(err, auth.ErrTokenTooOld):
 			return nil, gqlerror.Errorf("token too old to refresh, please log in again")
 		case errors.Is(err, auth.ErrTokenRevoked):

--- a/gitstore-api/internal/graph/resolver/namespace.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/namespace.resolvers.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/gitstore-dev/gitstore/api/internal/auth"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // CreateNamespace is the resolver for the createNamespace field.
 func (r *mutationResolver) CreateNamespace(ctx context.Context, input model.CreateNamespaceInput) (*model.CreateNamespacePayload, error) {
 	p := auth.PrincipalFromContext(ctx)
-	if p == nil || p.AuthMethod == "none" {
-		return nil, gqlerror.Errorf("authentication required")
+	if p == nil {
+		p = auth.Anonymous()
 	}
 
 	ns, err := r.service.CreateNamespace(ctx, input, p.Subject, p.IsAdmin())
@@ -34,8 +33,8 @@ func (r *mutationResolver) CreateNamespace(ctx context.Context, input model.Crea
 // DeleteNamespace is the resolver for the deleteNamespace field.
 func (r *mutationResolver) DeleteNamespace(ctx context.Context, input model.DeleteNamespaceInput) (*model.DeleteNamespacePayload, error) {
 	p := auth.PrincipalFromContext(ctx)
-	if p == nil || p.AuthMethod == "none" {
-		return nil, gqlerror.Errorf("authentication required")
+	if p == nil {
+		p = auth.Anonymous()
 	}
 
 	if err := r.service.DeleteNamespace(ctx, input.Identifier, p.Subject, p.IsAdmin()); err != nil {

--- a/gitstore-api/internal/graph/resolver/namespace.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/namespace.resolvers.go
@@ -9,6 +9,8 @@ import (
 	"context"
 
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
+	"github.com/gitstore-dev/gitstore/api/internal/middleware/security"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // CreateNamespace is the resolver for the createNamespace field.
@@ -26,7 +28,11 @@ func (r *mutationResolver) CreateNamespace(ctx context.Context, input model.Crea
 
 // DeleteNamespace is the resolver for the deleteNamespace field.
 func (r *mutationResolver) DeleteNamespace(ctx context.Context, input model.DeleteNamespaceInput) (*model.DeleteNamespacePayload, error) {
-	if err := r.service.DeleteNamespace(ctx, input.Identifier); err != nil {
+	ns, ok := security.AuthorizedNamespaceForDeletion(ctx)
+	if !ok || ns.Identifier != input.Identifier {
+		return nil, gqlerror.Errorf("namespace deletion authorization context is missing")
+	}
+	if err := r.service.DeleteNamespace(ctx, ns); err != nil {
 		return nil, err
 	}
 

--- a/gitstore-api/internal/graph/resolver/namespace.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/namespace.resolvers.go
@@ -8,18 +8,12 @@ package resolver
 import (
 	"context"
 
-	"github.com/gitstore-dev/gitstore/api/internal/auth"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
 )
 
 // CreateNamespace is the resolver for the createNamespace field.
 func (r *mutationResolver) CreateNamespace(ctx context.Context, input model.CreateNamespaceInput) (*model.CreateNamespacePayload, error) {
-	p := auth.PrincipalFromContext(ctx)
-	if p == nil {
-		p = auth.Anonymous()
-	}
-
-	ns, err := r.service.CreateNamespace(ctx, input, p.Subject, p.IsAdmin())
+	ns, err := r.service.CreateNamespace(ctx, input, callerUsernameOrAnon(ctx, r))
 	if err != nil {
 		return nil, err
 	}
@@ -32,12 +26,7 @@ func (r *mutationResolver) CreateNamespace(ctx context.Context, input model.Crea
 
 // DeleteNamespace is the resolver for the deleteNamespace field.
 func (r *mutationResolver) DeleteNamespace(ctx context.Context, input model.DeleteNamespaceInput) (*model.DeleteNamespacePayload, error) {
-	p := auth.PrincipalFromContext(ctx)
-	if p == nil {
-		p = auth.Anonymous()
-	}
-
-	if err := r.service.DeleteNamespace(ctx, input.Identifier, p.Subject, p.IsAdmin()); err != nil {
+	if err := r.service.DeleteNamespace(ctx, input.Identifier); err != nil {
 		return nil, err
 	}
 

--- a/gitstore-api/internal/graph/resolver/namespace_service_test.go
+++ b/gitstore-api/internal/graph/resolver/namespace_service_test.go
@@ -21,7 +21,7 @@ func TestCreateNamespace_userTier_success(t *testing.T) {
 		Identifier: "acme-corp",
 		Tier:       model.NamespaceTierUser,
 	}
-	ns, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	ns, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 	require.NotNil(t, ns)
 	assert.Equal(t, "acme-corp", ns.Identifier)
@@ -35,7 +35,7 @@ func TestCreateNamespace_orgTier_success(t *testing.T) {
 		Identifier: "acme-engineering",
 		Tier:       model.NamespaceTierOrganization,
 	}
-	ns, err := svc.CreateNamespace(context.Background(), input, "bob", true)
+	ns, err := svc.CreateNamespace(context.Background(), input, "bob")
 	require.NoError(t, err)
 	require.NotNil(t, ns)
 	assert.Equal(t, "acme-engineering", ns.Identifier)
@@ -47,11 +47,11 @@ func TestCreateNamespace_duplicateIdentifier_conflict(t *testing.T) {
 		Identifier: "duplicate-ns",
 		Tier:       model.NamespaceTierUser,
 	}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	_, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 
 	// second call with same identifier
-	_, err = svc.CreateNamespace(context.Background(), input, "bob", false)
+	_, err = svc.CreateNamespace(context.Background(), input, "bob")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }
@@ -62,7 +62,7 @@ func TestCreateNamespace_invalidIdentifier_spaces(t *testing.T) {
 		Identifier: "invalid identifier",
 		Tier:       model.NamespaceTierUser,
 	}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	_, err := svc.CreateNamespace(context.Background(), input, "alice")
 	assert.Error(t, err)
 }
 
@@ -73,7 +73,7 @@ func TestCreateNamespace_uppercaseIdentifier_normalizedToLowercase(t *testing.T)
 		Tier:       model.NamespaceTierUser,
 	}
 	// uppercase is folded to lowercase before validation; "invalidns" is a valid identifier
-	ns, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	ns, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 	assert.Equal(t, "invalidns", ns.Identifier)
 }
@@ -84,7 +84,7 @@ func TestCreateNamespace_invalidIdentifier_leadingHyphen(t *testing.T) {
 		Identifier: "-leading-hyphen",
 		Tier:       model.NamespaceTierUser,
 	}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	_, err := svc.CreateNamespace(context.Background(), input, "alice")
 	assert.Error(t, err)
 }
 
@@ -94,7 +94,7 @@ func TestCreateNamespace_reservedIdentifier_admin(t *testing.T) {
 		Identifier: "admin",
 		Tier:       model.NamespaceTierUser,
 	}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	_, err := svc.CreateNamespace(context.Background(), input, "alice")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "reserved")
 }
@@ -108,7 +108,7 @@ func TestCreateNamespace_enterpriseTier_rejected(t *testing.T) {
 		Identifier: "acme-enterprise",
 		Tier:       model.NamespaceTier("ENTERPRISE"),
 	}
-	_, err := svc.CreateNamespace(context.Background(), input, "admin-user", true)
+	_, err := svc.CreateNamespace(context.Background(), input, "admin-user")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "enterprise")
 }
@@ -120,7 +120,7 @@ func TestListNamespaces_returnsAll(t *testing.T) {
 
 	for _, id := range []string{"ns-alpha", "ns-beta", "ns-gamma"} {
 		input := model.CreateNamespaceInput{Identifier: id, Tier: model.NamespaceTierUser}
-		_, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+		_, err := svc.CreateNamespace(context.Background(), input, "alice")
 		require.NoError(t, err)
 	}
 
@@ -134,7 +134,7 @@ func TestListNamespaces_returnsAll(t *testing.T) {
 func TestGetNamespaceByIdentifier_success(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
 	input := model.CreateNamespaceInput{Identifier: "lookup-me", Tier: model.NamespaceTierUser}
-	created, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	created, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 
 	got, err := svc.GetNamespaceByIdentifier(context.Background(), "lookup-me")
@@ -153,10 +153,10 @@ func TestGetNamespaceByIdentifier_notFound(t *testing.T) {
 func TestDeleteNamespace_owner_success(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
 	input := model.CreateNamespaceInput{Identifier: "to-delete", Tier: model.NamespaceTierUser}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	_, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 
-	err = svc.DeleteNamespace(context.Background(), "to-delete", "alice", false)
+	err = svc.DeleteNamespace(context.Background(), "to-delete")
 	require.NoError(t, err)
 
 	_, err = svc.GetNamespaceByIdentifier(context.Background(), "to-delete")
@@ -166,40 +166,36 @@ func TestDeleteNamespace_owner_success(t *testing.T) {
 func TestDeleteNamespace_admin_canDeleteAny(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
 	input := model.CreateNamespaceInput{Identifier: "owned-by-alice", Tier: model.NamespaceTierUser}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	_, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 
 	// admin deletes alice's namespace
-	err = svc.DeleteNamespace(context.Background(), "owned-by-alice", "admin-user", true)
+	err = svc.DeleteNamespace(context.Background(), "owned-by-alice")
 	require.NoError(t, err)
 }
 
-func TestDeleteNamespace_nonOwner_nonAdmin_denied(t *testing.T) {
+func TestDeleteNamespace_withoutAuthorizationCheck_serviceAllowsDelete(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
 	input := model.CreateNamespaceInput{Identifier: "alices-ns", Tier: model.NamespaceTierUser}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	_, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 
-	err = svc.DeleteNamespace(context.Background(), "alices-ns", "bob", false)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "permission denied")
+	err = svc.DeleteNamespace(context.Background(), "alices-ns")
+	require.NoError(t, err)
 }
 
 func TestDeleteNamespace_unknownIdentifier_notFound(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
-	err := svc.DeleteNamespace(context.Background(), "does-not-exist", "alice", false)
+	err := svc.DeleteNamespace(context.Background(), "does-not-exist")
 	assert.Error(t, err)
 }
 
-func TestDeleteNamespace_unauthenticated(t *testing.T) {
-	// Unauthenticated check is in the resolver, not service layer.
-	// Service requires callerUsername — empty caller cannot be owner.
+func TestDeleteNamespace_serviceDoesNotRequireCallerIdentity(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
 	input := model.CreateNamespaceInput{Identifier: "auth-test-ns", Tier: model.NamespaceTierUser}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice", false)
+	_, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 
-	// empty caller is not the owner and not admin
-	err = svc.DeleteNamespace(context.Background(), "auth-test-ns", "", false)
-	assert.Error(t, err)
+	err = svc.DeleteNamespace(context.Background(), "auth-test-ns")
+	require.NoError(t, err)
 }

--- a/gitstore-api/internal/graph/resolver/namespace_service_test.go
+++ b/gitstore-api/internal/graph/resolver/namespace_service_test.go
@@ -153,10 +153,10 @@ func TestGetNamespaceByIdentifier_notFound(t *testing.T) {
 func TestDeleteNamespace_owner_success(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
 	input := model.CreateNamespaceInput{Identifier: "to-delete", Tier: model.NamespaceTierUser}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice")
+	ns, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 
-	err = svc.DeleteNamespace(context.Background(), "to-delete")
+	err = svc.DeleteNamespace(context.Background(), ns)
 	require.NoError(t, err)
 
 	_, err = svc.GetNamespaceByIdentifier(context.Background(), "to-delete")
@@ -166,36 +166,43 @@ func TestDeleteNamespace_owner_success(t *testing.T) {
 func TestDeleteNamespace_admin_canDeleteAny(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
 	input := model.CreateNamespaceInput{Identifier: "owned-by-alice", Tier: model.NamespaceTierUser}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice")
+	ns, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 
 	// admin deletes alice's namespace
-	err = svc.DeleteNamespace(context.Background(), "owned-by-alice")
+	err = svc.DeleteNamespace(context.Background(), ns)
 	require.NoError(t, err)
 }
 
 func TestDeleteNamespace_withoutAuthorizationCheck_serviceAllowsDelete(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
 	input := model.CreateNamespaceInput{Identifier: "alices-ns", Tier: model.NamespaceTierUser}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice")
+	ns, err := svc.CreateNamespace(context.Background(), input, "alice")
 	require.NoError(t, err)
 
-	err = svc.DeleteNamespace(context.Background(), "alices-ns")
+	err = svc.DeleteNamespace(context.Background(), ns)
 	require.NoError(t, err)
 }
 
 func TestDeleteNamespace_unknownIdentifier_notFound(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
-	err := svc.DeleteNamespace(context.Background(), "does-not-exist")
+	err := svc.DeleteNamespace(context.Background(), &datastore.Namespace{ID: "does-not-exist", Identifier: "does-not-exist"})
 	assert.Error(t, err)
 }
 
-func TestDeleteNamespace_serviceDoesNotRequireCallerIdentity(t *testing.T) {
+func TestDeleteNamespace_recreatedIdentifierDoesNotDeleteReplacement(t *testing.T) {
 	svc := newTestSvc(t, &mockGitWriter{})
 	input := model.CreateNamespaceInput{Identifier: "auth-test-ns", Tier: model.NamespaceTierUser}
-	_, err := svc.CreateNamespace(context.Background(), input, "alice")
+	authorized, err := svc.CreateNamespace(context.Background(), input, "alice")
+	require.NoError(t, err)
+	require.NoError(t, svc.Store().DeleteNamespace(context.Background(), authorized.ID))
+	replacement, err := svc.CreateNamespace(context.Background(), input, "mallory")
 	require.NoError(t, err)
 
-	err = svc.DeleteNamespace(context.Background(), "auth-test-ns")
+	err = svc.DeleteNamespace(context.Background(), authorized)
+	require.Error(t, err)
+
+	got, err := svc.GetNamespaceByIdentifier(context.Background(), input.Identifier)
 	require.NoError(t, err)
+	assert.Equal(t, replacement.ID, got.ID)
 }

--- a/gitstore-api/internal/graph/resolver/namespace_service_test.go
+++ b/gitstore-api/internal/graph/resolver/namespace_service_test.go
@@ -7,12 +7,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gitstore-dev/gitstore/api/internal/auth/provider/allowall"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // ── createNamespace ────────────────────────────────────────────────────────────
@@ -32,14 +30,12 @@ func TestCreateNamespace_userTier_success(t *testing.T) {
 }
 
 func TestCreateNamespace_orgTier_success(t *testing.T) {
-	// Wire an allow-all authz so a non-admin can create ORGANIZATION namespaces
-	// (the authz provider controls this; nil-authz fallback requires isAdmin=true).
-	svc := newTestSvcWithAuthZ(t, &mockGitWriter{}, allowall.New(zap.NewNop()))
+	svc := newTestSvc(t, &mockGitWriter{})
 	input := model.CreateNamespaceInput{
 		Identifier: "acme-engineering",
 		Tier:       model.NamespaceTierOrganization,
 	}
-	ns, err := svc.CreateNamespace(context.Background(), input, "bob", false)
+	ns, err := svc.CreateNamespace(context.Background(), input, "bob", true)
 	require.NoError(t, err)
 	require.NotNil(t, ns)
 	assert.Equal(t, "acme-engineering", ns.Identifier)

--- a/gitstore-api/internal/graph/resolver/repository.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/repository.resolvers.go
@@ -8,7 +8,6 @@ package resolver
 import (
 	"context"
 
-	"github.com/gitstore-dev/gitstore/api/internal/auth"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.uber.org/zap"
@@ -16,10 +15,6 @@ import (
 
 // CreateRepository is the resolver for the createRepository field.
 func (r *mutationResolver) CreateRepository(ctx context.Context, input model.CreateRepositoryInput) (*model.CreateRepositoryPayload, error) {
-	p := auth.PrincipalFromContext(ctx)
-	if p == nil || p.AuthMethod == "none" {
-		return nil, gqlerror.Errorf("authentication required")
-	}
 	namespaceID, err := decodeNodeIDAs(nodeKindNamespace, input.NamespaceID)
 	if err != nil {
 		return nil, err
@@ -49,10 +44,6 @@ func (r *mutationResolver) CreateRepository(ctx context.Context, input model.Cre
 
 // RenameRepository is the resolver for the renameRepository field.
 func (r *mutationResolver) RenameRepository(ctx context.Context, input model.RenameRepositoryInput) (*model.RenameRepositoryPayload, error) {
-	p := auth.PrincipalFromContext(ctx)
-	if p == nil || p.AuthMethod == "none" {
-		return nil, gqlerror.Errorf("authentication required")
-	}
 	repoID, err := decodeNodeIDAs(nodeKindRepository, input.RepositoryID)
 	if err != nil {
 		return nil, err
@@ -77,10 +68,6 @@ func (r *mutationResolver) RenameRepository(ctx context.Context, input model.Ren
 
 // TransferRepository is the resolver for the transferRepository field.
 func (r *mutationResolver) TransferRepository(ctx context.Context, input model.TransferRepositoryInput) (*model.TransferRepositoryPayload, error) {
-	p := auth.PrincipalFromContext(ctx)
-	if p == nil || p.AuthMethod == "none" {
-		return nil, gqlerror.Errorf("authentication required")
-	}
 	repoID, err := decodeNodeIDAs(nodeKindRepository, input.RepositoryID)
 	if err != nil {
 		return nil, err
@@ -109,10 +96,6 @@ func (r *mutationResolver) TransferRepository(ctx context.Context, input model.T
 
 // DeleteRepository is the resolver for the deleteRepository field.
 func (r *mutationResolver) DeleteRepository(ctx context.Context, input model.DeleteRepositoryInput) (*model.DeleteRepositoryPayload, error) {
-	p := auth.PrincipalFromContext(ctx)
-	if p == nil || p.AuthMethod == "none" {
-		return nil, gqlerror.Errorf("authentication required")
-	}
 	repoID, err := decodeNodeIDAs(nodeKindRepository, input.RepositoryID)
 	if err != nil {
 		return nil, err

--- a/gitstore-api/internal/graph/resolver/resolver.go
+++ b/gitstore-api/internal/graph/resolver/resolver.go
@@ -30,7 +30,6 @@ type Resolver struct {
 type ResolverDeps struct {
 	Store       datastore.Datastore
 	GitWriter   GitWriter
-	AuthZ       auth.AuthZProvider
 	Registry    *auth.ProviderRegistry
 	Logger      *zap.Logger
 	Clock       apiruntime.Clock
@@ -42,11 +41,15 @@ func NewResolver(deps ResolverDeps) (*Resolver, error) {
 	if deps.Logger == nil {
 		return nil, errMissingLogger
 	}
+	var authz auth.AuthZProvider
+	if deps.Registry != nil {
+		authz = deps.Registry.AuthZ()
+	}
 	SetConverterLogger(deps.Logger)
 	svc, err := NewService(ServiceDeps{
 		Store:       deps.Store,
 		GitWriter:   deps.GitWriter,
-		AuthZ:       deps.AuthZ,
+		AuthZ:       authz,
 		Logger:      deps.Logger,
 		Clock:       deps.Clock,
 		IDGenerator: deps.IDGenerator,

--- a/gitstore-api/internal/graph/resolver/resolver.go
+++ b/gitstore-api/internal/graph/resolver/resolver.go
@@ -41,15 +41,10 @@ func NewResolver(deps ResolverDeps) (*Resolver, error) {
 	if deps.Logger == nil {
 		return nil, errMissingLogger
 	}
-	var authz auth.AuthZProvider
-	if deps.Registry != nil {
-		authz = deps.Registry.AuthZ()
-	}
 	SetConverterLogger(deps.Logger)
 	svc, err := NewService(ServiceDeps{
 		Store:       deps.Store,
 		GitWriter:   deps.GitWriter,
-		AuthZ:       authz,
 		Logger:      deps.Logger,
 		Clock:       deps.Clock,
 		IDGenerator: deps.IDGenerator,

--- a/gitstore-api/internal/graph/resolver/service.go
+++ b/gitstore-api/internal/graph/resolver/service.go
@@ -13,7 +13,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/gitstore-dev/gitstore/api/internal/auth"
 	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
@@ -41,7 +40,6 @@ var reservedIdentifiers = map[string]struct{}{
 type Service struct {
 	store     datastore.Datastore
 	gitWriter GitWriter
-	authz     auth.AuthZProvider
 	logger    *zap.Logger
 	clock     apiruntime.Clock
 	ids       apiruntime.IDGenerator
@@ -61,7 +59,6 @@ type GitWriter interface {
 type ServiceDeps struct {
 	Store       datastore.Datastore
 	GitWriter   GitWriter
-	AuthZ       auth.AuthZProvider
 	Logger      *zap.Logger
 	Clock       apiruntime.Clock
 	IDGenerator apiruntime.IDGenerator
@@ -86,7 +83,6 @@ func NewService(deps ServiceDeps) (*Service, error) {
 	return &Service{
 		store:     deps.Store,
 		gitWriter: deps.GitWriter,
-		authz:     deps.AuthZ,
 		logger:    deps.Logger,
 		clock:     clock,
 		ids:       ids,
@@ -244,23 +240,9 @@ func (s *Service) CreateNamespace(ctx context.Context, input model.CreateNamespa
 	}
 	tier := datastoreNamespaceTierFromModel(input.Tier)
 
-	// ORGANIZATION namespaces require explicit authorization.
+	// ORGANIZATION namespaces require admin role.
 	if tier == datastore.NamespaceTierOrganization {
-		principal := auth.PrincipalFromContext(ctx)
-		if principal == nil {
-			principal = auth.Anonymous()
-		}
-		if s.authz != nil {
-			decision, err := s.authz.Authorize(ctx, principal, "namespace.create.organization",
-				auth.ResourceContext{Kind: "namespace", Attrs: map[string]any{"tier": string(tier)}})
-			if err != nil {
-				return nil, gqlerror.Errorf("authorization error")
-			}
-			if decision.Outcome == auth.OutcomeDeny {
-				return nil, gqlerror.Errorf("permission denied: %s", decision.Reason)
-			}
-		} else if !isAdmin {
-			// Fallback when no authz provider is wired (tests using nil Service.authz).
+		if !isAdmin {
 			return nil, gqlerror.Errorf("permission denied: only admins can create ORGANIZATION namespaces")
 		}
 	}
@@ -342,25 +324,7 @@ func (s *Service) DeleteNamespace(ctx context.Context, identifier string, caller
 
 	// Determine whether this is own-namespace or any-namespace deletion.
 	isOwner := ns.CreatedBy == callerUsername
-	action := "namespace.delete.any"
-	if isOwner {
-		action = "namespace.delete.own"
-	}
-	principal := auth.PrincipalFromContext(ctx)
-	if principal == nil {
-		principal = auth.Anonymous()
-	}
-	if s.authz != nil {
-		decision, err := s.authz.Authorize(ctx, principal, action,
-			auth.ResourceContext{Kind: "namespace", Name: identifier, OwnerSub: ns.CreatedBy})
-		if err != nil {
-			return gqlerror.Errorf("authorization error")
-		}
-		if decision.Outcome == auth.OutcomeDeny {
-			return gqlerror.Errorf("permission denied: %s", decision.Reason)
-		}
-	} else if !isOwner && !isAdmin {
-		// Fallback for tests using nil authz.
+	if !isOwner && !isAdmin {
 		return gqlerror.Errorf("permission denied: only the namespace owner or an admin may delete this namespace")
 	}
 

--- a/gitstore-api/internal/graph/resolver/service.go
+++ b/gitstore-api/internal/graph/resolver/service.go
@@ -308,26 +308,22 @@ func (s *Service) ListNamespaces(ctx context.Context, params datastore.PageParam
 
 // DeleteNamespace deletes a namespace after safety checks.
 // Authorization is enforced in GraphQL middleware before this method is called.
-func (s *Service) DeleteNamespace(ctx context.Context, identifier string) error {
-	ns, err := s.store.GetNamespaceByIdentifier(ctx, identifier)
-	if err != nil {
-		if errors.Is(err, datastore.ErrNotFound) {
-			return gqlerror.Errorf("namespace %q not found", identifier)
-		}
-		return gqlerror.Errorf("failed to retrieve namespace")
+func (s *Service) DeleteNamespace(ctx context.Context, ns *datastore.Namespace) error {
+	if ns == nil || ns.ID == "" {
+		return gqlerror.Errorf("namespace deletion target is missing")
 	}
 
 	// TODO: enforce when repositories table exists
 	if hasRepositories(ns.ID) {
-		return gqlerror.Errorf("namespace %q contains repositories and cannot be deleted", identifier)
+		return gqlerror.Errorf("namespace %q contains repositories and cannot be deleted", ns.Identifier)
 	}
 
 	if err := s.store.DeleteNamespace(ctx, ns.ID); err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
-			return gqlerror.Errorf("namespace %q not found", identifier)
+			return gqlerror.Errorf("namespace %q not found", ns.Identifier)
 		}
 		s.logger.Error("failed to delete namespace",
-			zap.String("identifier", identifier),
+			zap.String("identifier", ns.Identifier),
 			zap.Error(err),
 		)
 		return gqlerror.Errorf("failed to delete namespace")

--- a/gitstore-api/internal/graph/resolver/service.go
+++ b/gitstore-api/internal/graph/resolver/service.go
@@ -225,7 +225,8 @@ func (s *Service) UpdateCollection(ctx context.Context, uid string, input map[st
 // ── Namespace ─────────────────────────────────────────────────────────────────
 
 // CreateNamespace validates and creates a new namespace.
-func (s *Service) CreateNamespace(ctx context.Context, input model.CreateNamespaceInput, callerUsername string, isAdmin bool) (*datastore.Namespace, error) {
+// Authorization is enforced in GraphQL middleware before this method is called.
+func (s *Service) CreateNamespace(ctx context.Context, input model.CreateNamespaceInput, callerUsername string) (*datastore.Namespace, error) {
 	identifier := strings.ToLower(strings.TrimSpace(input.Identifier))
 
 	if !identifierRegex.MatchString(identifier) {
@@ -239,13 +240,6 @@ func (s *Service) CreateNamespace(ctx context.Context, input model.CreateNamespa
 		return nil, gqlerror.Errorf("invalid namespace tier %q: must be USER or ORGANIZATION; enterprise and other tier values are not supported", input.Tier)
 	}
 	tier := datastoreNamespaceTierFromModel(input.Tier)
-
-	// ORGANIZATION namespaces require admin role.
-	if tier == datastore.NamespaceTierOrganization {
-		if !isAdmin {
-			return nil, gqlerror.Errorf("permission denied: only admins can create ORGANIZATION namespaces")
-		}
-	}
 
 	now := s.clock.Now()
 	var displayName string
@@ -312,20 +306,15 @@ func (s *Service) ListNamespaces(ctx context.Context, params datastore.PageParam
 	return result, nil
 }
 
-// DeleteNamespace deletes a namespace after authorisation and safety checks.
-func (s *Service) DeleteNamespace(ctx context.Context, identifier string, callerUsername string, isAdmin bool) error {
+// DeleteNamespace deletes a namespace after safety checks.
+// Authorization is enforced in GraphQL middleware before this method is called.
+func (s *Service) DeleteNamespace(ctx context.Context, identifier string) error {
 	ns, err := s.store.GetNamespaceByIdentifier(ctx, identifier)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			return gqlerror.Errorf("namespace %q not found", identifier)
 		}
 		return gqlerror.Errorf("failed to retrieve namespace")
-	}
-
-	// Determine whether this is own-namespace or any-namespace deletion.
-	isOwner := ns.CreatedBy == callerUsername
-	if !isOwner && !isAdmin {
-		return gqlerror.Errorf("permission denied: only the namespace owner or an admin may delete this namespace")
 	}
 
 	// TODO: enforce when repositories table exists

--- a/gitstore-api/internal/graph/resolver/service_constructor_test.go
+++ b/gitstore-api/internal/graph/resolver/service_constructor_test.go
@@ -65,7 +65,7 @@ func TestServiceCreateNamespaceAndRepositoryUsesInjectedClockAndIDs(t *testing.T
 	ns, err := svc.CreateNamespace(ctx, model.CreateNamespaceInput{
 		Identifier: "acme",
 		Tier:       model.NamespaceTierUser,
-	}, "admin", true)
+	}, "admin")
 	require.NoError(t, err)
 	assert.Equal(t, namespaceID, ns.ID)
 	assert.Equal(t, now, ns.CreatedAt)

--- a/gitstore-api/internal/graph/resolver/service_mutations_test.go
+++ b/gitstore-api/internal/graph/resolver/service_mutations_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/gitstore-dev/gitstore/api/internal/auth"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore/memdb"
 	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
@@ -81,18 +80,11 @@ func (m *mockGitWriter) CreateTag(_ context.Context, p gitclient.CreateTagParams
 // newTestSvc builds a Service backed by an in-memory datastore.
 func newTestSvc(t *testing.T, writer *mockGitWriter) *resolver.Service {
 	t.Helper()
-	return newTestSvcWithAuthZ(t, writer, nil)
-}
-
-// newTestSvcWithAuthZ builds a Service with an explicit AuthZ provider.
-func newTestSvcWithAuthZ(t *testing.T, writer *mockGitWriter, authz auth.AuthZProvider) *resolver.Service {
-	t.Helper()
 	store, err := memdb.New()
 	require.NoError(t, err)
 	svc, err := resolver.NewService(resolver.ServiceDeps{
 		Store:     store,
 		GitWriter: writer,
-		AuthZ:     authz,
 		Logger:    zap.NewNop(),
 	})
 	require.NoError(t, err)

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package security
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/gitstore-dev/gitstore/api/internal/auth"
+	"github.com/vektah/gqlparser/v2/ast"
+	"go.uber.org/zap"
+)
+
+type remoteAddrContextKey struct{}
+
+// ContextWithRemoteAddr stores the caller IP/remote address so GraphQL auth
+// middleware can pass it to providers without depending on Gin internals.
+func ContextWithRemoteAddr(ctx context.Context, remoteAddr string) context.Context {
+	return context.WithValue(ctx, remoteAddrContextKey{}, remoteAddr)
+}
+
+func remoteAddrFromContext(ctx context.Context) string {
+	remoteAddr, _ := ctx.Value(remoteAddrContextKey{}).(string)
+	return remoteAddr
+}
+
+// GraphQLAuthenticator authenticates each GraphQL operation via the active
+// authn chain and injects the resulting Principal into operation context.
+func (a *Authenticate) GraphQLAuthenticator(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
+	if a.logger == nil {
+		a.logger = zap.NewNop()
+	}
+	if a.registry == nil || a.registry.AuthN() == nil {
+		return graphql.OneShot(graphql.ErrorResponse(ctx, "authentication service unavailable"))
+	}
+
+	opCtx := graphql.GetOperationContext(ctx)
+	if opCtx == nil {
+		return graphql.OneShot(graphql.ErrorResponse(ctx, "invalid graphql operation context"))
+	}
+
+	req := auth.AuthRequest{
+		Header:     opCtx.Headers,
+		RemoteAddr: remoteAddrFromContext(ctx),
+	}
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+
+	authCtx := ctx
+	if authHeader := req.Header.Get("Authorization"); strings.HasPrefix(authHeader, "Bearer ") {
+		authCtx = auth.ContextWithRawToken(authCtx, strings.TrimPrefix(authHeader, "Bearer "))
+	}
+
+	principal, decision, err := a.registry.AuthN().Authenticate(authCtx, req)
+	if err != nil {
+		a.logger.Warn("graphql auth chain error", zap.Error(err))
+		return graphql.OneShot(graphql.ErrorResponse(ctx, "invalid or expired credentials"))
+	}
+	if decision.Outcome != auth.OutcomeAllow {
+		return graphql.OneShot(graphql.ErrorResponse(ctx, "invalid or expired credentials"))
+	}
+	if principal == nil {
+		principal = auth.Anonymous()
+	}
+
+	return next(auth.ContextWithPrincipal(authCtx, principal))
+}
+
+// GraphQLAuthorizer enforces cross-cutting GraphQL authz guardrails and
+// provides a centralized middleware seam for future operation-level policies.
+func (a *Authorize) GraphQLAuthorizer(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
+	if a.logger == nil {
+		a.logger = zap.NewNop()
+	}
+
+	opCtx := graphql.GetOperationContext(ctx)
+	if opCtx == nil {
+		return graphql.OneShot(graphql.ErrorResponse(ctx, "invalid graphql operation context"))
+	}
+
+	principal := auth.PrincipalFromContext(ctx)
+	if principal == nil {
+		principal = auth.Anonymous()
+		ctx = auth.ContextWithPrincipal(ctx, principal)
+	}
+
+	if requiresAuthenticatedPrincipal(opCtx.Operation) && principal.AuthMethod == "none" {
+		return graphql.OneShot(graphql.ErrorResponse(ctx, "authentication required"))
+	}
+
+	return next(ctx)
+}
+
+func requiresAuthenticatedPrincipal(op *ast.OperationDefinition) bool {
+	if op == nil || op.Operation != ast.Mutation {
+		return false
+	}
+	return firstOperationFieldName(op) != "login"
+}
+
+func firstOperationFieldName(op *ast.OperationDefinition) string {
+	if op == nil {
+		return ""
+	}
+	for _, selection := range op.SelectionSet {
+		if field, ok := selection.(*ast.Field); ok {
+			return field.Name
+		}
+	}
+	return ""
+}

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -101,7 +101,7 @@ func (a *Authorize) GraphQLAuthorizer(ctx context.Context, next graphql.Operatio
 		ctx = auth.ContextWithPrincipal(ctx, principal)
 	}
 
-	if requiresAuthenticatedPrincipal(opCtx.Operation, opCtx.Doc) && principal.AuthMethod == "none" {
+	if requiresAuthenticatedPrincipal(opCtx) && principal.AuthMethod == "none" {
 		return graphql.OneShot(graphql.ErrorResponse(ctx, "authentication required"))
 	}
 
@@ -235,44 +235,18 @@ func nestedStringArg(args map[string]any, parent, key string) (string, bool) {
 	return field.String(), true
 }
 
-func requiresAuthenticatedPrincipal(op *ast.OperationDefinition, doc *ast.QueryDocument) bool {
-	if op == nil || op.Operation != ast.Mutation {
+// requiresAuthenticatedPrincipal reports whether the operation executes any
+// root mutation field other than "login"/"__typename". It delegates to
+// graphql.CollectFields — the same field-collection gqlgen itself uses to
+// decide what will actually run — so fragment spreads, inline fragments, and
+// @skip/@include directives are honored instead of re-derived by hand.
+func requiresAuthenticatedPrincipal(opCtx *graphql.OperationContext) bool {
+	if opCtx == nil || opCtx.Operation == nil || opCtx.Operation.Operation != ast.Mutation {
 		return false
 	}
-	var fragments ast.FragmentDefinitionList
-	if doc != nil {
-		fragments = doc.Fragments
-	}
-	return selectionSetRequiresAuthentication(op.SelectionSet, fragments, make(map[string]bool))
-}
-
-func selectionSetRequiresAuthentication(selections ast.SelectionSet, fragments ast.FragmentDefinitionList, visiting map[string]bool) bool {
-	for _, selection := range selections {
-		switch selection := selection.(type) {
-		case *ast.Field:
-			if selection.Name != "login" && selection.Name != "__typename" {
-				return true
-			}
-		case *ast.InlineFragment:
-			if selectionSetRequiresAuthentication(selection.SelectionSet, fragments, visiting) {
-				return true
-			}
-		case *ast.FragmentSpread:
-			definition := selection.Definition
-			if definition == nil {
-				definition = fragments.ForName(selection.Name)
-			}
-			// Validated documents always resolve fragment spreads. Fail closed if
-			// an incomplete or cyclic AST reaches this security boundary.
-			if definition == nil || visiting[definition.Name] {
-				return true
-			}
-			visiting[definition.Name] = true
-			requiresAuth := selectionSetRequiresAuthentication(definition.SelectionSet, fragments, visiting)
-			delete(visiting, definition.Name)
-			if requiresAuth {
-				return true
-			}
+	for _, field := range graphql.CollectFields(opCtx, opCtx.Operation.SelectionSet, []string{"Mutation"}) {
+		if field.Name != "login" && field.Name != "__typename" {
+			return true
 		}
 	}
 	return false

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -20,6 +20,7 @@ import (
 )
 
 type remoteAddrContextKey struct{}
+type authorizedNamespaceDeleteContextKey struct{}
 
 // ContextWithRemoteAddr stores the caller IP/remote address so GraphQL auth
 // middleware can pass it to providers without depending on Gin internals.
@@ -30,6 +31,13 @@ func ContextWithRemoteAddr(ctx context.Context, remoteAddr string) context.Conte
 func remoteAddrFromContext(ctx context.Context) string {
 	remoteAddr, _ := ctx.Value(remoteAddrContextKey{}).(string)
 	return remoteAddr
+}
+
+// AuthorizedNamespaceForDeletion returns the exact namespace record whose
+// deletion was authorized by GraphQLFieldAuthorizer.
+func AuthorizedNamespaceForDeletion(ctx context.Context) (*datastore.Namespace, bool) {
+	ns, ok := ctx.Value(authorizedNamespaceDeleteContextKey{}).(*datastore.Namespace)
+	return ns, ok && ns != nil
 }
 
 // GraphQLAuthenticator authenticates each GraphQL operation via the active
@@ -93,7 +101,7 @@ func (a *Authorize) GraphQLAuthorizer(ctx context.Context, next graphql.Operatio
 		ctx = auth.ContextWithPrincipal(ctx, principal)
 	}
 
-	if requiresAuthenticatedPrincipal(opCtx.Operation) && principal.AuthMethod == "none" {
+	if requiresAuthenticatedPrincipal(opCtx.Operation, opCtx.Doc) && principal.AuthMethod == "none" {
 		return graphql.OneShot(graphql.ErrorResponse(ctx, "authentication required"))
 	}
 
@@ -143,11 +151,10 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 		if !ok || identifier == "" {
 			return next(ctx)
 		}
-		action, ownerSub, err := a.namespaceDeleteAction(ctx, identifier, principal)
+		ns, action, err := a.namespaceDeleteAction(ctx, identifier, principal)
 		if err != nil {
 			if errors.Is(err, datastore.ErrNotFound) {
-				// Preserve existing resolver/service behavior for unknown namespaces.
-				return next(ctx)
+				return nil, gqlerror.Errorf("namespace %q not found", identifier)
 			}
 			return nil, gqlerror.Errorf("authorization error")
 		}
@@ -155,7 +162,7 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 		decision, err := authz.Authorize(ctx, principal, action, auth.ResourceContext{
 			Kind:     "namespace",
 			Name:     identifier,
-			OwnerSub: ownerSub,
+			OwnerSub: ns.CreatedBy,
 		})
 		if err != nil {
 			return nil, gqlerror.Errorf("authorization error")
@@ -163,6 +170,7 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 		if decision.Outcome == auth.OutcomeDeny {
 			return nil, gqlerror.Errorf("permission denied: %s", decision.Reason)
 		}
+		ctx = context.WithValue(ctx, authorizedNamespaceDeleteContextKey{}, ns)
 	case "refreshToken":
 		if auth.RawTokenFromContext(ctx) == "" {
 			return nil, gqlerror.Errorf("refresh token requires bearer authentication")
@@ -172,19 +180,18 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 	return next(ctx)
 }
 
-func (a *Authorize) namespaceDeleteAction(ctx context.Context, identifier string, principal *auth.Principal) (action string, ownerSub string, err error) {
+func (a *Authorize) namespaceDeleteAction(ctx context.Context, identifier string, principal *auth.Principal) (ns *datastore.Namespace, action string, err error) {
 	if a.store == nil {
-		return "", "", fmt.Errorf("authorization store is not configured")
+		return nil, "", fmt.Errorf("authorization store is not configured")
 	}
-	ns, err := a.store.GetNamespaceByIdentifier(ctx, identifier)
+	ns, err = a.store.GetNamespaceByIdentifier(ctx, identifier)
 	if err != nil {
-		return "", "", err
+		return nil, "", err
 	}
-	ownerSub = ns.CreatedBy
-	if ownerSub == principal.Subject {
-		return "namespace.delete.own", ownerSub, nil
+	if ns.CreatedBy == principal.Subject {
+		return ns, "namespace.delete.own", nil
 	}
-	return "namespace.delete.any", ownerSub, nil
+	return ns, "namespace.delete.any", nil
 }
 
 func nestedStringArg(args map[string]any, parent, key string) (string, bool) {
@@ -227,17 +234,44 @@ func nestedStringArg(args map[string]any, parent, key string) (string, bool) {
 	return field.String(), true
 }
 
-func requiresAuthenticatedPrincipal(op *ast.OperationDefinition) bool {
+func requiresAuthenticatedPrincipal(op *ast.OperationDefinition, doc *ast.QueryDocument) bool {
 	if op == nil || op.Operation != ast.Mutation {
 		return false
 	}
-	for _, selection := range op.SelectionSet {
-		field, ok := selection.(*ast.Field)
-		if !ok {
-			continue
-		}
-		if field.Name != "login" {
-			return true
+	var fragments ast.FragmentDefinitionList
+	if doc != nil {
+		fragments = doc.Fragments
+	}
+	return selectionSetRequiresAuthentication(op.SelectionSet, fragments, make(map[string]bool))
+}
+
+func selectionSetRequiresAuthentication(selections ast.SelectionSet, fragments ast.FragmentDefinitionList, visiting map[string]bool) bool {
+	for _, selection := range selections {
+		switch selection := selection.(type) {
+		case *ast.Field:
+			if selection.Name != "login" {
+				return true
+			}
+		case *ast.InlineFragment:
+			if selectionSetRequiresAuthentication(selection.SelectionSet, fragments, visiting) {
+				return true
+			}
+		case *ast.FragmentSpread:
+			definition := selection.Definition
+			if definition == nil {
+				definition = fragments.ForName(selection.Name)
+			}
+			// Validated documents always resolve fragment spreads. Fail closed if
+			// an incomplete or cyclic AST reaches this security boundary.
+			if definition == nil || visiting[definition.Name] {
+				return true
+			}
+			visiting[definition.Name] = true
+			requiresAuth := selectionSetRequiresAuthentication(definition.SelectionSet, fragments, visiting)
+			delete(visiting, definition.Name)
+			if requiresAuth {
+				return true
+			}
 		}
 	}
 	return false

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -123,9 +123,9 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 	if principal == nil {
 		principal = auth.Anonymous()
 	}
-	authz := a.registry.AuthZ()
-	if authz == nil {
-		return next(ctx)
+	var authz auth.AuthZProvider
+	if a.registry != nil {
+		authz = a.registry.AuthZ()
 	}
 
 	switch fc.Field.Name {
@@ -133,6 +133,9 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 		tier, ok := nestedStringArg(fc.Args, "input", "tier")
 		if !ok || tier != "ORGANIZATION" {
 			return next(ctx)
+		}
+		if authz == nil {
+			return nil, gqlerror.Errorf("authorization service unavailable")
 		}
 		decision, err := authz.Authorize(ctx, principal, "namespace.create.organization", auth.ResourceContext{
 			Kind: "namespace",
@@ -150,6 +153,9 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 		identifier, ok := nestedStringArg(fc.Args, "input", "identifier")
 		if !ok || identifier == "" {
 			return next(ctx)
+		}
+		if authz == nil {
+			return nil, gqlerror.Errorf("authorization service unavailable")
 		}
 		ns, action, err := a.namespaceDeleteAction(ctx, identifier, principal)
 		if err != nil {
@@ -249,7 +255,7 @@ func selectionSetRequiresAuthentication(selections ast.SelectionSet, fragments a
 	for _, selection := range selections {
 		switch selection := selection.(type) {
 		case *ast.Field:
-			if selection.Name != "login" {
+			if selection.Name != "login" && selection.Name != "__typename" {
 				return true
 			}
 		case *ast.InlineFragment:

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -200,20 +200,15 @@ func (a *Authorize) namespaceDeleteAction(ctx context.Context, identifier string
 	return ns, "namespace.delete.any", nil
 }
 
+// nestedStringArg reads a string field off a gqlgen-generated input struct
+// (e.g. args["input"].tier). gqlgen always unmarshals GraphQL input objects
+// into their generated struct type before FieldContext.Args is populated, so
+// only the struct-based representation is handled here.
 func nestedStringArg(args map[string]any, parent, key string) (string, bool) {
 	parentVal, ok := args[parent]
 	if !ok || parentVal == nil {
 		return "", false
 	}
-	// map-based argument representation
-	if m, ok := parentVal.(map[string]any); ok {
-		v, ok := m[key]
-		if !ok || v == nil {
-			return "", false
-		}
-		return fmt.Sprint(v), true
-	}
-	// struct-based argument representation (gqlgen generated input types)
 	rv := reflect.ValueOf(parentVal)
 	if rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -5,12 +5,17 @@ package security
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/gitstore-dev/gitstore/api/internal/auth"
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.uber.org/zap"
 )
 
@@ -95,21 +100,145 @@ func (a *Authorize) GraphQLAuthorizer(ctx context.Context, next graphql.Operatio
 	return next(ctx)
 }
 
+// GraphQLFieldAuthorizer runs fine-grained GraphQL authorization checks for
+// mutation fields that require policy evaluation against resource context.
+func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Resolver) (any, error) {
+	if a.logger == nil {
+		a.logger = zap.NewNop()
+	}
+	fc := graphql.GetFieldContext(ctx)
+	if fc == nil || fc.Object != "Mutation" {
+		return next(ctx)
+	}
+
+	principal := auth.PrincipalFromContext(ctx)
+	if principal == nil {
+		principal = auth.Anonymous()
+	}
+	authz := a.registry.AuthZ()
+	if authz == nil {
+		return next(ctx)
+	}
+
+	switch fc.Field.Name {
+	case "createNamespace":
+		tier, ok := nestedStringArg(fc.Args, "input", "tier")
+		if !ok || tier != "ORGANIZATION" {
+			return next(ctx)
+		}
+		decision, err := authz.Authorize(ctx, principal, "namespace.create.organization", auth.ResourceContext{
+			Kind: "namespace",
+			Attrs: map[string]any{
+				"tier": tier,
+			},
+		})
+		if err != nil {
+			return nil, gqlerror.Errorf("authorization error")
+		}
+		if decision.Outcome == auth.OutcomeDeny {
+			return nil, gqlerror.Errorf("permission denied: %s", decision.Reason)
+		}
+	case "deleteNamespace":
+		identifier, ok := nestedStringArg(fc.Args, "input", "identifier")
+		if !ok || identifier == "" {
+			return next(ctx)
+		}
+		action, ownerSub, err := a.namespaceDeleteAction(ctx, identifier, principal)
+		if err != nil {
+			if errors.Is(err, datastore.ErrNotFound) {
+				// Preserve existing resolver/service behavior for unknown namespaces.
+				return next(ctx)
+			}
+			return nil, gqlerror.Errorf("authorization error")
+		}
+
+		decision, err := authz.Authorize(ctx, principal, action, auth.ResourceContext{
+			Kind:     "namespace",
+			Name:     identifier,
+			OwnerSub: ownerSub,
+		})
+		if err != nil {
+			return nil, gqlerror.Errorf("authorization error")
+		}
+		if decision.Outcome == auth.OutcomeDeny {
+			return nil, gqlerror.Errorf("permission denied: %s", decision.Reason)
+		}
+	case "refreshToken":
+		if auth.RawTokenFromContext(ctx) == "" {
+			return nil, gqlerror.Errorf("refresh token requires bearer authentication")
+		}
+	}
+
+	return next(ctx)
+}
+
+func (a *Authorize) namespaceDeleteAction(ctx context.Context, identifier string, principal *auth.Principal) (action string, ownerSub string, err error) {
+	if a.store == nil {
+		return "", "", fmt.Errorf("authorization store is not configured")
+	}
+	ns, err := a.store.GetNamespaceByIdentifier(ctx, identifier)
+	if err != nil {
+		return "", "", err
+	}
+	ownerSub = ns.CreatedBy
+	if ownerSub == principal.Subject {
+		return "namespace.delete.own", ownerSub, nil
+	}
+	return "namespace.delete.any", ownerSub, nil
+}
+
+func nestedStringArg(args map[string]any, parent, key string) (string, bool) {
+	parentVal, ok := args[parent]
+	if !ok || parentVal == nil {
+		return "", false
+	}
+	// map-based argument representation
+	if m, ok := parentVal.(map[string]any); ok {
+		v, ok := m[key]
+		if !ok || v == nil {
+			return "", false
+		}
+		return fmt.Sprint(v), true
+	}
+	// struct-based argument representation (gqlgen generated input types)
+	rv := reflect.ValueOf(parentVal)
+	if rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return "", false
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return "", false
+	}
+	field := rv.FieldByNameFunc(func(name string) bool { return strings.EqualFold(name, key) })
+	if !field.IsValid() {
+		return "", false
+	}
+	for field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return "", false
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return "", false
+	}
+	return field.String(), true
+}
+
 func requiresAuthenticatedPrincipal(op *ast.OperationDefinition) bool {
 	if op == nil || op.Operation != ast.Mutation {
 		return false
 	}
-	return firstOperationFieldName(op) != "login"
-}
-
-func firstOperationFieldName(op *ast.OperationDefinition) string {
-	if op == nil {
-		return ""
-	}
 	for _, selection := range op.SelectionSet {
-		if field, ok := selection.(*ast.Field); ok {
-			return field.Name
+		field, ok := selection.(*ast.Field)
+		if !ok {
+			continue
+		}
+		if field.Name != "login" {
+			return true
 		}
 	}
-	return ""
+	return false
 }

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -177,10 +177,6 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 			return nil, gqlerror.Errorf("permission denied: %s", decision.Reason)
 		}
 		ctx = context.WithValue(ctx, authorizedNamespaceDeleteContextKey{}, ns)
-	case "refreshToken":
-		if auth.RawTokenFromContext(ctx) == "" {
-			return nil, gqlerror.Errorf("refresh token requires bearer authentication")
-		}
 	}
 
 	return next(ctx)
@@ -236,7 +232,8 @@ func nestedStringArg(args map[string]any, parent, key string) (string, bool) {
 }
 
 // requiresAuthenticatedPrincipal reports whether the operation executes any
-// root mutation field other than "login"/"__typename". It delegates to
+// root mutation field other than "login", "refreshToken", or "__typename".
+// It delegates to
 // graphql.CollectFields — the same field-collection gqlgen itself uses to
 // decide what will actually run — so fragment spreads, inline fragments, and
 // @skip/@include directives are honored instead of re-derived by hand.
@@ -245,7 +242,7 @@ func requiresAuthenticatedPrincipal(opCtx *graphql.OperationContext) bool {
 		return false
 	}
 	for _, field := range graphql.CollectFields(opCtx, opCtx.Operation.SelectionSet, []string{"Mutation"}) {
-		if field.Name != "login" && field.Name != "__typename" {
+		if field.Name != "login" && field.Name != "refreshToken" && field.Name != "__typename" {
 			return true
 		}
 	}

--- a/gitstore-api/internal/middleware/security/graphql_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_test.go
@@ -131,6 +131,35 @@ func TestGraphQLAuthorizerAllowsLoginMutationForAnonymous(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestGraphQLAuthorizerAllowsRefreshTokenMutationForAnonymous(t *testing.T) {
+	registry, _ := newTestRegistry(t)
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{Name: "refreshToken"},
+			},
+		},
+	}
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+
+	authn := NewAuthenticate(registry, zap.NewNop())
+	authz := NewAuthorize(registry, zap.NewNop())
+	called := false
+	final := func(context.Context) graphql.ResponseHandler {
+		called = true
+		return graphql.OneShot(&graphql.Response{Data: []byte(`{"ok":true}`)})
+	}
+
+	resp := authn.GraphQLAuthenticator(ctx, func(inner context.Context) graphql.ResponseHandler {
+		return authz.GraphQLAuthorizer(inner, final)
+	})(ctx)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Errors)
+	assert.True(t, called)
+}
+
 func TestGraphQLAuthorizerAllowsLoginMutationWithRootTypenameForAnonymous(t *testing.T) {
 	registry, _ := newTestRegistry(t)
 	opCtx := &graphql.OperationContext{

--- a/gitstore-api/internal/middleware/security/graphql_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package security
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/gitstore-dev/gitstore/api/internal/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
+	"go.uber.org/zap"
+)
+
+func TestGraphQLAuthenticatorValidBearerInjectsPrincipal(t *testing.T) {
+	registry, staticAdmin := newTestRegistry(t)
+	token, _, err := staticAdmin.IssueSession(t.Context(), "admin")
+	require.NoError(t, err)
+
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{"Authorization": []string{"Bearer " + token}},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Query,
+		},
+	}
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+	ctx = ContextWithRemoteAddr(ctx, "127.0.0.1")
+
+	authMiddleware := NewAuthenticate(registry, zap.NewNop())
+	var principal *auth.Principal
+	next := func(nextCtx context.Context) graphql.ResponseHandler {
+		principal = auth.PrincipalFromContext(nextCtx)
+		return graphql.OneShot(&graphql.Response{Data: []byte(`{"ok":true}`)})
+	}
+
+	resp := authMiddleware.GraphQLAuthenticator(ctx, next)(ctx)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Errors)
+	require.NotNil(t, principal)
+	assert.Equal(t, "admin", principal.Subject)
+	assert.Equal(t, "static-admin", principal.AuthMethod)
+}
+
+func TestGraphQLAuthenticatorInvalidBearerReturnsGraphQLError(t *testing.T) {
+	registry, _ := newTestRegistry(t)
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{"Authorization": []string{"Bearer invalid-token"}},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Query,
+		},
+	}
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+
+	authMiddleware := NewAuthenticate(registry, zap.NewNop())
+	called := false
+	next := func(context.Context) graphql.ResponseHandler {
+		called = true
+		return graphql.OneShot(&graphql.Response{Data: []byte(`{"ok":true}`)})
+	}
+
+	resp := authMiddleware.GraphQLAuthenticator(ctx, next)(ctx)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Errors)
+	assert.False(t, called)
+	assert.Contains(t, resp.Errors[0].Message, "invalid or expired credentials")
+}
+
+func TestGraphQLAuthorizerRequiresAuthForNonLoginMutation(t *testing.T) {
+	registry, _ := newTestRegistry(t)
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{Name: "createNamespace"},
+			},
+		},
+	}
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+
+	authn := NewAuthenticate(registry, zap.NewNop())
+	authz := NewAuthorize(registry, zap.NewNop())
+	called := false
+	final := func(context.Context) graphql.ResponseHandler {
+		called = true
+		return graphql.OneShot(&graphql.Response{Data: []byte(`{"ok":true}`)})
+	}
+
+	resp := authn.GraphQLAuthenticator(ctx, func(inner context.Context) graphql.ResponseHandler {
+		return authz.GraphQLAuthorizer(inner, final)
+	})(ctx)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Errors)
+	assert.False(t, called)
+	assert.Contains(t, resp.Errors[0].Message, "authentication required")
+}
+
+func TestGraphQLAuthorizerAllowsLoginMutationForAnonymous(t *testing.T) {
+	registry, _ := newTestRegistry(t)
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{Name: "login"},
+			},
+		},
+	}
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+
+	authn := NewAuthenticate(registry, zap.NewNop())
+	authz := NewAuthorize(registry, zap.NewNop())
+	called := false
+	final := func(context.Context) graphql.ResponseHandler {
+		called = true
+		return graphql.OneShot(&graphql.Response{Data: []byte(`{"ok":true}`)})
+	}
+
+	resp := authn.GraphQLAuthenticator(ctx, func(inner context.Context) graphql.ResponseHandler {
+		return authz.GraphQLAuthorizer(inner, final)
+	})(ctx)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Errors)
+	assert.True(t, called)
+}

--- a/gitstore-api/internal/middleware/security/graphql_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_test.go
@@ -204,6 +204,127 @@ func TestGraphQLAuthorizerRequiresAuthForMutationInInlineFragment(t *testing.T) 
 	assertAnonymousOperationRejected(t, opCtx)
 }
 
+func TestGraphQLAuthorizerAllowsLoginViaFragmentSpreadForAnonymous(t *testing.T) {
+	fragment := &ast.FragmentDefinition{
+		Name:          "Login",
+		TypeCondition: "Mutation",
+		SelectionSet: ast.SelectionSet{
+			&ast.Field{Name: "login"},
+		},
+	}
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{},
+		Doc: &ast.QueryDocument{
+			Fragments: ast.FragmentDefinitionList{fragment},
+		},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.FragmentSpread{Name: fragment.Name},
+			},
+		},
+	}
+
+	registry, _ := newTestRegistry(t)
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+	authn := NewAuthenticate(registry, zap.NewNop())
+	authz := NewAuthorize(registry, zap.NewNop())
+	called := false
+	final := func(context.Context) graphql.ResponseHandler {
+		called = true
+		return graphql.OneShot(&graphql.Response{Data: []byte(`{"ok":true}`)})
+	}
+
+	resp := authn.GraphQLAuthenticator(ctx, func(inner context.Context) graphql.ResponseHandler {
+		return authz.GraphQLAuthorizer(inner, final)
+	})(ctx)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Errors)
+	assert.True(t, called)
+}
+
+func TestGraphQLAuthorizerRequiresAuthForSecondRootFieldAfterLogin(t *testing.T) {
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{Name: "login"},
+				&ast.Field{Name: "createNamespace"},
+			},
+		},
+	}
+
+	assertAnonymousOperationRejected(t, opCtx)
+}
+
+func TestGraphQLAuthorizerHonorsSkipDirectiveOnMutationField(t *testing.T) {
+	opCtx := &graphql.OperationContext{
+		Headers:   http.Header{},
+		Variables: map[string]any{"skipCreate": true},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{Name: "login"},
+				&ast.Field{
+					Name: "createNamespace",
+					Directives: ast.DirectiveList{
+						&ast.Directive{
+							Name: "skip",
+							Arguments: ast.ArgumentList{
+								{Name: "if", Value: &ast.Value{Kind: ast.Variable, Raw: "skipCreate"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	registry, _ := newTestRegistry(t)
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+	authn := NewAuthenticate(registry, zap.NewNop())
+	authz := NewAuthorize(registry, zap.NewNop())
+	called := false
+	final := func(context.Context) graphql.ResponseHandler {
+		called = true
+		return graphql.OneShot(&graphql.Response{Data: []byte(`{"ok":true}`)})
+	}
+
+	resp := authn.GraphQLAuthenticator(ctx, func(inner context.Context) graphql.ResponseHandler {
+		return authz.GraphQLAuthorizer(inner, final)
+	})(ctx)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Errors)
+	assert.True(t, called)
+}
+
+func TestGraphQLAuthorizerRequiresAuthWhenSkipConditionFalse(t *testing.T) {
+	opCtx := &graphql.OperationContext{
+		Headers:   http.Header{},
+		Variables: map[string]any{"skipCreate": false},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{Name: "login"},
+				&ast.Field{
+					Name: "createNamespace",
+					Directives: ast.DirectiveList{
+						&ast.Directive{
+							Name: "skip",
+							Arguments: ast.ArgumentList{
+								{Name: "if", Value: &ast.Value{Kind: ast.Variable, Raw: "skipCreate"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assertAnonymousOperationRejected(t, opCtx)
+}
+
 func assertAnonymousOperationRejected(t *testing.T, opCtx *graphql.OperationContext) {
 	t.Helper()
 	registry, _ := newTestRegistry(t)

--- a/gitstore-api/internal/middleware/security/graphql_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_test.go
@@ -131,6 +131,36 @@ func TestGraphQLAuthorizerAllowsLoginMutationForAnonymous(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestGraphQLAuthorizerAllowsLoginMutationWithRootTypenameForAnonymous(t *testing.T) {
+	registry, _ := newTestRegistry(t)
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{Name: "login"},
+				&ast.Field{Name: "__typename"},
+			},
+		},
+	}
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+
+	authn := NewAuthenticate(registry, zap.NewNop())
+	authz := NewAuthorize(registry, zap.NewNop())
+	called := false
+	final := func(context.Context) graphql.ResponseHandler {
+		called = true
+		return graphql.OneShot(&graphql.Response{Data: []byte(`{"ok":true}`)})
+	}
+
+	resp := authn.GraphQLAuthenticator(ctx, func(inner context.Context) graphql.ResponseHandler {
+		return authz.GraphQLAuthorizer(inner, final)
+	})(ctx)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Errors)
+	assert.True(t, called)
+}
+
 func TestGraphQLAuthorizerRequiresAuthForMutationInNamedFragment(t *testing.T) {
 	fragment := &ast.FragmentDefinition{
 		Name:          "MutationFields",
@@ -232,6 +262,31 @@ func TestGraphQLFieldAuthorizerCreateNamespaceOrganizationUsesPolicy(t *testing.
 	require.NoError(t, err)
 	assert.True(t, called)
 	assert.Equal(t, "namespace.create.organization", authz.action)
+}
+
+func TestGraphQLFieldAuthorizerCreateNamespaceOrganizationFailsWithoutAuthZ(t *testing.T) {
+	registry := auth.NewProviderRegistry(nil, nil, nil)
+	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "bob", AuthMethod: "static-admin"})
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Mutation",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "createNamespace"}},
+		Args: map[string]any{
+			"input": model.CreateNamespaceInput{
+				Identifier: "acme",
+				Tier:       model.NamespaceTierOrganization,
+			},
+		},
+	})
+
+	called := false
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) {
+		called = true
+		return "ok", nil
+	})
+	require.Error(t, err)
+	assert.False(t, called)
+	assert.Contains(t, err.Error(), "authorization service unavailable")
 }
 
 func TestGraphQLFieldAuthorizerDeleteNamespaceDenyFromPolicy(t *testing.T) {

--- a/gitstore-api/internal/middleware/security/graphql_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_test.go
@@ -131,6 +131,70 @@ func TestGraphQLAuthorizerAllowsLoginMutationForAnonymous(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestGraphQLAuthorizerRequiresAuthForMutationInNamedFragment(t *testing.T) {
+	fragment := &ast.FragmentDefinition{
+		Name:          "MutationFields",
+		TypeCondition: "Mutation",
+		SelectionSet: ast.SelectionSet{
+			&ast.Field{Name: "createRepository"},
+		},
+	}
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{},
+		Doc: &ast.QueryDocument{
+			Fragments: ast.FragmentDefinitionList{fragment},
+		},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.FragmentSpread{Name: fragment.Name},
+			},
+		},
+	}
+
+	assertAnonymousOperationRejected(t, opCtx)
+}
+
+func TestGraphQLAuthorizerRequiresAuthForMutationInInlineFragment(t *testing.T) {
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.InlineFragment{
+					TypeCondition: "Mutation",
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{Name: "createRepository"},
+					},
+				},
+			},
+		},
+	}
+
+	assertAnonymousOperationRejected(t, opCtx)
+}
+
+func assertAnonymousOperationRejected(t *testing.T, opCtx *graphql.OperationContext) {
+	t.Helper()
+	registry, _ := newTestRegistry(t)
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+	authn := NewAuthenticate(registry, zap.NewNop())
+	authz := NewAuthorize(registry, zap.NewNop())
+	called := false
+	final := func(context.Context) graphql.ResponseHandler {
+		called = true
+		return graphql.OneShot(&graphql.Response{Data: []byte(`{"ok":true}`)})
+	}
+
+	resp := authn.GraphQLAuthenticator(ctx, func(inner context.Context) graphql.ResponseHandler {
+		return authz.GraphQLAuthorizer(inner, final)
+	})(ctx)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Errors)
+	assert.False(t, called)
+	assert.Contains(t, resp.Errors[0].Message, "authentication required")
+}
+
 type stubAuthZProvider struct {
 	decision auth.Decision
 	err      error
@@ -197,4 +261,33 @@ func TestGraphQLFieldAuthorizerDeleteNamespaceDenyFromPolicy(t *testing.T) {
 	assert.False(t, called)
 	assert.Contains(t, err.Error(), "permission denied")
 	assert.Equal(t, "namespace.delete.any", authz.action)
+}
+
+func TestGraphQLFieldAuthorizerDeleteNamespacePassesAuthorizedRecord(t *testing.T) {
+	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	registry := auth.NewProviderRegistry(nil, authz, nil)
+	authorized := &datastore.Namespace{ID: "namespace-id", Identifier: "acme", CreatedBy: "alice"}
+	store := &testutil.StubStore{
+		GetNamespaceByIdentifierFunc: func(_ context.Context, _ string) (*datastore.Namespace, error) {
+			return authorized, nil
+		},
+	}
+	mw := NewAuthorizeWithStore(registry, store, zap.NewNop())
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "alice", AuthMethod: "static-admin"})
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Mutation",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "deleteNamespace"}},
+		Args: map[string]any{
+			"input": model.DeleteNamespaceInput{Identifier: "acme"},
+		},
+	})
+
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(nextCtx context.Context) (any, error) {
+		got, ok := AuthorizedNamespaceForDeletion(nextCtx)
+		require.True(t, ok)
+		assert.Same(t, authorized, got)
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "namespace.delete.own", authz.action)
 }

--- a/gitstore-api/internal/middleware/security/graphql_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/gitstore-dev/gitstore/api/internal/auth"
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
+	"github.com/gitstore-dev/gitstore/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -126,4 +129,72 @@ func TestGraphQLAuthorizerAllowsLoginMutationForAnonymous(t *testing.T) {
 	require.NotNil(t, resp)
 	require.Nil(t, resp.Errors)
 	assert.True(t, called)
+}
+
+type stubAuthZProvider struct {
+	decision auth.Decision
+	err      error
+	action   string
+}
+
+func (s *stubAuthZProvider) Name() string { return "stub-authz" }
+func (s *stubAuthZProvider) Authorize(_ context.Context, _ *auth.Principal, action string, _ auth.ResourceContext) (auth.Decision, error) {
+	s.action = action
+	return s.decision, s.err
+}
+
+func TestGraphQLFieldAuthorizerCreateNamespaceOrganizationUsesPolicy(t *testing.T) {
+	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	registry := auth.NewProviderRegistry(nil, authz, nil)
+
+	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "bob", AuthMethod: "static-admin", Roles: []string{"developer"}})
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Mutation",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "createNamespace"}},
+		Args: map[string]any{
+			"input": model.CreateNamespaceInput{
+				Identifier: "acme",
+				Tier:       model.NamespaceTierOrganization,
+			},
+		},
+	})
+
+	called := false
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) {
+		called = true
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "namespace.create.organization", authz.action)
+}
+
+func TestGraphQLFieldAuthorizerDeleteNamespaceDenyFromPolicy(t *testing.T) {
+	authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "no access")}
+	registry := auth.NewProviderRegistry(nil, authz, nil)
+	store := &testutil.StubStore{
+		GetNamespaceByIdentifierFunc: func(_ context.Context, identifier string) (*datastore.Namespace, error) {
+			return &datastore.Namespace{Identifier: identifier, CreatedBy: "alice"}, nil
+		},
+	}
+	mw := NewAuthorizeWithStore(registry, store, zap.NewNop())
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "bob", AuthMethod: "static-admin"})
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Mutation",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "deleteNamespace"}},
+		Args: map[string]any{
+			"input": model.DeleteNamespaceInput{Identifier: "acme"},
+		},
+	})
+
+	called := false
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) {
+		called = true
+		return "ok", nil
+	})
+	require.Error(t, err)
+	assert.False(t, called)
+	assert.Contains(t, err.Error(), "permission denied")
+	assert.Equal(t, "namespace.delete.any", authz.action)
 }

--- a/gitstore-api/internal/middleware/security/secure.go
+++ b/gitstore-api/internal/middleware/security/secure.go
@@ -222,11 +222,6 @@ func (a *Authenticate) BasicAuthenticator(c *gin.Context) {
 	a.authenticator(c, basicAuth)
 }
 
-// Authorizer authorizes a GraphQL request.
-func (a *Authorize) Authorizer(c *gin.Context) {
-	c.Next()
-}
-
 // repoIDKey matches the constant defined in githttp/resolver.go.
 // Duplicated here to avoid an import cycle; both must be kept in sync.
 const repoIDKey = "repoID"

--- a/gitstore-api/internal/middleware/security/secure.go
+++ b/gitstore-api/internal/middleware/security/secure.go
@@ -36,6 +36,7 @@ type Authorize struct {
 // datastoreGetter is the minimal datastore interface needed by the security middleware.
 type datastoreGetter interface {
 	GetRepository(ctx context.Context, id string) (*datastore.Repository, error)
+	GetNamespaceByIdentifier(ctx context.Context, identifier string) (*datastore.Namespace, error)
 }
 
 type RateLimit struct {

--- a/gitstore-api/internal/middleware/security/secure.go
+++ b/gitstore-api/internal/middleware/security/secure.go
@@ -223,7 +223,7 @@ func (a *Authenticate) BasicAuthenticator(c *gin.Context) {
 
 // Authorizer authorizes a GraphQL request.
 func (a *Authorize) Authorizer(c *gin.Context) {
-	// Implement GraphQL Authorizer middleware
+	c.Next()
 }
 
 // repoIDKey matches the constant defined in githttp/resolver.go.

--- a/shared/schemas/auth.graphqls
+++ b/shared/schemas/auth.graphqls
@@ -15,24 +15,34 @@ type User {
   isAdmin: Boolean!
 }
 
-"""
-Authentication session response
-"""
-type AuthSession {
-  """
-  JWT token for authentication
-  """
-  token: String!
+"""OIDC-compatible token response."""
+type TokenResponse {
+  """Access token used for authenticated API calls."""
+  accessToken: String!
+
+  """Token type. Always `Bearer` for GitStore-issued tokens."""
+  tokenType: String!
+
+  """Seconds until the access token expires."""
+  expiresIn: Int!
 
   """
-  Token expiration time (ISO 8601)
+  Refresh token used to obtain a new access token.
+  For local providers, this is currently a GitStore-issued token.
   """
-  expiresAt: DateTime!
+  refreshToken: String
 
   """
-  Authenticated user information
+  Granted scope set as a space-delimited string.
+  Scope requests are currently unsupported and this field is null.
   """
-  user: User!
+  scope: String
+
+  """
+  OIDC ID token when available.
+  GitStore local providers currently do not issue this field.
+  """
+  idToken: String
 }
 
 """
@@ -48,6 +58,12 @@ input LoginInput {
   Password
   """
   password: String!
+
+  """
+  Optional OAuth2 scope request.
+  Scope requests are currently unsupported by local providers.
+  """
+  scope: String
 }
 
 """
@@ -55,9 +71,9 @@ Login mutation payload (Relay pattern)
 """
 type LoginPayload {
   """
-  Authentication session (token + user info)
+  OIDC-compatible token payload.
   """
-  session: AuthSession
+  token: TokenResponse!
 }
 
 """
@@ -86,10 +102,15 @@ Refresh token mutation input (Relay pattern)
 """
 input RefreshTokenInput {
   """
-  TODO: Is it safe to remove and empty Input?
-  Client mutation ID for request tracking (Relay pattern)
+  Refresh token used to issue a new access token.
   """
-  clientMutationId: String
+  refreshToken: String!
+
+  """
+  Optional OAuth2 scope request.
+  Scope requests are currently unsupported by local providers.
+  """
+  scope: String
 }
 
 """
@@ -97,9 +118,9 @@ Refresh token mutation payload (Relay pattern)
 """
 type RefreshTokenPayload {
   """
-  New authentication session
+  OIDC-compatible token payload.
   """
-  session: AuthSession
+  token: TokenResponse!
 }
 
 # Add authentication mutations to the Mutation type


### PR DESCRIPTION
## Summary

Refactor GraphQL authentication and authorization to run through gqlgen middleware so security is centralized at the GraphQL operation layer and remains pluggable through the existing provider registry.

## What changed

- Added GraphQL middleware in `gitstore-api/internal/middleware/security/graphql.go`:
  - `GraphQLAuthenticator` authenticates each operation via `ProviderRegistry.AuthN()`
  - `GraphQLAuthorizer` enforces authenticated principal for non-`login` mutations
  - request remote address is passed via context for auth request metadata
- Updated `gitstore-api/internal/app/server.go`:
  - registers gqlgen `AroundOperations` middleware hooks for auth/authz
  - removes Gin route-level GraphQL authenticator to avoid duplicate auth layers
- Replaced GraphQL authz stub in `gitstore-api/internal/middleware/security/secure.go` with concrete pass-through behavior.
- Added tests:
  - `gitstore-api/internal/middleware/security/graphql_test.go`
  - invalid bearer mutation path test in `gitstore-api/cmd/server/main_test.go`
- Updated rollout documentation in `docs/implementation/pluggable_auth_architecture.md` to mark GraphQL middleware centralization complete.

## Validation

- `go test ./internal/middleware/security ./cmd/server` (from `gitstore-api`)
