### PR TITLE
feat(api): align login/refresh payloads with OIDC token response

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,20 +21,23 @@ Public read access depends on resolver and deployment policy. Protected mutation
 Authorization: Bearer <token>
 ```
 
-First-party login is GraphQL-only via the `login(input:)` mutation.
+GitStore delegates OAuth2/OIDC federation to external identity providers. The GraphQL `login`
+mutation is a local-provider convenience (for example `static-admin`) and returns an OIDC-style
+token payload. External providers such as `oidc-jwt` are expected to authenticate out-of-band and
+present a token to GitStore for verification.
 
 Login:
 
 ```graphql
 mutation Login {
   login(input: { username: "admin", password: "<password>" }) {
-    session {
-      token
-      expiresAt
-      user {
-        username
-        isAdmin
-      }
+    token {
+      accessToken
+      tokenType
+      expiresIn
+      refreshToken
+      scope
+      idToken
     }
   }
 }
@@ -44,10 +47,14 @@ Refresh:
 
 ```graphql
 mutation RefreshToken {
-  refreshToken(input: {}) {
-    session {
-      token
-      expiresAt
+  refreshToken(input: { refreshToken: "<refresh-token>" }) {
+    token {
+      accessToken
+      tokenType
+      expiresIn
+      refreshToken
+      scope
+      idToken
     }
   }
 }
@@ -62,6 +69,8 @@ mutation Logout {
   }
 }
 ```
+
+`scope` requests are currently unsupported for local providers; send no scope to avoid a validation error.
 
 ## Operation Summary
 
@@ -89,9 +98,9 @@ mutation Logout {
 
 | Operation | Purpose |
 |---|---|
-| `login(input: LoginInput!)` | Create a JWT session |
+| `login(input: LoginInput!)` | Create an OIDC-style token response for local providers |
 | `logout(input: LogoutInput!)` | End the current session |
-| `refreshToken(input: RefreshTokenInput!)` | Refresh a JWT session |
+| `refreshToken(input: RefreshTokenInput!)` | Exchange a refresh token for a new OIDC-style token response |
 | `createNamespace(input: CreateNamespaceInput!)` | Create a namespace |
 | `deleteNamespace(input: DeleteNamespaceInput!)` | Delete an empty namespace |
 | `createRepository(input: CreateRepositoryInput!)` | Create a repository in a namespace |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -376,24 +376,40 @@ curl -s http://localhost:4000/graphql \
 
 Use GraphQL mutations for authentication, namespaces, and repositories. The Make bootstrap targets wrap these calls for the common local workflow.
 
-First-party login is GraphQL-only via the `login(input:)` mutation.
+GitStore delegates OAuth2/OIDC federation to external identity providers. The GraphQL
+`login(input:)` mutation is a convenience flow for local providers (for example `static-admin`).
 
 Login:
 
 ```graphql
 mutation Login {
   login(input: { username: "admin", password: "<password>" }) {
-    session {
-      token
-      expiresAt
-      user {
-        username
-        isAdmin
-      }
+    token {
+      accessToken
+      tokenType
+      expiresIn
+      refreshToken
     }
   }
 }
 ```
+
+Refresh:
+
+```graphql
+mutation RefreshToken {
+  refreshToken(input: { refreshToken: "<refresh-token>" }) {
+    token {
+      accessToken
+      tokenType
+      expiresIn
+      refreshToken
+    }
+  }
+}
+```
+
+`scope` requests are currently unsupported by local providers.
 
 Create a namespace and repository manually when you need custom provisioning. See [API Reference](api-reference.md#mutation-operations) for the exact inputs.
 

--- a/gitstore-api/internal/graph/generated/auth.generated.go
+++ b/gitstore-api/internal/graph/generated/auth.generated.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"strconv"
 	"sync/atomic"
-	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
@@ -29,160 +28,36 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _AuthSession_token(ctx context.Context, field graphql.CollectedField, obj *model.AuthSession) (ret graphql.Marshaler) {
+func (ec *executionContext) _LoginPayload_token(ctx context.Context, field graphql.CollectedField, obj *model.LoginPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_AuthSession_token(ctx, field)
+			return ec.fieldContext_LoginPayload_token(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
 			return obj.Token, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
-			return ec.marshalNString2string(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *model.TokenResponse) graphql.Marshaler {
+			return ec.marshalNTokenResponse2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐTokenResponse(ctx, selections, v)
 		},
 		true,
 		true,
 	)
 }
-func (ec *executionContext) fieldContext_AuthSession_token(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("AuthSession", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
-func (ec *executionContext) _AuthSession_expiresAt(ctx context.Context, field graphql.CollectedField, obj *model.AuthSession) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_AuthSession_expiresAt(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ExpiresAt, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v time.Time) graphql.Marshaler {
-			return ec.marshalNDateTime2timeᚐTime(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_AuthSession_expiresAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("AuthSession", field, false, false, errors.New("field of type DateTime does not have child fields"))
-}
-
-func (ec *executionContext) _AuthSession_user(ctx context.Context, field graphql.CollectedField, obj *model.AuthSession) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_AuthSession_user(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.User, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *model.User) graphql.Marshaler {
-			return ec.marshalNUser2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐUser(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_AuthSession_user(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "AuthSession",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_User(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _LoginPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.LoginPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_LoginPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_LoginPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("LoginPayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
-func (ec *executionContext) _LoginPayload_session(ctx context.Context, field graphql.CollectedField, obj *model.LoginPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_LoginPayload_session(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.Session, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *model.AuthSession) graphql.Marshaler {
-			return ec.marshalOAuthSession2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐAuthSession(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_LoginPayload_session(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_LoginPayload_token(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "LoginPayload",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_AuthSession(ctx, field)
+			return ec.childFields_TokenResponse(ctx, field)
 		},
 	}
 	return fc, nil
-}
-
-func (ec *executionContext) _LogoutPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.LogoutPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_LogoutPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_LogoutPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("LogoutPayload", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _LogoutPayload_success(ctx context.Context, field graphql.CollectedField, obj *model.LogoutPayload) (ret graphql.Marshaler) {
@@ -208,16 +83,117 @@ func (ec *executionContext) fieldContext_LogoutPayload_success(_ context.Context
 	return graphql.NewScalarFieldContext("LogoutPayload", field, false, false, errors.New("field of type Boolean does not have child fields"))
 }
 
-func (ec *executionContext) _RefreshTokenPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.RefreshTokenPayload) (ret graphql.Marshaler) {
+func (ec *executionContext) _RefreshTokenPayload_token(ctx context.Context, field graphql.CollectedField, obj *model.RefreshTokenPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_RefreshTokenPayload_clientMutationId(ctx, field)
+			return ec.fieldContext_RefreshTokenPayload_token(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
+			return obj.Token, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.TokenResponse) graphql.Marshaler {
+			return ec.marshalNTokenResponse2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐTokenResponse(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_RefreshTokenPayload_token(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RefreshTokenPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_TokenResponse(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TokenResponse_accessToken(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenResponse_accessToken(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.AccessToken, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TokenResponse_accessToken(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _TokenResponse_tokenType(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenResponse_tokenType(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.TokenType, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TokenResponse_tokenType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _TokenResponse_expiresIn(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenResponse_expiresIn(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ExpiresIn, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int32) graphql.Marshaler {
+			return ec.marshalNInt2int32(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TokenResponse_expiresIn(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TokenResponse_refreshToken(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenResponse_refreshToken(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.RefreshToken, nil
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
@@ -227,40 +203,54 @@ func (ec *executionContext) _RefreshTokenPayload_clientMutationId(ctx context.Co
 		false,
 	)
 }
-func (ec *executionContext) fieldContext_RefreshTokenPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("RefreshTokenPayload", field, false, false, errors.New("field of type String does not have child fields"))
+func (ec *executionContext) fieldContext_TokenResponse_refreshToken(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _RefreshTokenPayload_session(ctx context.Context, field graphql.CollectedField, obj *model.RefreshTokenPayload) (ret graphql.Marshaler) {
+func (ec *executionContext) _TokenResponse_scope(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_RefreshTokenPayload_session(ctx, field)
+			return ec.fieldContext_TokenResponse_scope(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.Session, nil
+			return obj.Scope, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *model.AuthSession) graphql.Marshaler {
-			return ec.marshalOAuthSession2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐAuthSession(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
 		},
 		true,
 		false,
 	)
 }
-func (ec *executionContext) fieldContext_RefreshTokenPayload_session(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "RefreshTokenPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_AuthSession(ctx, field)
+func (ec *executionContext) fieldContext_TokenResponse_scope(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _TokenResponse_idToken(ctx context.Context, field graphql.CollectedField, obj *model.TokenResponse) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenResponse_idToken(ctx, field)
 		},
-	}
-	return fc, nil
+		func(ctx context.Context) (any, error) {
+			return obj.IDToken, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_TokenResponse_idToken(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenResponse", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _User_username(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
@@ -324,20 +314,13 @@ func (ec *executionContext) unmarshalInputLoginInput(ctx context.Context, obj an
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "username", "password"}
+	fieldsInOrder := [...]string{"username", "password", "scope"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "username":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("username"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -352,6 +335,13 @@ func (ec *executionContext) unmarshalInputLoginInput(ctx context.Context, obj an
 				return it, err
 			}
 			it.Password = data
+		case "scope":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scope"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Scope = data
 		}
 	}
 	return it, nil
@@ -398,20 +388,27 @@ func (ec *executionContext) unmarshalInputRefreshTokenInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId"}
+	fieldsInOrder := [...]string{"refreshToken", "scope"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
+		case "refreshToken":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("refreshToken"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RefreshToken = data
+		case "scope":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scope"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.ClientMutationID = data
+			it.Scope = data
 		}
 	}
 	return it, nil
@@ -425,55 +422,6 @@ func (ec *executionContext) unmarshalInputRefreshTokenInput(ctx context.Context,
 
 // region    **************************** object.gotpl ****************************
 
-var authSessionImplementors = []string{"AuthSession"}
-
-func (ec *executionContext) _AuthSession(ctx context.Context, sel ast.SelectionSet, obj *model.AuthSession) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, authSessionImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	deferred := make(map[string]*graphql.FieldSet)
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("AuthSession")
-		case "token":
-			out.Values[i] = ec._AuthSession_token(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "expiresAt":
-			out.Values[i] = ec._AuthSession_expiresAt(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "user":
-			out.Values[i] = ec._AuthSession_user(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch(ctx)
-	if out.Invalids > 0 {
-		return graphql.Null
-	}
-
-	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
-
-	for label, dfs := range deferred {
-		ec.ProcessDeferredGroup(graphql.DeferredGroup{
-			Label:    label,
-			Path:     graphql.GetPath(ctx),
-			FieldSet: dfs,
-			Context:  ctx,
-		})
-	}
-
-	return out
-}
-
 var loginPayloadImplementors = []string{"LoginPayload"}
 
 func (ec *executionContext) _LoginPayload(ctx context.Context, sel ast.SelectionSet, obj *model.LoginPayload) graphql.Marshaler {
@@ -485,10 +433,11 @@ func (ec *executionContext) _LoginPayload(ctx context.Context, sel ast.Selection
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("LoginPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._LoginPayload_clientMutationId(ctx, field, obj)
-		case "session":
-			out.Values[i] = ec._LoginPayload_session(ctx, field, obj)
+		case "token":
+			out.Values[i] = ec._LoginPayload_token(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -523,8 +472,6 @@ func (ec *executionContext) _LogoutPayload(ctx context.Context, sel ast.Selectio
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("LogoutPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._LogoutPayload_clientMutationId(ctx, field, obj)
 		case "success":
 			out.Values[i] = ec._LogoutPayload_success(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -564,10 +511,66 @@ func (ec *executionContext) _RefreshTokenPayload(ctx context.Context, sel ast.Se
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("RefreshTokenPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._RefreshTokenPayload_clientMutationId(ctx, field, obj)
-		case "session":
-			out.Values[i] = ec._RefreshTokenPayload_session(ctx, field, obj)
+		case "token":
+			out.Values[i] = ec._RefreshTokenPayload_token(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var tokenResponseImplementors = []string{"TokenResponse"}
+
+func (ec *executionContext) _TokenResponse(ctx context.Context, sel ast.SelectionSet, obj *model.TokenResponse) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tokenResponseImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TokenResponse")
+		case "accessToken":
+			out.Values[i] = ec._TokenResponse_accessToken(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "tokenType":
+			out.Values[i] = ec._TokenResponse_tokenType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "expiresIn":
+			out.Values[i] = ec._TokenResponse_expiresIn(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "refreshToken":
+			out.Values[i] = ec._TokenResponse_refreshToken(ctx, field, obj)
+		case "scope":
+			out.Values[i] = ec._TokenResponse_scope(ctx, field, obj)
+		case "idToken":
+			out.Values[i] = ec._TokenResponse_idToken(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -696,21 +699,14 @@ func (ec *executionContext) marshalNRefreshTokenPayload2ᚖgithubᚗcomᚋgitsto
 	return ec._RefreshTokenPayload(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v *model.User) graphql.Marshaler {
+func (ec *executionContext) marshalNTokenResponse2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐTokenResponse(ctx context.Context, sel ast.SelectionSet, v *model.TokenResponse) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
 		}
 		return graphql.Null
 	}
-	return ec._User(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOAuthSession2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐAuthSession(ctx context.Context, sel ast.SelectionSet, v *model.AuthSession) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._AuthSession(ctx, sel, v)
+	return ec._TokenResponse(ctx, sel, v)
 }
 
 // endregion ***************************** type.gotpl *****************************

--- a/gitstore-api/internal/graph/generated/root_.generated.go
+++ b/gitstore-api/internal/graph/generated/root_.generated.go
@@ -33,12 +33,6 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
-	AuthSession struct {
-		ExpiresAt func(childComplexity int) int
-		Token     func(childComplexity int) int
-		User      func(childComplexity int) int
-	}
-
 	CatalogObjectReference struct {
 		APIVersion      func(childComplexity int) int
 		FieldPath       func(childComplexity int) int
@@ -264,13 +258,11 @@ type ComplexityRoot struct {
 	}
 
 	LoginPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Session          func(childComplexity int) int
+		Token func(childComplexity int) int
 	}
 
 	LogoutPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Success          func(childComplexity int) int
+		Success func(childComplexity int) int
 	}
 
 	MediaDefinition struct {
@@ -518,8 +510,7 @@ type ComplexityRoot struct {
 	}
 
 	RefreshTokenPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Session          func(childComplexity int) int
+		Token func(childComplexity int) int
 	}
 
 	RenameRepositoryPayload struct {
@@ -624,6 +615,15 @@ type ComplexityRoot struct {
 		Type func(childComplexity int) int
 	}
 
+	TokenResponse struct {
+		AccessToken  func(childComplexity int) int
+		ExpiresIn    func(childComplexity int) int
+		IDToken      func(childComplexity int) int
+		RefreshToken func(childComplexity int) int
+		Scope        func(childComplexity int) int
+		TokenType    func(childComplexity int) int
+	}
+
 	TransferRepositoryPayload struct {
 		ClientMutationID func(childComplexity int) int
 		Repository       func(childComplexity int) int
@@ -665,27 +665,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	ec := newExecutionContext(nil, e, nil)
 	_ = ec
 	switch typeName + "." + field {
-
-	case "AuthSession.expiresAt":
-		if e.ComplexityRoot.AuthSession.ExpiresAt == nil {
-			break
-		}
-
-		return e.ComplexityRoot.AuthSession.ExpiresAt(childComplexity), true
-
-	case "AuthSession.token":
-		if e.ComplexityRoot.AuthSession.Token == nil {
-			break
-		}
-
-		return e.ComplexityRoot.AuthSession.Token(childComplexity), true
-
-	case "AuthSession.user":
-		if e.ComplexityRoot.AuthSession.User == nil {
-			break
-		}
-
-		return e.ComplexityRoot.AuthSession.User(childComplexity), true
 
 	case "CatalogObjectReference.apiVersion":
 		if e.ComplexityRoot.CatalogObjectReference.APIVersion == nil {
@@ -1572,26 +1551,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.LabelSelectorRequirement.Values(childComplexity), true
 
-	case "LoginPayload.clientMutationId":
-		if e.ComplexityRoot.LoginPayload.ClientMutationID == nil {
+	case "LoginPayload.token":
+		if e.ComplexityRoot.LoginPayload.Token == nil {
 			break
 		}
 
-		return e.ComplexityRoot.LoginPayload.ClientMutationID(childComplexity), true
-
-	case "LoginPayload.session":
-		if e.ComplexityRoot.LoginPayload.Session == nil {
-			break
-		}
-
-		return e.ComplexityRoot.LoginPayload.Session(childComplexity), true
-
-	case "LogoutPayload.clientMutationId":
-		if e.ComplexityRoot.LogoutPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.LogoutPayload.ClientMutationID(childComplexity), true
+		return e.ComplexityRoot.LoginPayload.Token(childComplexity), true
 
 	case "LogoutPayload.success":
 		if e.ComplexityRoot.LogoutPayload.Success == nil {
@@ -2838,19 +2803,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Query.Repository(childComplexity, args["by"].(model.RepositoryBy)), true
 
-	case "RefreshTokenPayload.clientMutationId":
-		if e.ComplexityRoot.RefreshTokenPayload.ClientMutationID == nil {
+	case "RefreshTokenPayload.token":
+		if e.ComplexityRoot.RefreshTokenPayload.Token == nil {
 			break
 		}
 
-		return e.ComplexityRoot.RefreshTokenPayload.ClientMutationID(childComplexity), true
-
-	case "RefreshTokenPayload.session":
-		if e.ComplexityRoot.RefreshTokenPayload.Session == nil {
-			break
-		}
-
-		return e.ComplexityRoot.RefreshTokenPayload.Session(childComplexity), true
+		return e.ComplexityRoot.RefreshTokenPayload.Token(childComplexity), true
 
 	case "RenameRepositoryPayload.clientMutationId":
 		if e.ComplexityRoot.RenameRepositoryPayload.ClientMutationID == nil {
@@ -3230,6 +3188,48 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.StrategyDefinition.Type(childComplexity), true
 
+	case "TokenResponse.accessToken":
+		if e.ComplexityRoot.TokenResponse.AccessToken == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.AccessToken(childComplexity), true
+
+	case "TokenResponse.expiresIn":
+		if e.ComplexityRoot.TokenResponse.ExpiresIn == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.ExpiresIn(childComplexity), true
+
+	case "TokenResponse.idToken":
+		if e.ComplexityRoot.TokenResponse.IDToken == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.IDToken(childComplexity), true
+
+	case "TokenResponse.refreshToken":
+		if e.ComplexityRoot.TokenResponse.RefreshToken == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.RefreshToken(childComplexity), true
+
+	case "TokenResponse.scope":
+		if e.ComplexityRoot.TokenResponse.Scope == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.Scope(childComplexity), true
+
+	case "TokenResponse.tokenType":
+		if e.ComplexityRoot.TokenResponse.TokenType == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenResponse.TokenType(childComplexity), true
+
 	case "TransferRepositoryPayload.clientMutationId":
 		if e.ComplexityRoot.TransferRepositoryPayload.ClientMutationID == nil {
 			break
@@ -3442,35 +3442,40 @@ type User {
   isAdmin: Boolean!
 }
 
-"""
-Authentication session response
-"""
-type AuthSession {
-  """
-  JWT token for authentication
-  """
-  token: String!
+"""OIDC-compatible token response."""
+type TokenResponse {
+  """Access token used for authenticated API calls."""
+  accessToken: String!
+
+  """Token type. Always ` + "`" + `Bearer` + "`" + ` for GitStore-issued tokens."""
+  tokenType: String!
+
+  """Seconds until the access token expires."""
+  expiresIn: Int!
 
   """
-  Token expiration time (ISO 8601)
+  Refresh token used to obtain a new access token.
+  For local providers, this is currently a GitStore-issued token.
   """
-  expiresAt: DateTime!
+  refreshToken: String
 
   """
-  Authenticated user information
+  Granted scope set as a space-delimited string.
+  Scope requests are currently unsupported and this field is null.
   """
-  user: User!
+  scope: String
+
+  """
+  OIDC ID token when available.
+  GitStore local providers currently do not issue this field.
+  """
+  idToken: String
 }
 
 """
 Login mutation input (Relay pattern)
 """
 input LoginInput {
-  """
-  Client mutation ID for request tracking (Relay pattern)
-  """
-  clientMutationId: String
-
   """
   Username
   """
@@ -3480,6 +3485,12 @@ input LoginInput {
   Password
   """
   password: String!
+
+  """
+  Optional OAuth2 scope request.
+  Scope requests are currently unsupported by local providers.
+  """
+  scope: String
 }
 
 """
@@ -3487,14 +3498,9 @@ Login mutation payload (Relay pattern)
 """
 type LoginPayload {
   """
-  Client mutation ID for request tracking (Relay pattern)
+  OIDC-compatible token payload.
   """
-  clientMutationId: String
-
-  """
-  Authentication session (token + user info)
-  """
-  session: AuthSession
+  token: TokenResponse!
 }
 
 """
@@ -3502,6 +3508,7 @@ Logout mutation input (Relay pattern)
 """
 input LogoutInput {
   """
+  TODO: Is it safe to remove and empty Input?
   Client mutation ID for request tracking (Relay pattern)
   """
   clientMutationId: String
@@ -3511,11 +3518,6 @@ input LogoutInput {
 Logout mutation payload (Relay pattern)
 """
 type LogoutPayload {
-  """
-  Client mutation ID for request tracking (Relay pattern)
-  """
-  clientMutationId: String
-
   """
   Success indicator
   """
@@ -3527,9 +3529,15 @@ Refresh token mutation input (Relay pattern)
 """
 input RefreshTokenInput {
   """
-  Client mutation ID for request tracking (Relay pattern)
+  Refresh token used to issue a new access token.
   """
-  clientMutationId: String
+  refreshToken: String!
+
+  """
+  Optional OAuth2 scope request.
+  Scope requests are currently unsupported by local providers.
+  """
+  scope: String
 }
 
 """
@@ -3537,14 +3545,9 @@ Refresh token mutation payload (Relay pattern)
 """
 type RefreshTokenPayload {
   """
-  Client mutation ID for request tracking (Relay pattern)
+  OIDC-compatible token payload.
   """
-  clientMutationId: String
-
-  """
-  New authentication session
-  """
-  session: AuthSession
+  token: TokenResponse!
 }
 
 # Add authentication mutations to the Mutation type
@@ -4471,7 +4474,7 @@ Input for creating a new namespace.
 """
 input CreateNamespaceInput {
   """
-  Client mutation ID for request tracking (Relay pattern).
+  TODO: Remove, deprecated in relay
   """
   clientMutationId: String
 
@@ -4502,7 +4505,7 @@ Input for deleting a namespace.
 """
 input DeleteNamespaceInput {
   """
-  Client mutation ID for request tracking (Relay pattern).
+  TODO: Remove, deprecated in relay
   """
   clientMutationId: String
 
@@ -4519,7 +4522,7 @@ Payload returned after successfully creating a namespace.
 """
 type CreateNamespacePayload {
   """
-  Client mutation ID for request tracking (Relay pattern).
+  TODO: Remove, deprecated in relay
   """
   clientMutationId: String
 
@@ -4534,7 +4537,7 @@ Payload returned after successfully deleting a namespace.
 """
 type DeleteNamespacePayload {
   """
-  Client mutation ID for request tracking (Relay pattern).
+  TODO: Remove, deprecated in relay
   """
   clientMutationId: String
 
@@ -5655,18 +5658,6 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // Each function is generated once per unique object type, deduplicating the
 // switch statements that were previously inlined in every fieldContext_* function.
 
-func (ec *executionContext) childFields_AuthSession(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-	switch field.Name {
-	case "token":
-		return ec.fieldContext_AuthSession_token(ctx, field)
-	case "expiresAt":
-		return ec.fieldContext_AuthSession_expiresAt(ctx, field)
-	case "user":
-		return ec.fieldContext_AuthSession_user(ctx, field)
-	}
-	return nil, fmt.Errorf("no field named %q was found under type AuthSession", field.Name)
-}
-
 func (ec *executionContext) childFields_CatalogObjectReference(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
 	case "apiVersion":
@@ -6117,18 +6108,14 @@ func (ec *executionContext) childFields_LabelSelectorRequirement(ctx context.Con
 
 func (ec *executionContext) childFields_LoginPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_LoginPayload_clientMutationId(ctx, field)
-	case "session":
-		return ec.fieldContext_LoginPayload_session(ctx, field)
+	case "token":
+		return ec.fieldContext_LoginPayload_token(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type LoginPayload", field.Name)
 }
 
 func (ec *executionContext) childFields_LogoutPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_LogoutPayload_clientMutationId(ctx, field)
 	case "success":
 		return ec.fieldContext_LogoutPayload_success(ctx, field)
 	}
@@ -6549,10 +6536,8 @@ func (ec *executionContext) childFields_QuantityDefinition(ctx context.Context, 
 
 func (ec *executionContext) childFields_RefreshTokenPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_RefreshTokenPayload_clientMutationId(ctx, field)
-	case "session":
-		return ec.fieldContext_RefreshTokenPayload_session(ctx, field)
+	case "token":
+		return ec.fieldContext_RefreshTokenPayload_token(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type RefreshTokenPayload", field.Name)
 }
@@ -6761,6 +6746,24 @@ func (ec *executionContext) childFields_StrategyDefinition(ctx context.Context, 
 	return nil, fmt.Errorf("no field named %q was found under type StrategyDefinition", field.Name)
 }
 
+func (ec *executionContext) childFields_TokenResponse(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "accessToken":
+		return ec.fieldContext_TokenResponse_accessToken(ctx, field)
+	case "tokenType":
+		return ec.fieldContext_TokenResponse_tokenType(ctx, field)
+	case "expiresIn":
+		return ec.fieldContext_TokenResponse_expiresIn(ctx, field)
+	case "refreshToken":
+		return ec.fieldContext_TokenResponse_refreshToken(ctx, field)
+	case "scope":
+		return ec.fieldContext_TokenResponse_scope(ctx, field)
+	case "idToken":
+		return ec.fieldContext_TokenResponse_idToken(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type TokenResponse", field.Name)
+}
+
 func (ec *executionContext) childFields_TransferRepositoryPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
 	case "clientMutationId":
@@ -6791,16 +6794,6 @@ func (ec *executionContext) childFields_UpdateCollectionPayload(ctx context.Cont
 		return ec.fieldContext_UpdateCollectionPayload_conflict(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type UpdateCollectionPayload", field.Name)
-}
-
-func (ec *executionContext) childFields_User(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-	switch field.Name {
-	case "username":
-		return ec.fieldContext_User_username(ctx, field)
-	case "isAdmin":
-		return ec.fieldContext_User_isAdmin(ctx, field)
-	}
-	return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 }
 
 func (ec *executionContext) childFields_VariantSummaryDefinition(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {

--- a/gitstore-api/internal/graph/model/models_gen.go
+++ b/gitstore-api/internal/graph/model/models_gen.go
@@ -19,16 +19,6 @@ type Node interface {
 	GetID() string
 }
 
-// Authentication session response
-type AuthSession struct {
-	// JWT token for authentication
-	Token string `json:"token"`
-	// Token expiration time (ISO 8601)
-	ExpiresAt time.Time `json:"expiresAt"`
-	// Authenticated user information
-	User *User `json:"user"`
-}
-
 // A pointer to another catalogue resource.
 type CatalogObjectReference struct {
 	APIVersion      *string `json:"apiVersion,omitempty"`
@@ -326,7 +316,7 @@ type CreateCollectionPayload struct {
 
 // Input for creating a new namespace.
 type CreateNamespaceInput struct {
-	// Client mutation ID for request tracking (Relay pattern).
+	// TODO: Remove, deprecated in relay
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The human-readable identifier for the namespace.
 	// Must be globally unique across all tiers.
@@ -344,7 +334,7 @@ type CreateNamespaceInput struct {
 
 // Payload returned after successfully creating a namespace.
 type CreateNamespacePayload struct {
-	// Client mutation ID for request tracking (Relay pattern).
+	// TODO: Remove, deprecated in relay
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The newly created namespace.
 	Namespace *Namespace `json:"namespace"`
@@ -390,7 +380,7 @@ type DeleteCollectionPayload struct {
 
 // Input for deleting a namespace.
 type DeleteNamespaceInput struct {
-	// Client mutation ID for request tracking (Relay pattern).
+	// TODO: Remove, deprecated in relay
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The identifier of the namespace to delete.
 	// Deletion is blocked if any repositories exist within the namespace.
@@ -400,7 +390,7 @@ type DeleteNamespaceInput struct {
 
 // Payload returned after successfully deleting a namespace.
 type DeleteNamespacePayload struct {
-	// Client mutation ID for request tracking (Relay pattern).
+	// TODO: Remove, deprecated in relay
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The identifier of the deleted namespace.
 	DeletedIdentifier string `json:"deletedIdentifier"`
@@ -472,32 +462,30 @@ type LabelSelectorRequirement struct {
 
 // Login mutation input (Relay pattern)
 type LoginInput struct {
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Username
 	Username string `json:"username"`
 	// Password
 	Password string `json:"password"`
+	// Optional OAuth2 scope request.
+	// Scope requests are currently unsupported by local providers.
+	Scope *string `json:"scope,omitempty"`
 }
 
 // Login mutation payload (Relay pattern)
 type LoginPayload struct {
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// Authentication session (token + user info)
-	Session *AuthSession `json:"session,omitempty"`
+	// OIDC-compatible token payload.
+	Token *TokenResponse `json:"token"`
 }
 
 // Logout mutation input (Relay pattern)
 type LogoutInput struct {
+	// TODO: Is it safe to remove and empty Input?
 	// Client mutation ID for request tracking (Relay pattern)
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 }
 
 // Logout mutation payload (Relay pattern)
 type LogoutPayload struct {
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Success indicator
 	Success bool `json:"success"`
 }
@@ -868,16 +856,17 @@ type Query struct {
 
 // Refresh token mutation input (Relay pattern)
 type RefreshTokenInput struct {
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
+	// Refresh token used to issue a new access token.
+	RefreshToken string `json:"refreshToken"`
+	// Optional OAuth2 scope request.
+	// Scope requests are currently unsupported by local providers.
+	Scope *string `json:"scope,omitempty"`
 }
 
 // Refresh token mutation payload (Relay pattern)
 type RefreshTokenPayload struct {
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// New authentication session
-	Session *AuthSession `json:"session,omitempty"`
+	// OIDC-compatible token payload.
+	Token *TokenResponse `json:"token"`
 }
 
 type RenameRepositoryInput struct {
@@ -1059,6 +1048,25 @@ type SelectedOptionDefinition struct {
 type StrategyDefinition struct {
 	// Strategy identifier (e.g. fixed, percentage_discount, cost_plus).
 	Type string `json:"type"`
+}
+
+// OIDC-compatible token response.
+type TokenResponse struct {
+	// Access token used for authenticated API calls.
+	AccessToken string `json:"accessToken"`
+	// Token type. Always `Bearer` for GitStore-issued tokens.
+	TokenType string `json:"tokenType"`
+	// Seconds until the access token expires.
+	ExpiresIn int32 `json:"expiresIn"`
+	// Refresh token used to obtain a new access token.
+	// For local providers, this is currently a GitStore-issued token.
+	RefreshToken *string `json:"refreshToken,omitempty"`
+	// Granted scope set as a space-delimited string.
+	// Scope requests are currently unsupported and this field is null.
+	Scope *string `json:"scope,omitempty"`
+	// OIDC ID token when available.
+	// GitStore local providers currently do not issue this field.
+	IDToken *string `json:"idToken,omitempty"`
 }
 
 type TransferRepositoryInput struct {

--- a/gitstore-api/internal/graph/resolver/auth.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/auth.resolvers.go
@@ -7,15 +7,8 @@ package resolver
 
 import (
 	"context"
-	"encoding/base64"
-	"errors"
-	"fmt"
-	"net/http"
 
-	"github.com/gitstore-dev/gitstore/api/internal/auth"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
-	"github.com/vektah/gqlparser/v2/gqlerror"
-	"go.uber.org/zap"
 )
 
 // Login is the resolver for the login field.
@@ -23,133 +16,12 @@ func (r *mutationResolver) Login(ctx context.Context, input model.LoginInput) (*
 	return r.Resolver.Login(ctx, input)
 }
 
-// Login implements the login mutation on the base Resolver so it can be unit-tested directly.
-func (r *Resolver) Login(ctx context.Context, input model.LoginInput) (*model.LoginPayload, error) {
-	if r.registry == nil || r.registry.AuthN() == nil {
-		r.logger.Error("auth provider registry not configured")
-		return nil, gqlerror.Errorf("authentication service unavailable")
-	}
-
-	creds := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", input.Username, input.Password)))
-	req := auth.AuthRequest{
-		Header: http.Header{"Authorization": []string{"Basic " + creds}},
-	}
-
-	principal, decision, err := r.registry.AuthN().Authenticate(ctx, req)
-	if err != nil {
-		r.logger.Debug("login auth error", zap.Error(err))
-		return nil, gqlerror.Errorf("invalid username or password")
-	}
-	if decision.Outcome != auth.OutcomeAllow {
-		r.logger.Debug("login denied", zap.String("reason", decision.Reason))
-		return nil, gqlerror.Errorf("invalid username or password")
-	}
-
-	token, exp, err := r.registry.AuthN().IssueSession(ctx, principal.Subject)
-	if err != nil {
-		if errors.Is(err, auth.ErrNotSupported) {
-			r.logger.Error("no auth provider supports IssueSession")
-			return nil, gqlerror.Errorf("authentication service unavailable")
-		}
-		r.logger.Error("failed to issue session token", zap.String("subject", principal.Subject), zap.Error(err))
-		return nil, gqlerror.Errorf("internal server error")
-	}
-
-	r.logger.Debug("login succeeded", zap.String("subject", principal.Subject), zap.String("provider", decision.Provider))
-	return &model.LoginPayload{
-		Session: &model.AuthSession{
-			Token:     token,
-			ExpiresAt: exp,
-			User: &model.User{
-				Username: principal.Subject,
-				IsAdmin:  principal.IsAdmin(),
-			},
-		},
-	}, nil
-}
-
 // Logout is the resolver for the logout field.
 func (r *mutationResolver) Logout(ctx context.Context, input model.LogoutInput) (*model.LogoutPayload, error) {
 	return r.Resolver.Logout(ctx, input)
 }
 
-// Logout implements the logout mutation on the base Resolver so it can be unit-tested directly.
-func (r *Resolver) Logout(ctx context.Context, input model.LogoutInput) (*model.LogoutPayload, error) {
-	if r.registry == nil {
-		return nil, gqlerror.Errorf("authentication service unavailable")
-	}
-
-	// GraphQLAuthorizer already denies anonymous principals for non-login
-	// mutations; this check is defense-in-depth so Logout fails closed even
-	// if invoked without the operation middleware (e.g. direct resolver call).
-	principal := auth.PrincipalFromContext(ctx)
-	if principal == nil || principal.AuthMethod == "none" {
-		return nil, gqlerror.Errorf("authentication required")
-	}
-
-	// Empty TokenID means a Basic Auth session with no jti — nothing to revoke.
-	if principal.TokenID != "" {
-		err := r.registry.AuthN().RevokeSession(ctx, principal.TokenID, principal.ExpiresAt)
-		if err != nil {
-			if errors.Is(err, auth.ErrNotSupported) {
-				r.logger.Warn("logout not supported by active auth configuration")
-				return nil, gqlerror.Errorf("logout not supported by active auth configuration")
-			}
-			r.logger.Error("failed to revoke session", zap.String("subject", principal.Subject), zap.Error(err))
-			return nil, gqlerror.Errorf("internal server error")
-		}
-	}
-
-	r.logger.Debug("logout succeeded", zap.String("subject", principal.Subject))
-	return &model.LogoutPayload{Success: true}, nil
-}
-
 // RefreshToken is the resolver for the refreshToken field.
 func (r *mutationResolver) RefreshToken(ctx context.Context, input model.RefreshTokenInput) (*model.RefreshTokenPayload, error) {
 	return r.Resolver.RefreshToken(ctx, input)
-}
-
-// RefreshToken implements the refreshToken mutation on the base Resolver so it can be unit-tested directly.
-func (r *Resolver) RefreshToken(ctx context.Context, input model.RefreshTokenInput) (*model.RefreshTokenPayload, error) {
-	if r.registry == nil {
-		return nil, gqlerror.Errorf("authentication service unavailable")
-	}
-
-	rawToken := auth.RawTokenFromContext(ctx)
-	if rawToken == "" {
-		return nil, gqlerror.Errorf("refresh token requires bearer authentication")
-	}
-
-	newToken, exp, err := r.registry.AuthN().RefreshSession(ctx, rawToken)
-	if err != nil {
-		switch {
-		case errors.Is(err, auth.ErrNotSupported):
-			return nil, gqlerror.Errorf("token refresh not supported by active auth configuration")
-		case errors.Is(err, auth.ErrTokenTooOld):
-			return nil, gqlerror.Errorf("token too old to refresh, please log in again")
-		case errors.Is(err, auth.ErrTokenRevoked):
-			return nil, gqlerror.Errorf("token has been revoked")
-		default:
-			r.logger.Error("token refresh failed", zap.Error(err))
-			return nil, gqlerror.Errorf("internal server error")
-		}
-	}
-
-	principal := auth.PrincipalFromContext(ctx)
-	if principal == nil {
-		r.logger.Error("token refreshed but principal missing from context")
-		return nil, gqlerror.Errorf("internal server error")
-	}
-
-	r.logger.Debug("token refreshed", zap.String("subject", principal.Subject))
-	return &model.RefreshTokenPayload{
-		Session: &model.AuthSession{
-			Token:     newToken,
-			ExpiresAt: exp,
-			User: &model.User{
-				Username: principal.Subject,
-				IsAdmin:  principal.IsAdmin(),
-			},
-		},
-	}, nil
 }

--- a/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
+++ b/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
@@ -77,11 +77,6 @@ func ctxWithPrincipal(principal *authpkg.Principal) context.Context {
 	return authpkg.ContextWithPrincipal(context.Background(), principal)
 }
 
-func ctxWithPrincipalAndRawToken(principal *authpkg.Principal, rawToken string) context.Context {
-	ctx := authpkg.ContextWithPrincipal(context.Background(), principal)
-	return authpkg.ContextWithRawToken(ctx, rawToken)
-}
-
 // --- US1: Logout ---
 
 func TestLogout_AuthenticatedBearer_ReturnsSuccess(t *testing.T) {
@@ -158,16 +153,15 @@ func TestRefreshToken_ValidToken_ReturnsNewSession(t *testing.T) {
 	token, _, err := p.IssueToken("admin")
 	require.NoError(t, err)
 
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipalAndRawToken(principal, token)
-
-	payload, err := r.RefreshToken(ctx, model.RefreshTokenInput{})
+	payload, err := r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: token})
 	require.NoError(t, err)
 	require.NotNil(t, payload)
-	require.NotNil(t, payload.Session)
-	assert.NotEmpty(t, payload.Session.Token)
-	assert.NotEqual(t, token, payload.Session.Token, "refreshed token must differ from original")
-	assert.False(t, payload.Session.ExpiresAt.IsZero())
+	assert.NotEmpty(t, payload.Token.AccessToken)
+	assert.Equal(t, "Bearer", payload.Token.TokenType)
+	assert.Greater(t, payload.Token.ExpiresIn, int32(0))
+	require.NotNil(t, payload.Token.RefreshToken)
+	assert.NotEqual(t, token, payload.Token.AccessToken, "refreshed token must differ from original")
+	assert.Equal(t, payload.Token.AccessToken, *payload.Token.RefreshToken)
 }
 
 func TestRefreshToken_ExpiredWithinGrace_Succeeds(t *testing.T) {
@@ -178,13 +172,10 @@ func TestRefreshToken_ExpiredWithinGrace_Succeeds(t *testing.T) {
 	token, _, err := p.IssueToken("admin")
 	require.NoError(t, err)
 
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipalAndRawToken(principal, token)
-
-	payload, err := r.RefreshToken(ctx, model.RefreshTokenInput{})
+	payload, err := r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: token})
 	require.NoError(t, err)
 	require.NotNil(t, payload)
-	assert.NotEmpty(t, payload.Session.Token)
+	assert.NotEmpty(t, payload.Token.AccessToken)
 }
 
 func TestRefreshToken_ExpiredBeyondGrace_ReturnsError(t *testing.T) {
@@ -195,10 +186,7 @@ func TestRefreshToken_ExpiredBeyondGrace_ReturnsError(t *testing.T) {
 	token, _, err := p.IssueToken("admin")
 	require.NoError(t, err)
 
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipalAndRawToken(principal, token)
-
-	_, err = r.RefreshToken(ctx, model.RefreshTokenInput{})
+	_, err = r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: token})
 	require.Error(t, err)
 }
 
@@ -214,29 +202,39 @@ func TestRefreshToken_RevokedToken_ReturnsError(t *testing.T) {
 	err = p.RevokeSession(context.Background(), jti, exp)
 	require.NoError(t, err)
 
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipalAndRawToken(principal, token)
-
-	_, err = r.RefreshToken(ctx, model.RefreshTokenInput{})
+	_, err = r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: token})
 	require.Error(t, err)
 }
 
-func TestRefreshToken_NoRawToken_ReturnsError(t *testing.T) {
+func TestRefreshToken_EmptyRefreshToken_ReturnsError(t *testing.T) {
 	cfg := newTestConfig(t, "1h")
 	reg, _ := newTestRegistry(t, cfg)
 	r := newTestResolver(t, reg)
 
-	// No raw token in context — unauthenticated or Basic Auth session
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipal(principal)
-
-	_, err := r.RefreshToken(ctx, model.RefreshTokenInput{})
+	_, err := r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: ""})
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refresh token is required")
+}
+
+func TestRefreshToken_UnsupportedScope_ReturnsError(t *testing.T) {
+	cfg := newTestConfig(t, "1h")
+	reg, p := newTestRegistry(t, cfg)
+	r := newTestResolver(t, reg)
+
+	token, _, err := p.IssueToken("admin")
+	require.NoError(t, err)
+	scope := "catalog:read"
+	_, err = r.RefreshToken(context.Background(), model.RefreshTokenInput{
+		RefreshToken: token,
+		Scope:        &scope,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope requests are not supported")
 }
 
 // --- US3: Login migration ---
 
-func TestLogin_ValidCredentials_ReturnsSession(t *testing.T) {
+func TestLogin_ValidCredentials_ReturnsTokenPayload(t *testing.T) {
 	cfg := newTestConfig(t, "1h")
 	reg, _ := newTestRegistry(t, cfg)
 	r := newTestResolver(t, reg)
@@ -246,12 +244,13 @@ func TestLogin_ValidCredentials_ReturnsSession(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, payload)
-	require.NotNil(t, payload.Session)
-	assert.NotEmpty(t, payload.Session.Token)
-	assert.False(t, payload.Session.ExpiresAt.IsZero())
-	require.NotNil(t, payload.Session.User)
-	assert.Equal(t, "admin", payload.Session.User.Username)
-	assert.True(t, payload.Session.User.IsAdmin, "admin user must have isAdmin=true derived from principal roles")
+	assert.NotEmpty(t, payload.Token.AccessToken)
+	assert.Equal(t, "Bearer", payload.Token.TokenType)
+	assert.Greater(t, payload.Token.ExpiresIn, int32(0))
+	require.NotNil(t, payload.Token.RefreshToken)
+	assert.Equal(t, payload.Token.AccessToken, *payload.Token.RefreshToken)
+	assert.Nil(t, payload.Token.Scope)
+	assert.Nil(t, payload.Token.IDToken)
 }
 
 func TestLogin_InvalidPassword_ReturnsError(t *testing.T) {
@@ -261,6 +260,17 @@ func TestLogin_InvalidPassword_ReturnsError(t *testing.T) {
 
 	_, err := r.Login(context.Background(), model.LoginInput{Username: "admin", Password: "wrongpass"})
 	require.Error(t, err)
+}
+
+func TestLogin_UnsupportedScope_ReturnsError(t *testing.T) {
+	cfg := newTestConfig(t, "1h")
+	reg, _ := newTestRegistry(t, cfg)
+	r := newTestResolver(t, reg)
+	scope := "catalog:read"
+
+	_, err := r.Login(context.Background(), model.LoginInput{Username: "admin", Password: "testpass", Scope: &scope})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope requests are not supported")
 }
 
 func TestLogin_NilRegistry_ReturnsError(t *testing.T) {
@@ -304,9 +314,7 @@ func TestRefreshToken_NilRegistry_ReturnsError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin"}
-	ctx := ctxWithPrincipalAndRawToken(principal, "some.bearer.token")
-	_, err = r.RefreshToken(ctx, model.RefreshTokenInput{})
+	_, err = r.RefreshToken(context.Background(), model.RefreshTokenInput{RefreshToken: "some.refresh.token"})
 	require.Error(t, err)
 }
 

--- a/gitstore-api/internal/graph/resolver/auth_service.go
+++ b/gitstore-api/internal/graph/resolver/auth_service.go
@@ -1,0 +1,133 @@
+package resolver
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/auth"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"go.uber.org/zap"
+)
+
+func tokenResponse(accessToken, refreshToken string, exp time.Time) *model.TokenResponse {
+	ttl := int32(time.Until(exp).Seconds())
+	if ttl < 0 {
+		ttl = 0
+	}
+	return &model.TokenResponse{
+		AccessToken:  accessToken,
+		TokenType:    "Bearer",
+		ExpiresIn:    ttl,
+		RefreshToken: &refreshToken,
+	}
+}
+
+// Login implements the login mutation on the base Resolver so it can be unit-tested directly.
+func (r *Resolver) Login(ctx context.Context, input model.LoginInput) (*model.LoginPayload, error) {
+	if r.registry == nil || r.registry.AuthN() == nil {
+		r.logger.Error("auth provider registry not configured")
+		return nil, gqlerror.Errorf("authentication service unavailable")
+	}
+	if input.Scope != nil && *input.Scope != "" {
+		return nil, gqlerror.Errorf("scope requests are not supported by active auth configuration")
+	}
+
+	creds := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", input.Username, input.Password)))
+	req := auth.AuthRequest{
+		Header: http.Header{"Authorization": []string{"Basic " + creds}},
+	}
+
+	principal, decision, err := r.registry.AuthN().Authenticate(ctx, req)
+	if err != nil {
+		r.logger.Debug("login auth error", zap.Error(err))
+		return nil, gqlerror.Errorf("invalid username or password")
+	}
+	if decision.Outcome != auth.OutcomeAllow {
+		r.logger.Debug("login denied", zap.String("reason", decision.Reason))
+		return nil, gqlerror.Errorf("invalid username or password")
+	}
+
+	token, exp, err := r.registry.AuthN().IssueSession(ctx, principal.Subject)
+	if err != nil {
+		if errors.Is(err, auth.ErrNotSupported) {
+			r.logger.Error("no auth provider supports IssueSession")
+			return nil, gqlerror.Errorf("authentication service unavailable")
+		}
+		r.logger.Error("failed to issue session token", zap.String("subject", principal.Subject), zap.Error(err))
+		return nil, gqlerror.Errorf("internal server error")
+	}
+
+	r.logger.Debug("login succeeded", zap.String("subject", principal.Subject), zap.String("provider", decision.Provider))
+	return &model.LoginPayload{
+		Token: tokenResponse(token, token, exp),
+	}, nil
+}
+
+// Logout implements the logout mutation on the base Resolver so it can be unit-tested directly.
+func (r *Resolver) Logout(ctx context.Context, input model.LogoutInput) (*model.LogoutPayload, error) {
+	if r.registry == nil {
+		return nil, gqlerror.Errorf("authentication service unavailable")
+	}
+
+	// GraphQLAuthorizer already denies anonymous principals for non-login
+	// mutations; this check is defense-in-depth so Logout fails closed even
+	// if invoked without the operation middleware (e.g. direct resolver call).
+	principal := auth.PrincipalFromContext(ctx)
+	if principal == nil || principal.AuthMethod == "none" {
+		return nil, gqlerror.Errorf("authentication required")
+	}
+
+	// Empty TokenID means a Basic Auth session with no jti — nothing to revoke.
+	if principal.TokenID != "" {
+		err := r.registry.AuthN().RevokeSession(ctx, principal.TokenID, principal.ExpiresAt)
+		if err != nil {
+			if errors.Is(err, auth.ErrNotSupported) {
+				r.logger.Warn("logout not supported by active auth configuration")
+				return nil, gqlerror.Errorf("logout not supported by active auth configuration")
+			}
+			r.logger.Error("failed to revoke session", zap.String("subject", principal.Subject), zap.Error(err))
+			return nil, gqlerror.Errorf("internal server error")
+		}
+	}
+
+	r.logger.Debug("logout succeeded", zap.String("subject", principal.Subject))
+	return &model.LogoutPayload{Success: true}, nil
+}
+
+// RefreshToken implements the refreshToken mutation on the base Resolver so it can be unit-tested directly.
+func (r *Resolver) RefreshToken(ctx context.Context, input model.RefreshTokenInput) (*model.RefreshTokenPayload, error) {
+	if r.registry == nil {
+		return nil, gqlerror.Errorf("authentication service unavailable")
+	}
+	if input.Scope != nil && *input.Scope != "" {
+		return nil, gqlerror.Errorf("scope requests are not supported by active auth configuration")
+	}
+	if input.RefreshToken == "" {
+		return nil, gqlerror.Errorf("refresh token is required")
+	}
+
+	newToken, exp, err := r.registry.AuthN().RefreshSession(ctx, input.RefreshToken)
+	if err != nil {
+		switch {
+		case errors.Is(err, auth.ErrNotSupported):
+			return nil, gqlerror.Errorf("token refresh not supported by active auth configuration")
+		case errors.Is(err, auth.ErrTokenTooOld):
+			return nil, gqlerror.Errorf("token too old to refresh, please log in again")
+		case errors.Is(err, auth.ErrTokenRevoked):
+			return nil, gqlerror.Errorf("token has been revoked")
+		default:
+			r.logger.Error("token refresh failed", zap.Error(err))
+			return nil, gqlerror.Errorf("internal server error")
+		}
+	}
+
+	r.logger.Debug("token refreshed")
+	return &model.RefreshTokenPayload{
+		Token: tokenResponse(newToken, newToken, exp),
+	}, nil
+}

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -177,10 +177,6 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 			return nil, gqlerror.Errorf("permission denied: %s", decision.Reason)
 		}
 		ctx = context.WithValue(ctx, authorizedNamespaceDeleteContextKey{}, ns)
-	case "refreshToken":
-		if auth.RawTokenFromContext(ctx) == "" {
-			return nil, gqlerror.Errorf("refresh token requires bearer authentication")
-		}
 	}
 
 	return next(ctx)
@@ -236,7 +232,8 @@ func nestedStringArg(args map[string]any, parent, key string) (string, bool) {
 }
 
 // requiresAuthenticatedPrincipal reports whether the operation executes any
-// root mutation field other than "login"/"__typename". It delegates to
+// root mutation field other than "login", "refreshToken", or "__typename".
+// It delegates to
 // graphql.CollectFields — the same field-collection gqlgen itself uses to
 // decide what will actually run — so fragment spreads, inline fragments, and
 // @skip/@include directives are honored instead of re-derived by hand.
@@ -245,7 +242,7 @@ func requiresAuthenticatedPrincipal(opCtx *graphql.OperationContext) bool {
 		return false
 	}
 	for _, field := range graphql.CollectFields(opCtx, opCtx.Operation.SelectionSet, []string{"Mutation"}) {
-		if field.Name != "login" && field.Name != "__typename" {
+		if field.Name != "login" && field.Name != "refreshToken" && field.Name != "__typename" {
 			return true
 		}
 	}

--- a/gitstore-api/internal/middleware/security/graphql_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_test.go
@@ -131,6 +131,35 @@ func TestGraphQLAuthorizerAllowsLoginMutationForAnonymous(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestGraphQLAuthorizerAllowsRefreshTokenMutationForAnonymous(t *testing.T) {
+	registry, _ := newTestRegistry(t)
+	opCtx := &graphql.OperationContext{
+		Headers: http.Header{},
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{Name: "refreshToken"},
+			},
+		},
+	}
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+
+	authn := NewAuthenticate(registry, zap.NewNop())
+	authz := NewAuthorize(registry, zap.NewNop())
+	called := false
+	final := func(context.Context) graphql.ResponseHandler {
+		called = true
+		return graphql.OneShot(&graphql.Response{Data: []byte(`{"ok":true}`)})
+	}
+
+	resp := authn.GraphQLAuthenticator(ctx, func(inner context.Context) graphql.ResponseHandler {
+		return authz.GraphQLAuthorizer(inner, final)
+	})(ctx)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Errors)
+	assert.True(t, called)
+}
+
 func TestGraphQLAuthorizerAllowsLoginMutationWithRootTypenameForAnonymous(t *testing.T) {
 	registry, _ := newTestRegistry(t)
 	opCtx := &graphql.OperationContext{

--- a/shared/schemas/auth.graphqls
+++ b/shared/schemas/auth.graphqls
@@ -15,24 +15,34 @@ type User {
   isAdmin: Boolean!
 }
 
-"""
-Authentication session response
-"""
-type AuthSession {
-  """
-  JWT token for authentication
-  """
-  token: String!
+"""OIDC-compatible token response."""
+type TokenResponse {
+  """Access token used for authenticated API calls."""
+  accessToken: String!
+
+  """Token type. Always `Bearer` for GitStore-issued tokens."""
+  tokenType: String!
+
+  """Seconds until the access token expires."""
+  expiresIn: Int!
 
   """
-  Token expiration time (ISO 8601)
+  Refresh token used to obtain a new access token.
+  For local providers, this is currently a GitStore-issued token.
   """
-  expiresAt: DateTime!
+  refreshToken: String
 
   """
-  Authenticated user information
+  Granted scope set as a space-delimited string.
+  Scope requests are currently unsupported and this field is null.
   """
-  user: User!
+  scope: String
+
+  """
+  OIDC ID token when available.
+  GitStore local providers currently do not issue this field.
+  """
+  idToken: String
 }
 
 """
@@ -48,6 +58,12 @@ input LoginInput {
   Password
   """
   password: String!
+
+  """
+  Optional OAuth2 scope request.
+  Scope requests are currently unsupported by local providers.
+  """
+  scope: String
 }
 
 """
@@ -55,9 +71,9 @@ Login mutation payload (Relay pattern)
 """
 type LoginPayload {
   """
-  Authentication session (token + user info)
+  OIDC-compatible token payload.
   """
-  session: AuthSession
+  token: TokenResponse!
 }
 
 """
@@ -86,10 +102,15 @@ Refresh token mutation input (Relay pattern)
 """
 input RefreshTokenInput {
   """
-  TODO: Is it safe to remove and empty Input?
-  Client mutation ID for request tracking (Relay pattern)
+  Refresh token used to issue a new access token.
   """
-  clientMutationId: String
+  refreshToken: String!
+
+  """
+  Optional OAuth2 scope request.
+  Scope requests are currently unsupported by local providers.
+  """
+  scope: String
 }
 
 """
@@ -97,9 +118,9 @@ Refresh token mutation payload (Relay pattern)
 """
 type RefreshTokenPayload {
   """
-  New authentication session
+  OIDC-compatible token payload.
   """
-  session: AuthSession
+  token: TokenResponse!
 }
 
 # Add authentication mutations to the Mutation type


### PR DESCRIPTION
## Summary

Align auth mutation payload internals to OIDC-style token responses while preserving the established GraphQL `*Payload!` mutation wrapper contract.

## What changed

1. Updated auth schema contract:
   - `LoginPayload.token: TokenResponse!`
   - `RefreshTokenPayload.token: TokenResponse!`
   - `RefreshTokenInput.refreshToken: String!`
2. Switched refresh flow to explicit refresh-token input (token-endpoint style) instead of bearer-context rotation.
3. Kept `logout` behavior unchanged.
4. Regenerated gqlgen model/generated files to match schema updates.
5. Updated resolver + middleware tests and auth docs (`docs/api-reference.md`, `docs/user-guide.md`).

## Compatibility notes

- Mutation wrappers are unchanged:
  - `login(input: LoginInput!): LoginPayload!`
  - `refreshToken(input: RefreshTokenInput!): RefreshTokenPayload!`
  - `logout(input: LogoutInput!): LogoutPayload!`
- Breaking change for clients: `login` and `refreshToken` response internals moved from `session { ... }` to `token { ... }`.
- `scope` requests are currently unsupported for local providers and return a validation error when provided.

## Verification

- `go test ./internal/graph/resolver ./internal/middleware/security ./internal/auth/...`
