### PR TITLE
feat(controller-manager): list-then-watch bootstrap and resourceVersion checkpointing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -228,6 +228,9 @@ uri = "http://localhost:6000"
 | `controller.api_uri`                 | `GITSTORE_CONTROLLER__API_URI`                 | string   | `http://localhost:4000/graphql` | No       | No        | GraphQL API URI used by reconcilers                         |
 | `controller.default_max_attempts`    | `GITSTORE_CONTROLLER__DEFAULT_MAX_ATTEMPTS`    | integer  | `5`                             | No       | No        | Retry limit before quarantine                               |
 | `controller.default_stall_threshold` | `GITSTORE_CONTROLLER__DEFAULT_STALL_THRESHOLD` | duration | `5m`                            | No       | No        | Worker stall threshold                                      |
+| `controller.checkpoint_dir`          | `GITSTORE_CONTROLLER__CHECKPOINT_DIR`          | string   | `.gitstore/checkpoints`         | No       | No        | Directory for the filesystem checkpoint store (one file per kind) |
+| `controller.checkpoint_flush_interval_events` | `GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS` | integer | `100` | No | No | Watch events between checkpoint persists |
+| `controller.max_watch_backoff`       | `GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF`       | duration | `30s`                           | No       | No        | Cap on exponential backoff between watch-stream reconnect attempts |
 | `log.level`                          | `GITSTORE_LOG__LEVEL`                          | string   | `info`                          | No       | No        | `debug` \| `info` \| `warn` \| `error`                      |
 | `log.format`                         | `GITSTORE_LOG__FORMAT`                         | string   | `json`                          | No       | No        | `json` \| `text`                                            |
 
@@ -239,11 +242,21 @@ port = 5001
 api_uri = "http://localhost:4000/graphql"
 default_max_attempts = 5
 default_stall_threshold = "5m"
+checkpoint_dir = ".gitstore/checkpoints"
+checkpoint_flush_interval_events = 100
+max_watch_backoff = "30s"
 
 [log]
 level = "info"
 format = "json"
 ```
+
+List-then-watch bootstrap, restart resume, and expired-watch-cursor recovery for registered
+resource kinds (spec 036) persist a per-kind `resourceVersion` checkpoint under `checkpoint_dir`.
+Checkpoint health — last successful write time, replay backlog, and write-failure count — is
+exposed on the existing `/metrics` endpoint as `gitstore_controller_checkpoint_last_write_timestamp_seconds`,
+`gitstore_controller_checkpoint_replay_backlog`, and `gitstore_controller_checkpoint_write_failures_total`
+(all labeled by `kind`).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -252,7 +252,9 @@ format = "json"
 ```
 
 List-then-watch bootstrap, restart resume, and expired-watch-cursor recovery for registered
-resource kinds (spec 036) persist a per-kind `resourceVersion` checkpoint under `checkpoint_dir`.
+resource kinds (spec 036) persist a per-kind restart checkpoint under `checkpoint_dir`. Each
+checkpoint contains the `resourceVersion`, cache snapshot, and deletion replay keys needed to
+restore volatile controller state without losing queued reconciliation work.
 Checkpoint health — last successful write time, replay backlog, and write-failure count — is
 exposed on the existing `/metrics` endpoint as `gitstore_controller_checkpoint_last_write_timestamp_seconds`,
 `gitstore_controller_checkpoint_replay_backlog`, and `gitstore_controller_checkpoint_write_failures_total`

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -144,6 +144,7 @@ Runtime pieces:
 - Panic capture with stack traces.
 - Per-kind health statistics.
 - Prometheus metrics.
+- List-then-watch bootstrap and `resourceVersion` checkpointing per registered kind (`internal/checkpoint`, `internal/listwatch`) — populates the informer cache on first start, resumes a watch stream from a persisted checkpoint after a restart, and recovers from a compacted watch cursor by re-listing. See [`specs/036-controller-startup-resume`](../specs/036-controller-startup-resume/quickstart.md) for the `Runner[T]`/`ListWatcher[T]` wiring pattern; no concrete transport ships yet.
 
 HTTP surface on port `5001`:
 
@@ -365,6 +366,9 @@ Use Conventional Commits.
 | `GITSTORE_CONTROLLER__API_URI`                 | `http://localhost:4000/graphql` | API endpoint for reconciliation |
 | `GITSTORE_CONTROLLER__DEFAULT_MAX_ATTEMPTS`    | `5`                             | Retry limit before quarantine   |
 | `GITSTORE_CONTROLLER__DEFAULT_STALL_THRESHOLD` | `5m`                            | Worker stall threshold          |
+| `GITSTORE_CONTROLLER__CHECKPOINT_DIR`          | `.gitstore/checkpoints`         | Filesystem checkpoint store directory (one file per kind) |
+| `GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS` | `100`                  | Watch events between checkpoint persists |
+| `GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF`       | `30s`                           | Cap on watch-reconnect exponential backoff |
 
 See [configuration.md](configuration.md) for the operator reference.
 
@@ -381,6 +385,7 @@ Spec quickstarts are useful implementation references, but they are not user-fac
 | `024-product-variant`              | [quickstart](../specs/024-product-variant/quickstart.md), [plan](../specs/024-product-variant/plan.md)                           |
 | `025-controller-manager-runtime`   | [quickstart](../specs/025-controller-manager-runtime/quickstart.md), [plan](../specs/025-controller-manager-runtime/plan.md)     |
 | `026-reconcile-handler`            | [quickstart](../specs/026-reconcile-handler/quickstart.md), [plan](../specs/026-reconcile-handler/plan.md)                       |
+| `036-controller-startup-resume`    | [quickstart](../specs/036-controller-startup-resume/quickstart.md), [plan](../specs/036-controller-startup-resume/plan.md)       |
 
 ## Related Docs
 

--- a/gitstore-controller-manager/cmd/controller/main.go
+++ b/gitstore-controller-manager/cmd/controller/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/api"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint"
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/config"
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/health"
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/manager"
@@ -34,6 +35,20 @@ func main() {
 	defer log.Sync() //nolint:errcheck
 
 	mgr := manager.New().WithLogger(log)
+
+	// checkpointStore is shared across every kind's listwatch.Runner[T]
+	// (spec 036): each Runner persists into its own file within this
+	// directory (checkpoint.FilesystemStore, one file per kind). No
+	// concrete kind is wired here yet — gitstore-api exposes no
+	// watch/subscription transport as of this spec (see
+	// specs/036-controller-startup-resume/research.md §1). The first spec
+	// introducing a concrete resource kind constructs its
+	// listwatch.Runner[T] using this store, cfg.Controller.CheckpointFlushIntervalEvents,
+	// and cfg.Controller.MaxWatchBackoff, following the pattern in
+	// specs/036-controller-startup-resume/quickstart.md.
+	if _, err := checkpoint.NewFilesystemStore(cfg.Controller.CheckpointDir); err != nil {
+		log.Fatal("failed to init checkpoint store", zap.Error(err))
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/gitstore-controller-manager/internal/checkpoint/checkpoint.go
+++ b/gitstore-controller-manager/internal/checkpoint/checkpoint.go
@@ -8,14 +8,20 @@ package checkpoint
 
 import (
 	"context"
+	"encoding/json"
 	"time"
+
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/types"
 )
 
-// Record binds a resource kind to the resourceVersion of the last event (or
-// list completion) successfully processed by the controller.
+// Record contains everything required to resume a kind without re-listing.
+// Snapshot rebuilds the volatile informer cache, while ReplayKeys preserves
+// deletion tombstones that may not have completed before a crash.
 type Record struct {
 	Kind            string
 	ResourceVersion string
+	Snapshot        json.RawMessage
+	ReplayKeys      []types.WorkItemKey
 	WrittenAt       time.Time
 }
 

--- a/gitstore-controller-manager/internal/checkpoint/checkpoint.go
+++ b/gitstore-controller-manager/internal/checkpoint/checkpoint.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+// Package checkpoint provides pluggable, atomic per-kind persistence of the
+// last-processed resourceVersion so a controller can resume a watch stream
+// after a restart without re-listing every resource.
+package checkpoint
+
+import (
+	"context"
+	"time"
+)
+
+// Record binds a resource kind to the resourceVersion of the last event (or
+// list completion) successfully processed by the controller.
+type Record struct {
+	Kind            string
+	ResourceVersion string
+	WrittenAt       time.Time
+}
+
+// Store is the storage abstraction responsible for reading and writing
+// checkpoint Records. Writes MUST be atomic: a concurrent Load for the same
+// kind observes either the fully-written new Record or the previous one —
+// never a partial write.
+type Store interface {
+	// Load returns the persisted Record for kind. Returns a non-nil error if
+	// no record exists, the entry cannot be read, or its contents cannot be
+	// parsed. Callers MUST treat every error identically — there is no
+	// distinction between "missing" and "corrupt".
+	Load(ctx context.Context, kind string) (Record, error)
+
+	// Save persists rec, keyed by rec.Kind.
+	Save(ctx context.Context, rec Record) error
+}

--- a/gitstore-controller-manager/internal/checkpoint/filesystem.go
+++ b/gitstore-controller-manager/internal/checkpoint/filesystem.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package checkpoint
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FilesystemStore persists one JSON checkpoint file per kind under Dir.
+// Save writes to a temp file in Dir and renames it into place, so a crash
+// during write never leaves a partially-written checkpoint readable.
+type FilesystemStore struct {
+	Dir string
+}
+
+// NewFilesystemStore creates dir (if absent) and returns a FilesystemStore
+// rooted at it.
+func NewFilesystemStore(dir string) (*FilesystemStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("checkpoint: failed to create dir %q: %w", dir, err)
+	}
+	return &FilesystemStore{Dir: dir}, nil
+}
+
+func (s *FilesystemStore) path(kind string) string {
+	return filepath.Join(s.Dir, kind+".checkpoint.json")
+}
+
+// Load reads and unmarshals the checkpoint file for kind. Any error —
+// missing file, permission error, or malformed JSON — is returned as-is;
+// callers treat every error identically.
+func (s *FilesystemStore) Load(_ context.Context, kind string) (Record, error) {
+	data, err := os.ReadFile(s.path(kind))
+	if err != nil {
+		return Record{}, fmt.Errorf("checkpoint: failed to read %q: %w", kind, err)
+	}
+	var rec Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return Record{}, fmt.Errorf("checkpoint: failed to parse %q: %w", kind, err)
+	}
+	return rec, nil
+}
+
+// Save atomically writes rec to its kind's checkpoint file: write to a temp
+// file in Dir, fsync, close, then rename into place.
+func (s *FilesystemStore) Save(_ context.Context, rec Record) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("checkpoint: failed to marshal %q: %w", rec.Kind, err)
+	}
+
+	tmp, err := os.CreateTemp(s.Dir, rec.Kind+".checkpoint.*.tmp")
+	if err != nil {
+		return fmt.Errorf("checkpoint: failed to create temp file for %q: %w", rec.Kind, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename below succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("checkpoint: failed to write temp file for %q: %w", rec.Kind, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("checkpoint: failed to sync temp file for %q: %w", rec.Kind, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("checkpoint: failed to close temp file for %q: %w", rec.Kind, err)
+	}
+
+	if err := os.Rename(tmpName, s.path(rec.Kind)); err != nil {
+		return fmt.Errorf("checkpoint: failed to rename checkpoint for %q: %w", rec.Kind, err)
+	}
+	return nil
+}

--- a/gitstore-controller-manager/internal/checkpoint/filesystem.go
+++ b/gitstore-controller-manager/internal/checkpoint/filesystem.go
@@ -43,12 +43,18 @@ func (s *FilesystemStore) Load(_ context.Context, kind string) (Record, error) {
 	if err := json.Unmarshal(data, &rec); err != nil {
 		return Record{}, fmt.Errorf("checkpoint: failed to parse %q: %w", kind, err)
 	}
+	if err := validateRecord(kind, rec); err != nil {
+		return Record{}, err
+	}
 	return rec, nil
 }
 
 // Save atomically writes rec to its kind's checkpoint file: write to a temp
 // file in Dir, fsync, close, then rename into place.
 func (s *FilesystemStore) Save(_ context.Context, rec Record) error {
+	if err := validateRecord(rec.Kind, rec); err != nil {
+		return err
+	}
 	data, err := json.Marshal(rec)
 	if err != nil {
 		return fmt.Errorf("checkpoint: failed to marshal %q: %w", rec.Kind, err)
@@ -75,6 +81,25 @@ func (s *FilesystemStore) Save(_ context.Context, rec Record) error {
 
 	if err := os.Rename(tmpName, s.path(rec.Kind)); err != nil {
 		return fmt.Errorf("checkpoint: failed to rename checkpoint for %q: %w", rec.Kind, err)
+	}
+	return nil
+}
+
+func validateRecord(kind string, rec Record) error {
+	if rec.Kind == "" || rec.Kind != kind {
+		return fmt.Errorf("checkpoint: invalid kind %q for %q", rec.Kind, kind)
+	}
+	if rec.ResourceVersion == "" {
+		return fmt.Errorf("checkpoint: resourceVersion is empty for %q", kind)
+	}
+	var items []json.RawMessage
+	if len(rec.Snapshot) == 0 || json.Unmarshal(rec.Snapshot, &items) != nil || items == nil {
+		return fmt.Errorf("checkpoint: snapshot is missing or invalid for %q", kind)
+	}
+	for _, key := range rec.ReplayKeys {
+		if key.Kind != kind {
+			return fmt.Errorf("checkpoint: replay key kind %q does not match %q", key.Kind, kind)
+		}
 	}
 	return nil
 }

--- a/gitstore-controller-manager/internal/checkpoint/memory.go
+++ b/gitstore-controller-manager/internal/checkpoint/memory.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package checkpoint
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// MemoryStore is an in-memory Store implementation for tests. It is not
+// intended for production use.
+type MemoryStore struct {
+	mu      sync.RWMutex
+	records map[string]Record
+}
+
+// NewMemoryStore creates an empty MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{records: make(map[string]Record)}
+}
+
+// Load returns the stored Record for kind, or an error if none exists.
+func (s *MemoryStore) Load(_ context.Context, kind string) (Record, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rec, ok := s.records[kind]
+	if !ok {
+		return Record{}, fmt.Errorf("checkpoint: no record for kind %q", kind)
+	}
+	return rec, nil
+}
+
+// Save stores rec under rec.Kind, overwriting any previous value.
+func (s *MemoryStore) Save(_ context.Context, rec Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[rec.Kind] = rec
+	return nil
+}

--- a/gitstore-controller-manager/internal/checkpoint/memory.go
+++ b/gitstore-controller-manager/internal/checkpoint/memory.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/types"
 )
 
 // MemoryStore is an in-memory Store implementation for tests. It is not
@@ -29,13 +31,25 @@ func (s *MemoryStore) Load(_ context.Context, kind string) (Record, error) {
 	if !ok {
 		return Record{}, fmt.Errorf("checkpoint: no record for kind %q", kind)
 	}
-	return rec, nil
+	if err := validateRecord(kind, rec); err != nil {
+		return Record{}, err
+	}
+	return cloneRecord(rec), nil
 }
 
 // Save stores rec under rec.Kind, overwriting any previous value.
 func (s *MemoryStore) Save(_ context.Context, rec Record) error {
+	if err := validateRecord(rec.Kind, rec); err != nil {
+		return err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.records[rec.Kind] = rec
+	s.records[rec.Kind] = cloneRecord(rec)
 	return nil
+}
+
+func cloneRecord(rec Record) Record {
+	rec.Snapshot = append([]byte(nil), rec.Snapshot...)
+	rec.ReplayKeys = append([]types.WorkItemKey(nil), rec.ReplayKeys...)
+	return rec
 }

--- a/gitstore-controller-manager/internal/config/config.go
+++ b/gitstore-controller-manager/internal/config/config.go
@@ -34,6 +34,18 @@ type ControllerConfig struct {
 	// DefaultStallThreshold is parsed at startup into StallThreshold.
 	DefaultStallThresholdStr string        `mapstructure:"default_stall_threshold"`
 	DefaultStallThreshold    time.Duration `mapstructure:"-"`
+
+	// CheckpointDir is the directory used by the filesystem CheckpointStore
+	// (one JSON file per registered kind).
+	CheckpointDir string `mapstructure:"checkpoint_dir"`
+
+	// CheckpointFlushIntervalEvents is the number of watch events processed
+	// between checkpoint persists (an event count, not a duration).
+	CheckpointFlushIntervalEvents int `mapstructure:"checkpoint_flush_interval_events"`
+
+	// MaxWatchBackoffStr is parsed at startup into MaxWatchBackoff.
+	MaxWatchBackoffStr string        `mapstructure:"max_watch_backoff"`
+	MaxWatchBackoff    time.Duration `mapstructure:"-"`
 }
 
 // LogConfig holds logger settings.
@@ -52,6 +64,9 @@ func Load() (*Config, error) {
 	v.SetDefault("controller.api_uri", "http://localhost:4000/graphql")
 	v.SetDefault("controller.default_max_attempts", 5)
 	v.SetDefault("controller.default_stall_threshold", "5m")
+	v.SetDefault("controller.checkpoint_dir", ".gitstore/checkpoints")
+	v.SetDefault("controller.checkpoint_flush_interval_events", 100)
+	v.SetDefault("controller.max_watch_backoff", "30s")
 	v.SetDefault("log.level", "info")
 	v.SetDefault("log.format", "json")
 
@@ -97,6 +112,19 @@ func validate(cfg *Config) error {
 		return fmt.Errorf("controller.default_stall_threshold is not a valid duration: %w", err)
 	}
 	cfg.Controller.DefaultStallThreshold = d
+
+	if cfg.Controller.CheckpointDir == "" {
+		return fmt.Errorf("controller.checkpoint_dir must not be empty")
+	}
+	if cfg.Controller.CheckpointFlushIntervalEvents < 1 {
+		return fmt.Errorf("controller.checkpoint_flush_interval_events must be >= 1")
+	}
+
+	maxBackoff, err := time.ParseDuration(cfg.Controller.MaxWatchBackoffStr)
+	if err != nil {
+		return fmt.Errorf("controller.max_watch_backoff is not a valid duration: %w", err)
+	}
+	cfg.Controller.MaxWatchBackoff = maxBackoff
 
 	if err := validateLogFormat(&cfg.Log); err != nil {
 		return err

--- a/gitstore-controller-manager/internal/config/config_test.go
+++ b/gitstore-controller-manager/internal/config/config_test.go
@@ -37,6 +37,15 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.Controller.DefaultStallThreshold != 5*time.Minute {
 		t.Errorf("DefaultStallThreshold = %v, want 5m", cfg.Controller.DefaultStallThreshold)
 	}
+	if cfg.Controller.CheckpointDir != ".gitstore/checkpoints" {
+		t.Errorf("CheckpointDir = %q, want .gitstore/checkpoints", cfg.Controller.CheckpointDir)
+	}
+	if cfg.Controller.CheckpointFlushIntervalEvents != 100 {
+		t.Errorf("CheckpointFlushIntervalEvents = %d, want 100", cfg.Controller.CheckpointFlushIntervalEvents)
+	}
+	if cfg.Controller.MaxWatchBackoff != 30*time.Second {
+		t.Errorf("MaxWatchBackoff = %v, want 30s", cfg.Controller.MaxWatchBackoff)
+	}
 	if cfg.Log.Level != "info" {
 		t.Errorf("Log.Level = %q, want info", cfg.Log.Level)
 	}
@@ -51,6 +60,9 @@ func TestLoad_EnvOverrides(t *testing.T) {
 		"GITSTORE_CONTROLLER__API_URI", "http://api.example.com/graphql",
 		"GITSTORE_CONTROLLER__DEFAULT_MAX_ATTEMPTS", "10",
 		"GITSTORE_CONTROLLER__DEFAULT_STALL_THRESHOLD", "2m",
+		"GITSTORE_CONTROLLER__CHECKPOINT_DIR", "/tmp/checkpoints",
+		"GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS", "50",
+		"GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF", "1m",
 		"GITSTORE_LOG__LEVEL", "debug",
 		"GITSTORE_LOG__FORMAT", "text",
 	)
@@ -71,6 +83,15 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	}
 	if cfg.Controller.DefaultStallThreshold != 2*time.Minute {
 		t.Errorf("DefaultStallThreshold = %v, want 2m", cfg.Controller.DefaultStallThreshold)
+	}
+	if cfg.Controller.CheckpointDir != "/tmp/checkpoints" {
+		t.Errorf("CheckpointDir = %q, want /tmp/checkpoints", cfg.Controller.CheckpointDir)
+	}
+	if cfg.Controller.CheckpointFlushIntervalEvents != 50 {
+		t.Errorf("CheckpointFlushIntervalEvents = %d, want 50", cfg.Controller.CheckpointFlushIntervalEvents)
+	}
+	if cfg.Controller.MaxWatchBackoff != time.Minute {
+		t.Errorf("MaxWatchBackoff = %v, want 1m", cfg.Controller.MaxWatchBackoff)
 	}
 	if cfg.Log.Level != "debug" {
 		t.Errorf("Log.Level = %q, want debug", cfg.Log.Level)
@@ -159,6 +180,18 @@ func TestLoad_ValidationErrors(t *testing.T) {
 			envKey:  "GITSTORE_CONTROLLER__DEFAULT_STALL_THRESHOLD",
 			envVal:  "not-a-duration",
 			wantErr: "controller.default_stall_threshold",
+		},
+		{
+			name:    "checkpoint flush interval zero",
+			envKey:  "GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS",
+			envVal:  "0",
+			wantErr: "controller.checkpoint_flush_interval_events",
+		},
+		{
+			name:    "invalid max watch backoff",
+			envKey:  "GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF",
+			envVal:  "not-a-duration",
+			wantErr: "controller.max_watch_backoff",
 		},
 		{
 			name:    "invalid log format",

--- a/gitstore-controller-manager/internal/health/metrics.go
+++ b/gitstore-controller-manager/internal/health/metrics.go
@@ -34,4 +34,19 @@ var (
 		Name: "gitstore_controller_reconcile_total",
 		Help: "Total reconcile attempts per kind and result.",
 	}, []string{"kind", "result"})
+
+	CheckpointLastWriteTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gitstore_controller_checkpoint_last_write_timestamp_seconds",
+		Help: "Unix timestamp of the last successful checkpoint write per kind.",
+	}, []string{"kind"})
+
+	CheckpointWriteFailuresTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gitstore_controller_checkpoint_write_failures_total",
+		Help: "Total failed checkpoint write attempts per kind.",
+	}, []string{"kind"})
+
+	CheckpointReplayBacklog = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gitstore_controller_checkpoint_replay_backlog",
+		Help: "Number of watch events enqueued as work items but not yet dispatched, per kind.",
+	}, []string{"kind"})
 )

--- a/gitstore-controller-manager/internal/listwatch/listwatcher.go
+++ b/gitstore-controller-manager/internal/listwatch/listwatcher.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package listwatch
+
+import "context"
+
+// Watcher is an open watch stream for a single kind.
+type Watcher[T any] interface {
+	// Events delivers watch notifications. Events for a single resource key
+	// are delivered in resourceVersion order; events for different keys may
+	// interleave. The channel is closed when the watch ends (error, expiry,
+	// or Stop() called).
+	Events() <-chan WatchEvent[T]
+
+	// Err returns the reason Events() closed. Valid only after the channel
+	// is closed. errors.Is(Err(), ErrWatchExpired) signals a compacted
+	// cursor; any other non-nil value (or nil, e.g. a clean Stop()) signals
+	// a transient/ordinary close.
+	Err() error
+
+	// Stop ends the watch. Safe to call multiple times. MUST cause Events()
+	// to close if not already closed.
+	Stop()
+}
+
+// ListWatcher is the transport abstraction a Runner depends on to bootstrap
+// and resume a kind's cache. No concrete implementation ships in this
+// package — production wiring is provided by whichever spec introduces the
+// first concrete resource kind.
+type ListWatcher[T any] interface {
+	// List returns a full snapshot. Implementations do not retry internally
+	// — the caller retries with exponential backoff on error.
+	List(ctx context.Context) (ListResponse[T], error)
+
+	// Watch opens a stream starting after resourceVersion.
+	Watch(ctx context.Context, resourceVersion string) (Watcher[T], error)
+}

--- a/gitstore-controller-manager/internal/listwatch/runner.go
+++ b/gitstore-controller-manager/internal/listwatch/runner.go
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package listwatch
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/cache"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/health"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/types"
+	"go.uber.org/zap"
+)
+
+const (
+	// defaultListRetryInitialInterval / MaxInterval / Multiplier configure
+	// the unbounded exponential backoff used while retrying a failed List
+	// call (FR-014). A List failure must never give up.
+	defaultListRetryInitialInterval = 100 * time.Millisecond
+	defaultListRetryMaxInterval     = 5 * time.Second
+	defaultListRetryMultiplier      = 2.0
+
+	// defaultFlushRetryInitialInterval configures the backoff used between
+	// failed checkpoint Save attempts (FR-005 backpressure).
+	defaultFlushRetryInitialInterval = 100 * time.Millisecond
+	defaultFlushRetryMultiplier      = 2.0
+
+	// defaultReconnectInitialInterval configures the backoff used between
+	// failed/closed Watch reconnect attempts (FR-011). It escalates across
+	// consecutive failures and resets once a watch stream opens and stays
+	// open until closed by the caller (ctx cancellation) rather than by
+	// error.
+	defaultReconnectInitialInterval = 100 * time.Millisecond
+	defaultReconnectMultiplier      = 2.0
+)
+
+const (
+	defaultFlushIntervalEvents = 100
+	defaultMaxBackoff          = 30 * time.Second
+)
+
+// Runner orchestrates the list-then-watch bootstrap and resume loop for a
+// single registered kind. Exactly one Runner[T] instance runs per kind, on a
+// single dedicated goroutine — this is what satisfies "at most one active
+// list-or-watch loop per kind" without any additional locking.
+type Runner[T any] struct {
+	Kind         string
+	ListWatcher  ListWatcher[T]
+	Cache        *cache.Cache[T] // mutable — Runner is the sole writer (Set/Delete/MarkSynced)
+	Store        checkpoint.Store
+	Enqueue      func(types.WorkItemKey) error
+	KeyFunc      func(T) types.WorkItemKey
+	RevisionFunc func(T) string // extracts resourceVersion from an object, for expiry-recovery diffing
+
+	FlushIntervalEvents int           // events between checkpoint persists; default 100
+	MaxBackoff          time.Duration // cap on reconnect backoff; default 30s
+
+	Log *zap.Logger
+
+	// currentRV is the in-memory watch cursor, updated on every event. It is
+	// the source of truth for same-process reconnects — never the last
+	// value persisted to Store, which may lag by up to
+	// FlushIntervalEvents-1 events.
+	currentRV string
+
+	eventsSinceFlush int
+}
+
+// Run blocks until ctx is cancelled or an unrecoverable error occurs.
+// Exactly one Run call MUST be active per Kind at a time (FR-012) — the
+// caller is responsible for not starting a second Runner for the same kind.
+func (r *Runner[T]) Run(ctx context.Context) error {
+	r.applyDefaults()
+
+	pendingDedup, err := r.bootstrapOrResume(ctx)
+	if err != nil {
+		return err
+	}
+
+	return r.watchLoop(ctx, pendingDedup)
+}
+
+func (r *Runner[T]) applyDefaults() {
+	if r.FlushIntervalEvents <= 0 {
+		r.FlushIntervalEvents = defaultFlushIntervalEvents
+	}
+	if r.MaxBackoff <= 0 {
+		r.MaxBackoff = defaultMaxBackoff
+	}
+}
+
+// bootstrapOrResume decides between the resume path (valid checkpoint) and
+// the bootstrap path (missing/corrupt/unreadable checkpoint — FR-007,
+// FR-008), returning the transition-dedup set for keys already known as of
+// the bootstrap list (empty on resume, since no list occurs).
+func (r *Runner[T]) bootstrapOrResume(ctx context.Context) (map[types.WorkItemKey]string, error) {
+	if rec, err := r.Store.Load(ctx, r.Kind); err == nil {
+		r.currentRV = rec.ResourceVersion
+		r.Cache.MarkSynced()
+		return map[types.WorkItemKey]string{}, nil
+	}
+
+	listResp, err := r.retryList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	pendingDedup := r.applyListSnapshot(listResp)
+	return pendingDedup, nil
+}
+
+// applyListSnapshot populates the cache from a ListResponse, marks it
+// synced, enqueues every listed key, advances currentRV, and returns the
+// transition-dedup set: per key, the object revision observed at list time.
+// It is consulted exactly once per key — on the first watch event for that
+// key — to suppress a duplicate enqueue when the event describes the same
+// state already captured by the list snapshot (SC-008). ResourceVersion is
+// opaque and compared only for equality, never ordered (per spec
+// Assumptions).
+func (r *Runner[T]) applyListSnapshot(listResp ListResponse[T]) map[types.WorkItemKey]string {
+	pendingDedup := make(map[types.WorkItemKey]string, len(listResp.Items))
+	for _, item := range listResp.Items {
+		key := r.KeyFunc(item)
+		r.Cache.Set(key, item)
+		pendingDedup[key] = r.RevisionFunc(item)
+	}
+	r.Cache.MarkSynced()
+	for key := range pendingDedup {
+		r.enqueue(key)
+	}
+	r.currentRV = listResp.ResourceVersion
+	return pendingDedup
+}
+
+// retryList retries ListWatcher.List with unbounded exponential backoff
+// until it succeeds or ctx is cancelled (FR-014). The watch stream, cache
+// sync, and enqueue MUST NOT start until List succeeds.
+func (r *Runner[T]) retryList(ctx context.Context) (ListResponse[T], error) {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = defaultListRetryInitialInterval
+	b.MaxInterval = defaultListRetryMaxInterval
+	b.Multiplier = defaultListRetryMultiplier
+
+	return backoff.Retry(ctx, func() (ListResponse[T], error) {
+		return r.ListWatcher.List(ctx)
+	},
+		backoff.WithBackOff(b),
+		backoff.WithNotify(func(err error, d time.Duration) {
+			r.log().Warn("list failed; retrying",
+				zap.String("kind", r.Kind),
+				zap.Duration("backoff", d),
+				zap.Error(err),
+			)
+		}),
+	)
+}
+
+// watchLoop opens a watch stream at r.currentRV and processes events until
+// ctx is cancelled. On a watch close, it either reconnects (transient,
+// escalating backoff) or re-lists (expired cursor) and continues, per
+// FR-009/FR-011. reconnectBackoff persists across the loop's iterations so
+// consecutive transient failures escalate; it resets whenever a watch
+// stream opens successfully.
+func (r *Runner[T]) watchLoop(ctx context.Context, pendingDedup map[types.WorkItemKey]string) error {
+	reconnectBackoff := backoff.NewExponentialBackOff()
+	reconnectBackoff.InitialInterval = defaultReconnectInitialInterval
+	reconnectBackoff.MaxInterval = r.MaxBackoff
+	reconnectBackoff.Multiplier = defaultReconnectMultiplier
+	reconnectBackoff.Reset()
+
+	for {
+		watcher, err := r.ListWatcher.Watch(ctx, r.currentRV)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if !r.sleepBackoff(ctx, reconnectBackoff, err) {
+				return ctx.Err()
+			}
+			continue
+		}
+		reconnectBackoff.Reset()
+
+		closeErr := r.drainWatcher(ctx, watcher, pendingDedup)
+		watcher.Stop()
+
+		if ctx.Err() != nil {
+			r.finalFlush(ctx)
+			return ctx.Err()
+		}
+
+		if errors.Is(closeErr, ErrWatchExpired) {
+			newDedup, err := r.recoverFromExpiry(ctx)
+			if err != nil {
+				return err
+			}
+			pendingDedup = newDedup
+			reconnectBackoff.Reset()
+			continue
+		}
+
+		// Transient close (including a nil Err(), e.g. a clean Stop()) —
+		// reconnect at the in-memory currentRV, never Store.Load (FR-011).
+		if !r.sleepBackoff(ctx, reconnectBackoff, closeErr) {
+			return ctx.Err()
+		}
+	}
+}
+
+// sleepBackoff waits for the next backoff interval, logging err. Returns
+// false if ctx was cancelled during the wait.
+func (r *Runner[T]) sleepBackoff(ctx context.Context, b *backoff.ExponentialBackOff, err error) bool {
+	d := b.NextBackOff()
+	r.log().Warn("watch closed; reconnecting",
+		zap.String("kind", r.Kind),
+		zap.Duration("backoff", d),
+		zap.Error(err),
+	)
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}
+
+// drainWatcher processes events from watcher until its channel closes or
+// ctx is cancelled, returning watcher.Err() in the former case.
+func (r *Runner[T]) drainWatcher(ctx context.Context, watcher Watcher[T], pendingDedup map[types.WorkItemKey]string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev, ok := <-watcher.Events():
+			if !ok {
+				return watcher.Err()
+			}
+			r.handleEvent(ctx, ev, pendingDedup)
+		}
+	}
+}
+
+// recoverFromExpiry discards the stale cursor, re-lists with retry, writes a
+// fresh checkpoint, and enqueues only resources whose revision differs from
+// what's cached (or which are newly seen) — not every listed resource
+// (FR-009, US3 AC2). It returns a dedup map mirroring the bootstrap
+// transition dedup, so an immediate duplicate watch event for a
+// just-enqueued key is not double-enqueued.
+func (r *Runner[T]) recoverFromExpiry(ctx context.Context) (map[types.WorkItemKey]string, error) {
+	r.log().Warn("watch cursor expired; re-listing", zap.String("kind", r.Kind))
+	r.currentRV = ""
+	r.eventsSinceFlush = 0
+
+	listResp, err := r.retryList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	pendingDedup := make(map[types.WorkItemKey]string, len(listResp.Items))
+	for _, item := range listResp.Items {
+		key := r.KeyFunc(item)
+		newRev := r.RevisionFunc(item)
+		cached, ok := r.Cache.Get(key)
+		r.Cache.Set(key, item)
+		pendingDedup[key] = newRev
+		if !ok || r.RevisionFunc(cached) != newRev {
+			r.enqueue(key)
+		}
+	}
+	r.currentRV = listResp.ResourceVersion
+	r.flushWithBackoff(ctx)
+
+	return pendingDedup, nil
+}
+
+// handleEvent applies a single WatchEvent to the cache and, unless
+// suppressed by the list-to-watch transition dedup or the event is a
+// Bookmark, enqueues a work item. It also advances the flush counter and
+// applies backpressure at the configured flush interval (FR-005, SC-004).
+func (r *Runner[T]) handleEvent(ctx context.Context, ev WatchEvent[T], pendingDedup map[types.WorkItemKey]string) {
+	r.currentRV = ev.ResourceVersion
+	r.eventsSinceFlush++
+
+	if ev.Type != Bookmark {
+		key := r.KeyFunc(ev.Object)
+
+		suppressed := false
+		if rev, ok := pendingDedup[key]; ok {
+			delete(pendingDedup, key)
+			if ev.Type != Deleted && rev == r.RevisionFunc(ev.Object) {
+				// Exact same state already captured by the bootstrap list
+				// and enqueued from it — update the cache but do not
+				// double-enqueue.
+				r.Cache.Set(key, ev.Object)
+				suppressed = true
+			}
+		}
+
+		if !suppressed {
+			switch ev.Type {
+			case Added, Modified:
+				r.Cache.Set(key, ev.Object)
+			case Deleted:
+				r.Cache.Delete(key)
+			}
+			r.enqueue(key)
+		}
+	}
+
+	if r.eventsSinceFlush >= r.FlushIntervalEvents {
+		r.flushWithBackoff(ctx)
+	}
+}
+
+// finalFlush attempts one best-effort Save on shutdown — it does not retry
+// indefinitely since the process is exiting.
+func (r *Runner[T]) finalFlush(ctx context.Context) {
+	if r.eventsSinceFlush == 0 {
+		return
+	}
+	if err := r.Store.Save(context.WithoutCancel(ctx), checkpoint.Record{
+		Kind:            r.Kind,
+		ResourceVersion: r.currentRV,
+		WrittenAt:       time.Now(),
+	}); err != nil {
+		health.CheckpointWriteFailuresTotal.WithLabelValues(r.Kind).Inc()
+		r.log().Warn("final checkpoint flush on shutdown failed", zap.String("kind", r.Kind), zap.Error(err))
+		return
+	}
+	health.CheckpointLastWriteTimestamp.WithLabelValues(r.Kind).Set(float64(time.Now().Unix()))
+	r.eventsSinceFlush = 0
+}
+
+// flushWithBackoff persists the current checkpoint, retrying with backoff on
+// failure. The caller MUST NOT consume further watch events while this is
+// in progress — that is what bounds the replay window to FlushIntervalEvents
+// even under a sustained write outage (FR-005, SC-004).
+func (r *Runner[T]) flushWithBackoff(ctx context.Context) {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = defaultFlushRetryInitialInterval
+	b.MaxInterval = r.MaxBackoff
+	b.Multiplier = defaultFlushRetryMultiplier
+	b.Reset()
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		err := r.Store.Save(ctx, checkpoint.Record{
+			Kind:            r.Kind,
+			ResourceVersion: r.currentRV,
+			WrittenAt:       time.Now(),
+		})
+		if err == nil {
+			health.CheckpointLastWriteTimestamp.WithLabelValues(r.Kind).Set(float64(time.Now().Unix()))
+			r.eventsSinceFlush = 0
+			return
+		}
+
+		health.CheckpointWriteFailuresTotal.WithLabelValues(r.Kind).Inc()
+		d := b.NextBackOff()
+		r.log().Warn("checkpoint write failed; pausing watch consumption",
+			zap.String("kind", r.Kind),
+			zap.Duration("backoff", d),
+			zap.Error(err),
+		)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(d):
+		}
+	}
+}
+
+// enqueue calls Enqueue, logging (not panicking) on failure.
+func (r *Runner[T]) enqueue(key types.WorkItemKey) {
+	if err := r.Enqueue(key); err != nil {
+		r.log().Warn("enqueue failed",
+			zap.String("kind", key.Kind),
+			zap.String("namespace", key.Namespace),
+			zap.String("name", key.Name),
+			zap.Error(err),
+		)
+	}
+}
+
+func (r *Runner[T]) log() *zap.Logger {
+	if r.Log != nil {
+		return r.Log
+	}
+	return zap.NewNop()
+}

--- a/gitstore-controller-manager/internal/listwatch/runner.go
+++ b/gitstore-controller-manager/internal/listwatch/runner.go
@@ -5,7 +5,9 @@ package listwatch
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -68,6 +70,8 @@ type Runner[T any] struct {
 	currentRV string
 
 	eventsSinceFlush int
+	checkpointDirty  bool
+	replayKeys       map[types.WorkItemKey]struct{}
 }
 
 // Run blocks until ctx is cancelled or an unrecoverable error occurs.
@@ -75,6 +79,7 @@ type Runner[T any] struct {
 // caller is responsible for not starting a second Runner for the same kind.
 func (r *Runner[T]) Run(ctx context.Context) error {
 	r.applyDefaults()
+	defer r.finalFlush(ctx)
 
 	pendingDedup, err := r.bootstrapOrResume(ctx)
 	if err != nil {
@@ -99,9 +104,9 @@ func (r *Runner[T]) applyDefaults() {
 // the bootstrap list (empty on resume, since no list occurs).
 func (r *Runner[T]) bootstrapOrResume(ctx context.Context) (map[types.WorkItemKey]string, error) {
 	if rec, err := r.Store.Load(ctx, r.Kind); err == nil {
-		r.currentRV = rec.ResourceVersion
-		r.Cache.MarkSynced()
-		return map[types.WorkItemKey]string{}, nil
+		if err := r.restoreCheckpoint(rec); err == nil {
+			return map[types.WorkItemKey]string{}, nil
+		}
 	}
 
 	listResp, err := r.retryList(ctx)
@@ -110,11 +115,46 @@ func (r *Runner[T]) bootstrapOrResume(ctx context.Context) (map[types.WorkItemKe
 	}
 
 	pendingDedup := r.applyListSnapshot(listResp)
+	if err := r.flushWithBackoff(ctx); err != nil {
+		return nil, err
+	}
+	r.Cache.MarkSynced()
+	for key := range pendingDedup {
+		r.enqueue(key)
+	}
 	return pendingDedup, nil
 }
 
-// applyListSnapshot populates the cache from a ListResponse, marks it
-// synced, enqueues every listed key, advances currentRV, and returns the
+func (r *Runner[T]) restoreCheckpoint(rec checkpoint.Record) error {
+	var items []T
+	if err := json.Unmarshal(rec.Snapshot, &items); err != nil {
+		return fmt.Errorf("restore checkpoint snapshot: %w", err)
+	}
+	for _, key := range rec.ReplayKeys {
+		if key.Kind != r.Kind {
+			return fmt.Errorf("restore checkpoint: replay key kind %q does not match %q", key.Kind, r.Kind)
+		}
+	}
+
+	r.replayKeys = make(map[types.WorkItemKey]struct{}, len(rec.ReplayKeys))
+	for _, item := range items {
+		r.Cache.Set(r.KeyFunc(item), item)
+	}
+	for _, key := range rec.ReplayKeys {
+		r.replayKeys[key] = struct{}{}
+	}
+	r.currentRV = rec.ResourceVersion
+	r.Cache.MarkSynced()
+	for _, item := range items {
+		r.enqueue(r.KeyFunc(item))
+	}
+	for key := range r.replayKeys {
+		r.enqueue(key)
+	}
+	return nil
+}
+
+// applyListSnapshot populates the cache from a ListResponse and returns the
 // transition-dedup set: per key, the object revision observed at list time.
 // It is consulted exactly once per key — on the first watch event for that
 // key — to suppress a duplicate enqueue when the event describes the same
@@ -123,16 +163,14 @@ func (r *Runner[T]) bootstrapOrResume(ctx context.Context) (map[types.WorkItemKe
 // Assumptions).
 func (r *Runner[T]) applyListSnapshot(listResp ListResponse[T]) map[types.WorkItemKey]string {
 	pendingDedup := make(map[types.WorkItemKey]string, len(listResp.Items))
+	r.replayKeys = make(map[types.WorkItemKey]struct{})
 	for _, item := range listResp.Items {
 		key := r.KeyFunc(item)
 		r.Cache.Set(key, item)
 		pendingDedup[key] = r.RevisionFunc(item)
 	}
-	r.Cache.MarkSynced()
-	for key := range pendingDedup {
-		r.enqueue(key)
-	}
 	r.currentRV = listResp.ResourceVersion
+	r.checkpointDirty = true
 	return pendingDedup
 }
 
@@ -178,6 +216,15 @@ func (r *Runner[T]) watchLoop(ctx context.Context, pendingDedup map[types.WorkIt
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			if errors.Is(err, ErrWatchExpired) {
+				newDedup, recoverErr := r.recoverFromExpiry(ctx)
+				if recoverErr != nil {
+					return recoverErr
+				}
+				pendingDedup = newDedup
+				reconnectBackoff.Reset()
+				continue
+			}
 			if !r.sleepBackoff(ctx, reconnectBackoff, err) {
 				return ctx.Err()
 			}
@@ -185,11 +232,13 @@ func (r *Runner[T]) watchLoop(ctx context.Context, pendingDedup map[types.WorkIt
 		}
 		reconnectBackoff.Reset()
 
-		closeErr := r.drainWatcher(ctx, watcher, pendingDedup)
+		closeErr, processErr := r.drainWatcher(ctx, watcher, pendingDedup)
 		watcher.Stop()
+		if processErr != nil {
+			return processErr
+		}
 
 		if ctx.Err() != nil {
-			r.finalFlush(ctx)
 			return ctx.Err()
 		}
 
@@ -230,16 +279,18 @@ func (r *Runner[T]) sleepBackoff(ctx context.Context, b *backoff.ExponentialBack
 
 // drainWatcher processes events from watcher until its channel closes or
 // ctx is cancelled, returning watcher.Err() in the former case.
-func (r *Runner[T]) drainWatcher(ctx context.Context, watcher Watcher[T], pendingDedup map[types.WorkItemKey]string) error {
+func (r *Runner[T]) drainWatcher(ctx context.Context, watcher Watcher[T], pendingDedup map[types.WorkItemKey]string) (error, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return nil, nil
 		case ev, ok := <-watcher.Events():
 			if !ok {
-				return watcher.Err()
+				return watcher.Err(), nil
 			}
-			r.handleEvent(ctx, ev, pendingDedup)
+			if err := r.handleEvent(ctx, ev, pendingDedup); err != nil {
+				return nil, err
+			}
 		}
 	}
 }
@@ -253,7 +304,7 @@ func (r *Runner[T]) drainWatcher(ctx context.Context, watcher Watcher[T], pendin
 func (r *Runner[T]) recoverFromExpiry(ctx context.Context) (map[types.WorkItemKey]string, error) {
 	r.log().Warn("watch cursor expired; re-listing", zap.String("kind", r.Kind))
 	r.currentRV = ""
-	r.eventsSinceFlush = 0
+	r.checkpointDirty = true
 
 	listResp, err := r.retryList(ctx)
 	if err != nil {
@@ -261,18 +312,33 @@ func (r *Runner[T]) recoverFromExpiry(ctx context.Context) (map[types.WorkItemKe
 	}
 
 	pendingDedup := make(map[types.WorkItemKey]string, len(listResp.Items))
+	listedKeys := make(map[types.WorkItemKey]struct{}, len(listResp.Items))
 	for _, item := range listResp.Items {
 		key := r.KeyFunc(item)
 		newRev := r.RevisionFunc(item)
+		listedKeys[key] = struct{}{}
 		cached, ok := r.Cache.Get(key)
 		r.Cache.Set(key, item)
+		delete(r.replayKeys, key)
 		pendingDedup[key] = newRev
 		if !ok || r.RevisionFunc(cached) != newRev {
 			r.enqueue(key)
 		}
 	}
+	for _, cached := range r.Cache.List() {
+		key := r.KeyFunc(cached)
+		if _, ok := listedKeys[key]; ok {
+			continue
+		}
+		r.Cache.Delete(key)
+		r.rememberForReplay(key)
+		r.enqueue(key)
+	}
 	r.currentRV = listResp.ResourceVersion
-	r.flushWithBackoff(ctx)
+	r.checkpointDirty = true
+	if err := r.flushWithBackoff(ctx); err != nil {
+		return nil, err
+	}
 
 	return pendingDedup, nil
 }
@@ -281,9 +347,10 @@ func (r *Runner[T]) recoverFromExpiry(ctx context.Context) (map[types.WorkItemKe
 // suppressed by the list-to-watch transition dedup or the event is a
 // Bookmark, enqueues a work item. It also advances the flush counter and
 // applies backpressure at the configured flush interval (FR-005, SC-004).
-func (r *Runner[T]) handleEvent(ctx context.Context, ev WatchEvent[T], pendingDedup map[types.WorkItemKey]string) {
+func (r *Runner[T]) handleEvent(ctx context.Context, ev WatchEvent[T], pendingDedup map[types.WorkItemKey]string) error {
 	r.currentRV = ev.ResourceVersion
 	r.eventsSinceFlush++
+	r.checkpointDirty = true
 
 	if ev.Type != Bookmark {
 		key := r.KeyFunc(ev.Object)
@@ -304,42 +371,47 @@ func (r *Runner[T]) handleEvent(ctx context.Context, ev WatchEvent[T], pendingDe
 			switch ev.Type {
 			case Added, Modified:
 				r.Cache.Set(key, ev.Object)
+				delete(r.replayKeys, key)
 			case Deleted:
 				r.Cache.Delete(key)
+				r.rememberForReplay(key)
 			}
 			r.enqueue(key)
 		}
 	}
 
 	if r.eventsSinceFlush >= r.FlushIntervalEvents {
-		r.flushWithBackoff(ctx)
+		return r.flushWithBackoff(ctx)
 	}
+	return nil
 }
 
 // finalFlush attempts one best-effort Save on shutdown — it does not retry
 // indefinitely since the process is exiting.
 func (r *Runner[T]) finalFlush(ctx context.Context) {
-	if r.eventsSinceFlush == 0 {
+	if !r.checkpointDirty {
 		return
 	}
-	if err := r.Store.Save(context.WithoutCancel(ctx), checkpoint.Record{
-		Kind:            r.Kind,
-		ResourceVersion: r.currentRV,
-		WrittenAt:       time.Now(),
-	}); err != nil {
+	rec, err := r.checkpointRecord()
+	if err != nil {
+		r.log().Warn("final checkpoint snapshot failed", zap.String("kind", r.Kind), zap.Error(err))
+		return
+	}
+	if err := r.Store.Save(context.WithoutCancel(ctx), rec); err != nil {
 		health.CheckpointWriteFailuresTotal.WithLabelValues(r.Kind).Inc()
 		r.log().Warn("final checkpoint flush on shutdown failed", zap.String("kind", r.Kind), zap.Error(err))
 		return
 	}
 	health.CheckpointLastWriteTimestamp.WithLabelValues(r.Kind).Set(float64(time.Now().Unix()))
 	r.eventsSinceFlush = 0
+	r.checkpointDirty = false
 }
 
 // flushWithBackoff persists the current checkpoint, retrying with backoff on
 // failure. The caller MUST NOT consume further watch events while this is
 // in progress — that is what bounds the replay window to FlushIntervalEvents
 // even under a sustained write outage (FR-005, SC-004).
-func (r *Runner[T]) flushWithBackoff(ctx context.Context) {
+func (r *Runner[T]) flushWithBackoff(ctx context.Context) error {
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = defaultFlushRetryInitialInterval
 	b.MaxInterval = r.MaxBackoff
@@ -348,17 +420,18 @@ func (r *Runner[T]) flushWithBackoff(ctx context.Context) {
 
 	for {
 		if ctx.Err() != nil {
-			return
+			return ctx.Err()
 		}
-		err := r.Store.Save(ctx, checkpoint.Record{
-			Kind:            r.Kind,
-			ResourceVersion: r.currentRV,
-			WrittenAt:       time.Now(),
-		})
+		rec, err := r.checkpointRecord()
+		if err != nil {
+			return err
+		}
+		err = r.Store.Save(ctx, rec)
 		if err == nil {
 			health.CheckpointLastWriteTimestamp.WithLabelValues(r.Kind).Set(float64(time.Now().Unix()))
 			r.eventsSinceFlush = 0
-			return
+			r.checkpointDirty = false
+			return nil
 		}
 
 		health.CheckpointWriteFailuresTotal.WithLabelValues(r.Kind).Inc()
@@ -370,10 +443,35 @@ func (r *Runner[T]) flushWithBackoff(ctx context.Context) {
 		)
 		select {
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 		case <-time.After(d):
 		}
 	}
+}
+
+func (r *Runner[T]) checkpointRecord() (checkpoint.Record, error) {
+	snapshot, err := json.Marshal(r.Cache.List())
+	if err != nil {
+		return checkpoint.Record{}, fmt.Errorf("marshal checkpoint snapshot: %w", err)
+	}
+	replayKeys := make([]types.WorkItemKey, 0, len(r.replayKeys))
+	for key := range r.replayKeys {
+		replayKeys = append(replayKeys, key)
+	}
+	return checkpoint.Record{
+		Kind:            r.Kind,
+		ResourceVersion: r.currentRV,
+		Snapshot:        snapshot,
+		ReplayKeys:      replayKeys,
+		WrittenAt:       time.Now(),
+	}, nil
+}
+
+func (r *Runner[T]) rememberForReplay(key types.WorkItemKey) {
+	if r.replayKeys == nil {
+		r.replayKeys = make(map[types.WorkItemKey]struct{})
+	}
+	r.replayKeys[key] = struct{}{}
 }
 
 // enqueue calls Enqueue, logging (not panicking) on failure.

--- a/gitstore-controller-manager/internal/listwatch/types.go
+++ b/gitstore-controller-manager/internal/listwatch/types.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+// Package listwatch implements a generic list-then-watch bootstrap and
+// resume loop that populates a per-kind informer cache and drives the
+// controller manager's work queue, checkpointing its resourceVersion cursor
+// so a restart can resume without a full re-list.
+package listwatch
+
+import "errors"
+
+// EventType identifies the kind of change a WatchEvent carries.
+type EventType int
+
+const (
+	// Added indicates a new resource was created.
+	Added EventType = iota
+	// Modified indicates an existing resource changed.
+	Modified
+	// Deleted indicates a resource was removed.
+	Deleted
+	// Bookmark carries only a resourceVersion cursor update; Object is the
+	// zero value and MUST NOT be interpreted.
+	Bookmark
+)
+
+// WatchEvent is a single streaming change notification delivered by a
+// Watcher after a List. Every variant carries ResourceVersion; Bookmark
+// carries only the version.
+type WatchEvent[T any] struct {
+	Type            EventType
+	Object          T // zero value when Type == Bookmark
+	ResourceVersion string
+}
+
+// ListResponse is the result of a full list request for a given kind: a
+// snapshot of all current resources and the resourceVersion at the time of
+// the snapshot.
+type ListResponse[T any] struct {
+	Items           []T
+	ResourceVersion string
+}
+
+// ErrWatchExpired signals that a requested watch cursor is no longer
+// available because the event log has been compacted. Watcher.Err() MUST
+// satisfy errors.Is(err, ErrWatchExpired) when this condition occurs.
+var ErrWatchExpired = errors.New("watch cursor expired: event log compacted")

--- a/gitstore-controller-manager/internal/manager/manager.go
+++ b/gitstore-controller-manager/internal/manager/manager.go
@@ -150,6 +150,7 @@ func (m *Manager) KindStats() map[string]health.KindStat {
 		health.ActiveWorkers.WithLabelValues(kind).Set(float64(active))
 		health.QueueDepth.WithLabelValues(kind).Set(float64(depth))
 		health.PoisonItemsTotal.WithLabelValues(kind).Set(float64(poison))
+		health.CheckpointReplayBacklog.WithLabelValues(kind).Set(float64(depth))
 
 		ks.mu.Lock()
 		lastSuccess := ks.lastSuccess

--- a/gitstore-controller-manager/tests/checkpoint/filesystem_test.go
+++ b/gitstore-controller-manager/tests/checkpoint/filesystem_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package checkpoint_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint"
+)
+
+func TestFilesystemStore_SaveThenLoad_RoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	store, err := checkpoint.NewFilesystemStore(dir)
+	if err != nil {
+		t.Fatalf("NewFilesystemStore: %v", err)
+	}
+
+	want := checkpoint.Record{Kind: "Widget", ResourceVersion: "42", WrittenAt: time.Now().Truncate(time.Second)}
+	if err := store.Save(context.Background(), want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.Load(context.Background(), "Widget")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Kind != want.Kind || got.ResourceVersion != want.ResourceVersion {
+		t.Errorf("Load() = %+v, want %+v", got, want)
+	}
+}
+
+func TestFilesystemStore_AtomicWrite_NoPartialFileOnCrash(t *testing.T) {
+	dir := t.TempDir()
+	store, err := checkpoint.NewFilesystemStore(dir)
+	if err != nil {
+		t.Fatalf("NewFilesystemStore: %v", err)
+	}
+
+	if err := store.Save(context.Background(), checkpoint.Record{Kind: "Widget", ResourceVersion: "1"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" || filepath.Ext(filepath.Ext(e.Name())) == ".tmp" {
+			t.Errorf("temp file left behind after Save: %s", e.Name())
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "Widget.checkpoint.json")); err != nil {
+		t.Errorf("expected final checkpoint file to exist: %v", err)
+	}
+}
+
+func TestFilesystemStore_CorruptFile_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Widget.checkpoint.json"), []byte("{not valid json"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	store, err := checkpoint.NewFilesystemStore(dir)
+	if err != nil {
+		t.Fatalf("NewFilesystemStore: %v", err)
+	}
+
+	if _, err := store.Load(context.Background(), "Widget"); err == nil {
+		t.Error("expected error loading corrupt checkpoint file, got nil")
+	}
+}
+
+func TestFilesystemStore_MissingFile_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	store, err := checkpoint.NewFilesystemStore(dir)
+	if err != nil {
+		t.Fatalf("NewFilesystemStore: %v", err)
+	}
+
+	if _, err := store.Load(context.Background(), "DoesNotExist"); err == nil {
+		t.Error("expected error loading missing checkpoint file, got nil")
+	}
+}
+
+func TestFilesystemStore_OneFilePerKind_Isolated(t *testing.T) {
+	dir := t.TempDir()
+	store, err := checkpoint.NewFilesystemStore(dir)
+	if err != nil {
+		t.Fatalf("NewFilesystemStore: %v", err)
+	}
+
+	if err := store.Save(context.Background(), checkpoint.Record{Kind: "A", ResourceVersion: "1"}); err != nil {
+		t.Fatalf("Save A: %v", err)
+	}
+	if err := store.Save(context.Background(), checkpoint.Record{Kind: "B", ResourceVersion: "99"}); err != nil {
+		t.Fatalf("Save B: %v", err)
+	}
+
+	// Corrupt B's file; A must remain readable.
+	if err := os.WriteFile(filepath.Join(dir, "B.checkpoint.json"), []byte("garbage"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	recA, err := store.Load(context.Background(), "A")
+	if err != nil {
+		t.Fatalf("Load A after B corrupted: %v", err)
+	}
+	if recA.ResourceVersion != "1" {
+		t.Errorf("A.ResourceVersion = %q, want 1", recA.ResourceVersion)
+	}
+
+	if _, err := store.Load(context.Background(), "B"); err == nil {
+		t.Error("expected B to be unreadable after corruption")
+	}
+}

--- a/gitstore-controller-manager/tests/checkpoint/filesystem_test.go
+++ b/gitstore-controller-manager/tests/checkpoint/filesystem_test.go
@@ -20,7 +20,7 @@ func TestFilesystemStore_SaveThenLoad_RoundTrips(t *testing.T) {
 		t.Fatalf("NewFilesystemStore: %v", err)
 	}
 
-	want := checkpoint.Record{Kind: "Widget", ResourceVersion: "42", WrittenAt: time.Now().Truncate(time.Second)}
+	want := checkpoint.Record{Kind: "Widget", ResourceVersion: "42", Snapshot: []byte("[]"), WrittenAt: time.Now().Truncate(time.Second)}
 	if err := store.Save(context.Background(), want); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestFilesystemStore_AtomicWrite_NoPartialFileOnCrash(t *testing.T) {
 		t.Fatalf("NewFilesystemStore: %v", err)
 	}
 
-	if err := store.Save(context.Background(), checkpoint.Record{Kind: "Widget", ResourceVersion: "1"}); err != nil {
+	if err := store.Save(context.Background(), checkpoint.Record{Kind: "Widget", ResourceVersion: "1", Snapshot: []byte("[]")}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -93,10 +93,10 @@ func TestFilesystemStore_OneFilePerKind_Isolated(t *testing.T) {
 		t.Fatalf("NewFilesystemStore: %v", err)
 	}
 
-	if err := store.Save(context.Background(), checkpoint.Record{Kind: "A", ResourceVersion: "1"}); err != nil {
+	if err := store.Save(context.Background(), checkpoint.Record{Kind: "A", ResourceVersion: "1", Snapshot: []byte("[]")}); err != nil {
 		t.Fatalf("Save A: %v", err)
 	}
-	if err := store.Save(context.Background(), checkpoint.Record{Kind: "B", ResourceVersion: "99"}); err != nil {
+	if err := store.Save(context.Background(), checkpoint.Record{Kind: "B", ResourceVersion: "99", Snapshot: []byte("[]")}); err != nil {
 		t.Fatalf("Save B: %v", err)
 	}
 
@@ -115,5 +115,35 @@ func TestFilesystemStore_OneFilePerKind_Isolated(t *testing.T) {
 
 	if _, err := store.Load(context.Background(), "B"); err == nil {
 		t.Error("expected B to be unreadable after corruption")
+	}
+}
+
+func TestFilesystemStore_SemanticallyInvalidRecord_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Widget.checkpoint.json"), []byte(`{"Kind":"Other","ResourceVersion":"42","Snapshot":[]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	store, err := checkpoint.NewFilesystemStore(dir)
+	if err != nil {
+		t.Fatalf("NewFilesystemStore: %v", err)
+	}
+
+	if _, err := store.Load(context.Background(), "Widget"); err == nil {
+		t.Error("expected error loading checkpoint with mismatched kind")
+	}
+}
+
+func TestFilesystemStore_MissingSnapshot_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Widget.checkpoint.json"), []byte(`{"Kind":"Widget","ResourceVersion":"42"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	store, err := checkpoint.NewFilesystemStore(dir)
+	if err != nil {
+		t.Fatalf("NewFilesystemStore: %v", err)
+	}
+
+	if _, err := store.Load(context.Background(), "Widget"); err == nil {
+		t.Error("expected error loading checkpoint without a snapshot")
 	}
 }

--- a/gitstore-controller-manager/tests/checkpoint/memory_test.go
+++ b/gitstore-controller-manager/tests/checkpoint/memory_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package checkpoint_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint"
+)
+
+func TestMemoryStore_SaveThenLoad(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+
+	if _, err := store.Load(context.Background(), "Widget"); err == nil {
+		t.Error("expected error loading before any Save, got nil")
+	}
+
+	want := checkpoint.Record{Kind: "Widget", ResourceVersion: "7"}
+	if err := store.Save(context.Background(), want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.Load(context.Background(), "Widget")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.ResourceVersion != "7" {
+		t.Errorf("ResourceVersion = %q, want 7", got.ResourceVersion)
+	}
+}

--- a/gitstore-controller-manager/tests/checkpoint/memory_test.go
+++ b/gitstore-controller-manager/tests/checkpoint/memory_test.go
@@ -17,7 +17,7 @@ func TestMemoryStore_SaveThenLoad(t *testing.T) {
 		t.Error("expected error loading before any Save, got nil")
 	}
 
-	want := checkpoint.Record{Kind: "Widget", ResourceVersion: "7"}
+	want := checkpoint.Record{Kind: "Widget", ResourceVersion: "7", Snapshot: []byte("[]")}
 	if err := store.Save(context.Background(), want); err != nil {
 		t.Fatalf("Save: %v", err)
 	}

--- a/gitstore-controller-manager/tests/contract/health_test.go
+++ b/gitstore-controller-manager/tests/contract/health_test.go
@@ -13,8 +13,12 @@ import (
 	"time"
 
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/cache"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint"
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/health"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/listwatch"
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/manager"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/types"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestHealth_JSONFieldsPresent(t *testing.T) {
@@ -180,4 +184,139 @@ func TestHealth_MetricsEndpointResponds(t *testing.T) {
 
 func contains(s, sub string) bool {
 	return strings.Contains(s, sub)
+}
+
+// T036: checkpoint metrics update on successful and failed flush.
+func TestHealth_CheckpointLastWriteTimestamp_UpdatesOnSave(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
+	sw := newStubWatcher([]listwatch.WatchEvent[widget]{
+		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "a"}, ResourceVersion: "1"},
+	}, nil)
+	lw.watchers = []*stubWatcher[widget]{sw}
+
+	r, _, _ := newRunner(t, lw, store)
+	r.FlushIntervalEvents = 1
+	r.Kind = "HealthWidgetA"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	before := testutil.ToFloat64(health.CheckpointLastWriteTimestamp.WithLabelValues("HealthWidgetA"))
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(400 * time.Millisecond)
+	for {
+		if testutil.ToFloat64(health.CheckpointLastWriteTimestamp.WithLabelValues("HealthWidgetA")) > before {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected CheckpointLastWriteTimestamp to update after a successful flush")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+}
+
+func TestHealth_CheckpointWriteFailuresTotal_IncrementsOnFailure(t *testing.T) {
+	store := &failingStore{inner: checkpoint.NewMemoryStore(), failCount: 3}
+	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
+	sw := newStubWatcher([]listwatch.WatchEvent[widget]{
+		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "a"}, ResourceVersion: "1"},
+	}, nil)
+	lw.watchers = []*stubWatcher[widget]{sw}
+
+	r, _, _ := newRunner(t, lw, store)
+	r.FlushIntervalEvents = 1
+	r.Kind = "HealthWidgetB"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	before := testutil.ToFloat64(health.CheckpointWriteFailuresTotal.WithLabelValues("HealthWidgetB"))
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(800 * time.Millisecond)
+	for {
+		if testutil.ToFloat64(health.CheckpointWriteFailuresTotal.WithLabelValues("HealthWidgetB"))-before >= 3 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected CheckpointWriteFailuresTotal to increment at least 3 times")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+}
+
+// T037: replay backlog metric tracks the manager's existing queue depth.
+func TestHealth_CheckpointReplayBacklog_TracksQueueDepth(t *testing.T) {
+	mgr := manager.New()
+	c := cache.New[string]()
+	c.MarkSynced()
+	// Slow reconciler so enqueued items pile up in the queue instead of
+	// draining immediately, giving KindStats() a non-zero depth to report.
+	block := make(chan struct{})
+	slow := &blockingReconciler{unblock: block}
+	if err := mgr.Register(manager.ReconcilerRegistration{
+		Kind:            "HealthWidgetC",
+		Reconciler:      slow,
+		Cache:           c,
+		MaxAttempts:     1,
+		InitialInterval: time.Millisecond,
+		MaxInterval:     5 * time.Millisecond,
+		Multiplier:      2.0,
+		StallThreshold:  time.Minute,
+		WorkerCount:     1,
+	}); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	go func() { _ = mgr.Start(ctx) }()
+
+	for i := range 5 {
+		key := types.WorkItemKey{Kind: "HealthWidgetC", Namespace: "ns", Name: string(rune('a' + i))}
+		if err := mgr.Enqueue(key); err != nil {
+			t.Fatalf("Enqueue failed: %v", err)
+		}
+	}
+
+	deadline := time.After(1 * time.Second)
+	var stats map[string]health.KindStat
+	for {
+		stats = mgr.KindStats()
+		if stats["HealthWidgetC"].QueueDepth > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected non-zero queue depth before checking replay backlog metric")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	got := testutil.ToFloat64(health.CheckpointReplayBacklog.WithLabelValues("HealthWidgetC"))
+	want := float64(stats["HealthWidgetC"].QueueDepth)
+	if got != want {
+		t.Errorf("CheckpointReplayBacklog = %v, want %v (KindStats().QueueDepth)", got, want)
+	}
+	close(block)
+	cancel()
+}
+
+type blockingReconciler struct{ unblock <-chan struct{} }
+
+func (b *blockingReconciler) Reconcile(_ context.Context, _ manager.WorkItemKey) manager.ReconcileResult {
+	<-b.unblock
+	return types.ResultOK()
 }

--- a/gitstore-controller-manager/tests/contract/listwatch_bootstrap_test.go
+++ b/gitstore-controller-manager/tests/contract/listwatch_bootstrap_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package contract_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/cache"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/listwatch"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/types"
+)
+
+// widget is the test resource type used across listwatch contract tests.
+type widget struct {
+	Namespace, Name, ResourceVersion string
+}
+
+func widgetKey(w widget) types.WorkItemKey {
+	return types.WorkItemKey{Kind: "Widget", Namespace: w.Namespace, Name: w.Name}
+}
+
+func widgetRevision(w widget) string { return w.ResourceVersion }
+
+// stubWatcher is a test double for listwatch.Watcher[T]. Events are
+// delivered from a script slice; closing happens either when the script is
+// exhausted (err defaults to nil, as with a clean Stop()) or Stop is called.
+type stubWatcher[T any] struct {
+	mu      sync.Mutex
+	ch      chan listwatch.WatchEvent[T]
+	err     error
+	stopped bool
+}
+
+func newStubWatcher[T any](events []listwatch.WatchEvent[T], closeErr error) *stubWatcher[T] {
+	w := &stubWatcher[T]{
+		ch:  make(chan listwatch.WatchEvent[T], len(events)+1),
+		err: closeErr,
+	}
+	for _, ev := range events {
+		w.ch <- ev
+	}
+	// Do not close yet if the caller wants to append more events after
+	// construction (see stubListWatcher.pushWatch). Callers that want an
+	// immediately-closed stream call closeNow.
+	return w
+}
+
+func (w *stubWatcher[T]) closeNow() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.stopped {
+		w.stopped = true
+		close(w.ch)
+	}
+}
+
+func (w *stubWatcher[T]) Events() <-chan listwatch.WatchEvent[T] { return w.ch }
+func (w *stubWatcher[T]) Err() error                             { return w.err }
+func (w *stubWatcher[T]) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.stopped {
+		w.stopped = true
+		close(w.ch)
+	}
+}
+
+// stubListWatcher is a hand-written test double implementing
+// listwatch.ListWatcher[T], mirroring the stubReconciler convention used in
+// spec 026's contract tests. Configurable to fail List a fixed number of
+// times before succeeding, and to serve a scripted sequence of watchers.
+type stubListWatcher[T any] struct {
+	mu sync.Mutex
+
+	listResp      listwatch.ListResponse[T]
+	listRespQueue []listwatch.ListResponse[T] // if non-empty, List pops from here in order, then falls back to listResp
+	listErr       error
+	listFailures  int // number of times List fails before succeeding
+	listCalls     atomic.Int32
+
+	watchers   []*stubWatcher[T]
+	watchCalls atomic.Int32
+	watchRVs   []string // resourceVersion argument observed on each Watch call
+	watchErr   error
+}
+
+func (lw *stubListWatcher[T]) List(_ context.Context) (listwatch.ListResponse[T], error) {
+	n := lw.listCalls.Add(1)
+	if int(n) <= lw.listFailures {
+		return listwatch.ListResponse[T]{}, fmt.Errorf("stub list failure %d", n)
+	}
+	if lw.listErr != nil {
+		return listwatch.ListResponse[T]{}, lw.listErr
+	}
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	callIdx := int(n) - lw.listFailures - 1
+	if callIdx < len(lw.listRespQueue) {
+		return lw.listRespQueue[callIdx], nil
+	}
+	return lw.listResp, nil
+}
+
+func (lw *stubListWatcher[T]) Watch(_ context.Context, resourceVersion string) (listwatch.Watcher[T], error) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	lw.watchRVs = append(lw.watchRVs, resourceVersion)
+	idx := int(lw.watchCalls.Add(1)) - 1
+	if lw.watchErr != nil {
+		return nil, lw.watchErr
+	}
+	if idx < len(lw.watchers) {
+		return lw.watchers[idx], nil
+	}
+	// No more scripted watchers — return an already-closed stream so the
+	// Runner's watch loop exits cleanly instead of blocking forever.
+	w := newStubWatcher[T](nil, nil)
+	w.closeNow()
+	return w, nil
+}
+
+// enqueueRecorder collects WorkItemKeys passed to a Runner's Enqueue
+// callback under a mutex, so tests can safely read them from a different
+// goroutine than the one running Runner.Run.
+type enqueueRecorder struct {
+	mu   sync.Mutex
+	keys []types.WorkItemKey
+}
+
+func (e *enqueueRecorder) record(k types.WorkItemKey) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.keys = append(e.keys, k)
+	return nil
+}
+
+func (e *enqueueRecorder) snapshot() []types.WorkItemKey {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]types.WorkItemKey, len(e.keys))
+	copy(out, e.keys)
+	return out
+}
+
+func (e *enqueueRecorder) len() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.keys)
+}
+
+func newRunner(t *testing.T, lw *stubListWatcher[widget], store checkpoint.Store) (*listwatch.Runner[widget], *cache.Cache[widget], *enqueueRecorder) {
+	t.Helper()
+	c := cache.New[widget]()
+	rec := &enqueueRecorder{}
+	r := &listwatch.Runner[widget]{
+		Kind:                "Widget",
+		ListWatcher:         lw,
+		Cache:               c,
+		Store:               store,
+		KeyFunc:             widgetKey,
+		RevisionFunc:        widgetRevision,
+		FlushIntervalEvents: 100,
+		MaxBackoff:          time.Second,
+		Enqueue:             rec.record,
+	}
+	return r, c, rec
+}
+
+func TestRunner_Bootstrap_ListsAndEnqueuesAll(t *testing.T) {
+	items := make([]widget, 0, 50)
+	for i := range 50 {
+		items = append(items, widget{Namespace: "ns", Name: fmt.Sprintf("w%d", i), ResourceVersion: "1"})
+	}
+	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{Items: items, ResourceVersion: "100"}}
+	r, c, enqueued := newRunner(t, lw, checkpoint.NewMemoryStore())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	if !c.HasSynced() {
+		t.Fatal("expected cache to be synced after bootstrap list")
+	}
+	if enqueued.len() != 50 {
+		t.Errorf("expected 50 enqueued keys, got %d", enqueued.len())
+	}
+}
+
+func TestRunner_Bootstrap_NoDispatchBeforeSynced(t *testing.T) {
+	lw := &stubListWatcher[widget]{
+		listErr: errors.New("api unavailable"),
+	}
+	r, c, enqueued := newRunner(t, lw, checkpoint.NewMemoryStore())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+	<-done
+
+	if c.HasSynced() {
+		t.Error("expected cache NOT synced while List keeps failing")
+	}
+	if enqueued.len() != 0 {
+		t.Errorf("expected zero enqueued keys while List keeps failing, got %d", enqueued.len())
+	}
+}
+
+func TestRunner_Bootstrap_NoDuplicateAcrossListWatchTransition(t *testing.T) {
+	w := widget{Namespace: "ns", Name: "dup", ResourceVersion: "5"}
+	lw := &stubListWatcher[widget]{
+		listResp: listwatch.ListResponse[widget]{Items: []widget{w}, ResourceVersion: "5"},
+	}
+	dupEvent := listwatch.WatchEvent[widget]{Type: listwatch.Added, Object: w, ResourceVersion: "5"}
+	sw := newStubWatcher([]listwatch.WatchEvent[widget]{dupEvent}, nil)
+	lw.watchers = []*stubWatcher[widget]{sw}
+
+	r, _, enqueued := newRunner(t, lw, checkpoint.NewMemoryStore())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	count := 0
+	for _, k := range enqueued.snapshot() {
+		if k == widgetKey(w) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected key to be enqueued exactly once across list-watch transition, got %d", count)
+	}
+}
+
+func TestRunner_Bootstrap_ListFailure_RetriesWithBackoff_NeverMarksSynced(t *testing.T) {
+	w := widget{Namespace: "ns", Name: "w1", ResourceVersion: "1"}
+	lw := &stubListWatcher[widget]{
+		listFailures: 3,
+		listResp:     listwatch.ListResponse[widget]{Items: []widget{w}, ResourceVersion: "10"},
+	}
+	r, c, enqueued := newRunner(t, lw, checkpoint.NewMemoryStore())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if c.HasSynced() {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("cache never synced after List eventually succeeded")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	if lw.listCalls.Load() < 4 {
+		t.Errorf("expected at least 4 List calls (3 failures + 1 success), got %d", lw.listCalls.Load())
+	}
+	if enqueued.len() != 1 {
+		t.Errorf("expected exactly 1 enqueued key after eventual success, got %d", enqueued.len())
+	}
+	cancel()
+	<-done
+}

--- a/gitstore-controller-manager/tests/contract/listwatch_bootstrap_test.go
+++ b/gitstore-controller-manager/tests/contract/listwatch_bootstrap_test.go
@@ -5,6 +5,7 @@ package contract_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -86,10 +87,11 @@ type stubListWatcher[T any] struct {
 	listFailures  int // number of times List fails before succeeding
 	listCalls     atomic.Int32
 
-	watchers   []*stubWatcher[T]
-	watchCalls atomic.Int32
-	watchRVs   []string // resourceVersion argument observed on each Watch call
-	watchErr   error
+	watchers      []*stubWatcher[T]
+	watchCalls    atomic.Int32
+	watchRVs      []string // resourceVersion argument observed on each Watch call
+	watchErr      error
+	watchErrQueue []error
 }
 
 func (lw *stubListWatcher[T]) List(_ context.Context) (listwatch.ListResponse[T], error) {
@@ -114,6 +116,9 @@ func (lw *stubListWatcher[T]) Watch(_ context.Context, resourceVersion string) (
 	defer lw.mu.Unlock()
 	lw.watchRVs = append(lw.watchRVs, resourceVersion)
 	idx := int(lw.watchCalls.Add(1)) - 1
+	if idx < len(lw.watchErrQueue) && lw.watchErrQueue[idx] != nil {
+		return nil, lw.watchErrQueue[idx]
+	}
 	if lw.watchErr != nil {
 		return nil, lw.watchErr
 	}
@@ -125,6 +130,23 @@ func (lw *stubListWatcher[T]) Watch(_ context.Context, resourceVersion string) (
 	w := newStubWatcher[T](nil, nil)
 	w.closeNow()
 	return w, nil
+}
+
+func widgetCheckpoint(t *testing.T, resourceVersion string, items []widget, replayKeys ...types.WorkItemKey) checkpoint.Record {
+	t.Helper()
+	if items == nil {
+		items = []widget{}
+	}
+	snapshot, err := json.Marshal(items)
+	if err != nil {
+		t.Fatalf("marshal checkpoint snapshot: %v", err)
+	}
+	return checkpoint.Record{
+		Kind:            "Widget",
+		ResourceVersion: resourceVersion,
+		Snapshot:        snapshot,
+		ReplayKeys:      replayKeys,
+	}
 }
 
 // enqueueRecorder collects WorkItemKeys passed to a Runner's Enqueue
@@ -179,6 +201,7 @@ func TestRunner_Bootstrap_ListsAndEnqueuesAll(t *testing.T) {
 	for i := range 50 {
 		items = append(items, widget{Namespace: "ns", Name: fmt.Sprintf("w%d", i), ResourceVersion: "1"})
 	}
+
 	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{Items: items, ResourceVersion: "100"}}
 	r, c, enqueued := newRunner(t, lw, checkpoint.NewMemoryStore())
 
@@ -198,6 +221,38 @@ func TestRunner_Bootstrap_ListsAndEnqueuesAll(t *testing.T) {
 	if enqueued.len() != 50 {
 		t.Errorf("expected 50 enqueued keys, got %d", enqueued.len())
 	}
+}
+
+func TestRunner_Bootstrap_PersistsListCheckpointBeforeWatch(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	item := widget{Namespace: "ns", Name: "a", ResourceVersion: "1"}
+	lw := &stubListWatcher[widget]{
+		listResp: listwatch.ListResponse[widget]{Items: []widget{item}, ResourceVersion: "100"},
+	}
+	r, _, _ := newRunner(t, lw, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(200 * time.Millisecond)
+	for {
+		rec, err := store.Load(context.Background(), "Widget")
+		if err == nil {
+			if rec.ResourceVersion != "100" {
+				t.Fatalf("checkpoint ResourceVersion = %q, want 100", rec.ResourceVersion)
+			}
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("bootstrap list checkpoint was not persisted")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
 }
 
 func TestRunner_Bootstrap_NoDispatchBeforeSynced(t *testing.T) {

--- a/gitstore-controller-manager/tests/contract/listwatch_expiry_test.go
+++ b/gitstore-controller-manager/tests/contract/listwatch_expiry_test.go
@@ -70,6 +70,7 @@ func TestRunner_ExpiryRecovery_EnqueuesOnlyChangedResources(t *testing.T) {
 			{Items: []widget{unchanged, changedBefore}, ResourceVersion: "10"},
 		},
 	}
+
 	expiredWatcher := newStubWatcher[widget](nil, listwatch.ErrWatchExpired)
 	expiredWatcher.closeNow()
 	finalWatcher := newStubWatcher[widget](nil, nil)
@@ -117,6 +118,50 @@ func TestRunner_ExpiryRecovery_EnqueuesOnlyChangedResources(t *testing.T) {
 	// re-list diff, since its revision changed from 1 to 2.
 	if changedCount != 2 {
 		t.Errorf("expected 'changed' to be enqueued twice (bootstrap + re-list diff), got %d", changedCount)
+	}
+}
+
+func TestRunner_ExpiryRecovery_RemovesAndEnqueuesMissingResources(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	deleted := widget{Namespace: "ns", Name: "deleted", ResourceVersion: "1"}
+	lw := &stubListWatcher[widget]{
+		listResp: listwatch.ListResponse[widget]{ResourceVersion: "20"},
+		listRespQueue: []listwatch.ListResponse[widget]{
+			{Items: []widget{deleted}, ResourceVersion: "10"},
+		},
+	}
+	expired := newStubWatcher[widget](nil, listwatch.ErrWatchExpired)
+	expired.closeNow()
+	lw.watchers = []*stubWatcher[widget]{expired}
+
+	r, c, enqueued := newRunner(t, lw, store)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(800 * time.Millisecond)
+	for lw.listCalls.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatal("expected expiry recovery re-list")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+
+	if _, ok := c.Get(widgetKey(deleted)); ok {
+		t.Error("expected resource omitted from recovery snapshot to be removed from cache")
+	}
+	count := 0
+	for _, key := range enqueued.snapshot() {
+		if key == widgetKey(deleted) {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("deleted key enqueue count = %d, want 2 (bootstrap and deletion)", count)
 	}
 }
 

--- a/gitstore-controller-manager/tests/contract/listwatch_expiry_test.go
+++ b/gitstore-controller-manager/tests/contract/listwatch_expiry_test.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package contract_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/listwatch"
+)
+
+func TestRunner_ExpiryRecovery_DiscardsCheckpointAndRelists(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	lw := &stubListWatcher[widget]{
+		listResp: listwatch.ListResponse[widget]{
+			Items:           []widget{{Namespace: "ns", Name: "a", ResourceVersion: "1"}},
+			ResourceVersion: "100",
+		},
+	}
+	expiredWatcher := newStubWatcher[widget](nil, listwatch.ErrWatchExpired)
+	expiredWatcher.closeNow()
+	finalWatcher := newStubWatcher[widget](nil, nil)
+	finalWatcher.closeNow()
+	lw.watchers = []*stubWatcher[widget]{expiredWatcher, finalWatcher}
+
+	r, _, _ := newRunner(t, lw, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(800 * time.Millisecond)
+	for lw.listCalls.Load() < 1 {
+		select {
+		case <-deadline:
+			t.Fatal("expected a re-list after watch cursor expired")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+
+	if lw.watchCalls.Load() < 2 {
+		t.Fatalf("expected at least 2 Watch calls (initial expired + post-relist), got %d", lw.watchCalls.Load())
+	}
+	// The reconnect after re-list must use the fresh list's resourceVersion
+	// (100), not the stale cursor from before expiry.
+	if lw.watchRVs[len(lw.watchRVs)-1] != "100" {
+		t.Errorf("post-relist Watch resourceVersion = %q, want 100", lw.watchRVs[len(lw.watchRVs)-1])
+	}
+}
+
+func TestRunner_ExpiryRecovery_EnqueuesOnlyChangedResources(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	unchanged := widget{Namespace: "ns", Name: "unchanged", ResourceVersion: "1"}
+	changedBefore := widget{Namespace: "ns", Name: "changed", ResourceVersion: "1"}
+	changedAfter := widget{Namespace: "ns", Name: "changed", ResourceVersion: "2"}
+
+	// First List (bootstrap) returns both at revision "1". After expiry, the
+	// re-list reports "unchanged" still at "1" but "changed" now at "2" — so
+	// only "changed" should be re-enqueued by the expiry-recovery diff.
+	lw := &stubListWatcher[widget]{
+		listResp: listwatch.ListResponse[widget]{Items: []widget{unchanged, changedAfter}, ResourceVersion: "20"},
+		listRespQueue: []listwatch.ListResponse[widget]{
+			{Items: []widget{unchanged, changedBefore}, ResourceVersion: "10"},
+		},
+	}
+	expiredWatcher := newStubWatcher[widget](nil, listwatch.ErrWatchExpired)
+	expiredWatcher.closeNow()
+	finalWatcher := newStubWatcher[widget](nil, nil)
+	finalWatcher.closeNow()
+	lw.watchers = []*stubWatcher[widget]{expiredWatcher, finalWatcher}
+
+	r, c, enqueued := newRunner(t, lw, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(800 * time.Millisecond)
+	for lw.listCalls.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatal("expected a re-list after watch cursor expired")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+
+	if cached, ok := c.Get(widgetKey(changedAfter)); !ok || cached.ResourceVersion != "2" {
+		t.Errorf("expected cache to hold the re-listed changed resource at revision 2, got %+v (ok=%v)", cached, ok)
+	}
+
+	unchangedCount, changedCount := 0, 0
+	for _, k := range enqueued.snapshot() {
+		if k.Name == "unchanged" {
+			unchangedCount++
+		}
+		if k.Name == "changed" {
+			changedCount++
+		}
+	}
+	// "unchanged" is enqueued once (from the initial bootstrap list) but
+	// never again by the re-list diff, since its revision didn't change.
+	if unchangedCount != 1 {
+		t.Errorf("expected 'unchanged' to be enqueued exactly once (bootstrap only), got %d", unchangedCount)
+	}
+	// "changed" is enqueued once from bootstrap and once more from the
+	// re-list diff, since its revision changed from 1 to 2.
+	if changedCount != 2 {
+		t.Errorf("expected 'changed' to be enqueued twice (bootstrap + re-list diff), got %d", changedCount)
+	}
+}
+
+func TestRunner_ExpiryRecovery_RepeatedExpiry_NoLostWorkItems(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	firstRoundOnly := widget{Namespace: "ns", Name: "round1", ResourceVersion: "1"}
+	secondRoundOnly := widget{Namespace: "ns", Name: "round2", ResourceVersion: "1"}
+
+	lw := &stubListWatcher[widget]{
+		listResp: listwatch.ListResponse[widget]{Items: []widget{firstRoundOnly, secondRoundOnly}, ResourceVersion: "2"},
+		listRespQueue: []listwatch.ListResponse[widget]{
+			{Items: []widget{firstRoundOnly}, ResourceVersion: "1"},
+			{Items: []widget{firstRoundOnly, secondRoundOnly}, ResourceVersion: "2"},
+		},
+	}
+	expired1 := newStubWatcher[widget](nil, listwatch.ErrWatchExpired)
+	expired1.closeNow()
+	expired2 := newStubWatcher[widget](nil, listwatch.ErrWatchExpired)
+	expired2.closeNow()
+	final := newStubWatcher[widget](nil, nil)
+	final.closeNow()
+	lw.watchers = []*stubWatcher[widget]{expired1, expired2, final}
+
+	r, _, enqueued := newRunner(t, lw, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(1500 * time.Millisecond)
+	for lw.listCalls.Load() < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("expected 3 List calls (initial + 2 expiry recoveries), got %d", lw.listCalls.Load())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+
+	keys := enqueued.snapshot()
+	seen := map[string]bool{}
+	for _, k := range keys {
+		seen[k.Name] = true
+	}
+	if !seen["round1"] {
+		t.Error("expected round1 resource to have been enqueued at least once")
+	}
+	if !seen["round2"] {
+		t.Error("expected round2 resource to have been enqueued at least once")
+	}
+}

--- a/gitstore-controller-manager/tests/contract/listwatch_resume_test.go
+++ b/gitstore-controller-manager/tests/contract/listwatch_resume_test.go
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package contract_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/health"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/listwatch"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// failingStore wraps a checkpoint.Store, failing the first N Save calls.
+type failingStore struct {
+	mu        sync.Mutex
+	inner     checkpoint.Store
+	failCount int
+	saveCalls atomic.Int32
+	savedRVs  []string
+}
+
+func (s *failingStore) Load(ctx context.Context, kind string) (checkpoint.Record, error) {
+	return s.inner.Load(ctx, kind)
+}
+
+func (s *failingStore) Save(ctx context.Context, rec checkpoint.Record) error {
+	n := s.saveCalls.Add(1)
+	if int(n) <= s.failCount {
+		return fmt.Errorf("stub save failure %d", n)
+	}
+	s.mu.Lock()
+	s.savedRVs = append(s.savedRVs, rec.ResourceVersion)
+	s.mu.Unlock()
+	return s.inner.Save(ctx, rec)
+}
+
+func (s *failingStore) savedCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.savedRVs)
+}
+
+func TestRunner_Resume_SkipsListPhase(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	if err := store.Save(context.Background(), checkpoint.Record{Kind: "Widget", ResourceVersion: "500"}); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	lw := &stubListWatcher[widget]{}
+	r, c, _ := newRunner(t, lw, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+	<-done
+
+	if lw.listCalls.Load() != 0 {
+		t.Errorf("expected List to never be called on resume, got %d calls", lw.listCalls.Load())
+	}
+	if !c.HasSynced() {
+		t.Error("expected cache synced immediately on resume (no list phase needed)")
+	}
+}
+
+func TestRunner_Resume_WatchesFromCheckpointedVersion(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	if err := store.Save(context.Background(), checkpoint.Record{Kind: "Widget", ResourceVersion: "500"}); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	lw := &stubListWatcher[widget]{}
+	r, _, _ := newRunner(t, lw, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+	<-done
+
+	if lw.watchCalls.Load() == 0 {
+		t.Fatal("expected Watch to be called")
+	}
+	if lw.watchRVs[0] != "500" {
+		t.Errorf("first Watch resourceVersion = %q, want 500", lw.watchRVs[0])
+	}
+}
+
+func TestRunner_Flush_PersistsAfterNEvents(t *testing.T) {
+	store := &failingStore{inner: checkpoint.NewMemoryStore()}
+	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
+	events := []listwatch.WatchEvent[widget]{
+		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "a"}, ResourceVersion: "1"},
+		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "b"}, ResourceVersion: "2"},
+		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "c"}, ResourceVersion: "3"},
+	}
+	sw := newStubWatcher(events, nil)
+	lw.watchers = []*stubWatcher[widget]{sw}
+
+	r, _, _ := newRunner(t, lw, store)
+	r.FlushIntervalEvents = 3
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(400 * time.Millisecond)
+	for store.savedCount() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("expected a Save after 3 events, got none")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if store.savedRVs[0] != "3" {
+		t.Errorf("first flush ResourceVersion = %q, want 3", store.savedRVs[0])
+	}
+	cancel()
+	<-done
+}
+
+func TestRunner_Flush_PersistsOnCleanShutdown(t *testing.T) {
+	store := &failingStore{inner: checkpoint.NewMemoryStore()}
+	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
+	events := []listwatch.WatchEvent[widget]{
+		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "a"}, ResourceVersion: "1"},
+	}
+	sw := newStubWatcher(events, nil)
+	lw.watchers = []*stubWatcher[widget]{sw}
+
+	r, _, _ := newRunner(t, lw, store)
+	r.FlushIntervalEvents = 100 // won't hit the flush boundary naturally
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	<-done
+
+	if store.savedCount() == 0 {
+		t.Error("expected a final flush on clean shutdown even below the flush interval")
+	}
+}
+
+func TestRunner_Backpressure_PausesOnWriteFailure_ResumesOnSuccess(t *testing.T) {
+	store := &failingStore{inner: checkpoint.NewMemoryStore(), failCount: 2}
+	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
+	events := []listwatch.WatchEvent[widget]{
+		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "a"}, ResourceVersion: "1"},
+		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "b"}, ResourceVersion: "2"},
+	}
+	sw := newStubWatcher(events, nil)
+	lw.watchers = []*stubWatcher[widget]{sw}
+
+	r, _, enqueued := newRunner(t, lw, store)
+	r.FlushIntervalEvents = 1 // flush after the very first event
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	// While Save keeps failing, the second event must not be drained.
+	time.Sleep(150 * time.Millisecond)
+	if enqueued.len() > 1 {
+		t.Errorf("expected at most 1 event processed while checkpoint writes are failing, got %d", enqueued.len())
+	}
+	failuresBefore := testutil.ToFloat64(health.CheckpointWriteFailuresTotal.WithLabelValues("Widget"))
+	if failuresBefore < 2 {
+		t.Errorf("expected at least 2 recorded write failures, got %v", failuresBefore)
+	}
+
+	deadline := time.After(1 * time.Second)
+	for store.savedCount() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("expected Save to eventually succeed and unblock consumption")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+}
+
+func TestRunner_Backpressure_BoundedReplayWindow(t *testing.T) {
+	store := &failingStore{inner: checkpoint.NewMemoryStore(), failCount: 5}
+	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
+	var events []listwatch.WatchEvent[widget]
+	for i := 1; i <= 10; i++ {
+		events = append(events, listwatch.WatchEvent[widget]{
+			Type:            listwatch.Added,
+			Object:          widget{Namespace: "ns", Name: fmt.Sprintf("w%d", i)},
+			ResourceVersion: fmt.Sprintf("%d", i),
+		})
+	}
+	sw := newStubWatcher(events, nil)
+	lw.watchers = []*stubWatcher[widget]{sw}
+
+	r, _, enqueued := newRunner(t, lw, store)
+	r.FlushIntervalEvents = 2 // flush boundary every 2 events
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	// While Save keeps failing (5 failures configured), no more than
+	// FlushIntervalEvents events should ever be unpersisted at once.
+	time.Sleep(200 * time.Millisecond)
+	if enqueued.len() > 2 {
+		t.Errorf("expected at most FlushIntervalEvents=2 events processed while writes fail, got %d", enqueued.len())
+	}
+	cancel()
+	<-done
+}
+
+func TestRunner_TransientReconnect_UsesInMemoryCheckpoint_NotPersisted(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	if err := store.Save(context.Background(), checkpoint.Record{Kind: "Widget", ResourceVersion: "10"}); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	lw := &stubListWatcher[widget]{}
+	// First watcher: delivers one event advancing currentRV to "20", then
+	// closes with a transient (non-expiry) error.
+	firstEvents := []listwatch.WatchEvent[widget]{
+		{Type: listwatch.Bookmark, ResourceVersion: "20"},
+	}
+	firstWatcher := newStubWatcher(firstEvents, errors.New("transient network error"))
+	firstWatcher.closeNow()
+	secondWatcher := newStubWatcher[widget](nil, nil)
+	secondWatcher.closeNow()
+	lw.watchers = []*stubWatcher[widget]{firstWatcher, secondWatcher}
+
+	r, _, _ := newRunner(t, lw, store)
+	r.MaxBackoff = 50 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(800 * time.Millisecond)
+	for lw.watchCalls.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatal("expected a reconnect Watch call after transient close")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+
+	if lw.watchRVs[0] != "10" {
+		t.Errorf("initial Watch resourceVersion = %q, want 10 (from persisted checkpoint)", lw.watchRVs[0])
+	}
+	if lw.watchRVs[1] != "20" {
+		t.Errorf("reconnect Watch resourceVersion = %q, want 20 (in-memory cursor, not persisted 10)", lw.watchRVs[1])
+	}
+}
+
+func TestRunner_TransientReconnect_BackoffCappedAtMax(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
+
+	const attempts = 4
+	watchers := make([]*stubWatcher[widget], 0, attempts+1)
+	for range attempts {
+		w := newStubWatcher[widget](nil, errors.New("transient"))
+		w.closeNow()
+		watchers = append(watchers, w)
+	}
+	final := newStubWatcher[widget](nil, nil)
+	final.closeNow()
+	watchers = append(watchers, final)
+	lw.watchers = watchers
+
+	r, _, _ := newRunner(t, lw, store)
+	r.MaxBackoff = 40 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(2 * time.Second)
+	for lw.watchCalls.Load() < int32(attempts+1) {
+		select {
+		case <-deadline:
+			t.Fatalf("expected %d reconnect attempts, got %d", attempts+1, lw.watchCalls.Load())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	elapsed := time.Since(start)
+	cancel()
+	<-done
+
+	// With MaxBackoff=40ms and 4 reconnects, elapsed time must stay bounded
+	// (well under what an unbounded/uncapped exponential backoff would take).
+	if elapsed > 2*time.Second {
+		t.Errorf("reconnect attempts took %v, expected backoff capped near MaxBackoff", elapsed)
+	}
+}

--- a/gitstore-controller-manager/tests/contract/listwatch_resume_test.go
+++ b/gitstore-controller-manager/tests/contract/listwatch_resume_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint"
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/health"
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/listwatch"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/types"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
@@ -50,7 +51,7 @@ func (s *failingStore) savedCount() int {
 
 func TestRunner_Resume_SkipsListPhase(t *testing.T) {
 	store := checkpoint.NewMemoryStore()
-	if err := store.Save(context.Background(), checkpoint.Record{Kind: "Widget", ResourceVersion: "500"}); err != nil {
+	if err := store.Save(context.Background(), widgetCheckpoint(t, "500", nil)); err != nil {
 		t.Fatalf("seed Save: %v", err)
 	}
 
@@ -74,7 +75,7 @@ func TestRunner_Resume_SkipsListPhase(t *testing.T) {
 
 func TestRunner_Resume_WatchesFromCheckpointedVersion(t *testing.T) {
 	store := checkpoint.NewMemoryStore()
-	if err := store.Save(context.Background(), checkpoint.Record{Kind: "Widget", ResourceVersion: "500"}); err != nil {
+	if err := store.Save(context.Background(), widgetCheckpoint(t, "500", nil)); err != nil {
 		t.Fatalf("seed Save: %v", err)
 	}
 
@@ -96,8 +97,41 @@ func TestRunner_Resume_WatchesFromCheckpointedVersion(t *testing.T) {
 	}
 }
 
+func TestRunner_Resume_RestoresCacheAndReplaysDurableWork(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	item := widget{Namespace: "ns", Name: "a", ResourceVersion: "5"}
+	deletedKey := types.WorkItemKey{Kind: "Widget", Namespace: "ns", Name: "deleted"}
+	if err := store.Save(context.Background(), widgetCheckpoint(t, "500", []widget{item}, deletedKey)); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	lw := &stubListWatcher[widget]{}
+	r, c, enqueued := newRunner(t, lw, store)
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+	<-done
+
+	if cached, ok := c.Get(widgetKey(item)); !ok || cached != item {
+		t.Errorf("restored cache item = %+v (ok=%v), want %+v", cached, ok, item)
+	}
+	seen := map[types.WorkItemKey]bool{}
+	for _, key := range enqueued.snapshot() {
+		seen[key] = true
+	}
+	if !seen[widgetKey(item)] || !seen[deletedKey] {
+		t.Errorf("replayed keys = %+v, want current and deleted keys", enqueued.snapshot())
+	}
+}
+
 func TestRunner_Flush_PersistsAfterNEvents(t *testing.T) {
-	store := &failingStore{inner: checkpoint.NewMemoryStore()}
+	inner := checkpoint.NewMemoryStore()
+	if err := inner.Save(context.Background(), widgetCheckpoint(t, "0", nil)); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+	store := &failingStore{inner: inner}
 	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
 	events := []listwatch.WatchEvent[widget]{
 		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "a"}, ResourceVersion: "1"},
@@ -132,7 +166,11 @@ func TestRunner_Flush_PersistsAfterNEvents(t *testing.T) {
 }
 
 func TestRunner_Flush_PersistsOnCleanShutdown(t *testing.T) {
-	store := &failingStore{inner: checkpoint.NewMemoryStore()}
+	inner := checkpoint.NewMemoryStore()
+	if err := inner.Save(context.Background(), widgetCheckpoint(t, "0", nil)); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+	store := &failingStore{inner: inner}
 	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
 	events := []listwatch.WatchEvent[widget]{
 		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "a"}, ResourceVersion: "1"},
@@ -159,7 +197,11 @@ func TestRunner_Flush_PersistsOnCleanShutdown(t *testing.T) {
 }
 
 func TestRunner_Backpressure_PausesOnWriteFailure_ResumesOnSuccess(t *testing.T) {
-	store := &failingStore{inner: checkpoint.NewMemoryStore(), failCount: 2}
+	inner := checkpoint.NewMemoryStore()
+	if err := inner.Save(context.Background(), widgetCheckpoint(t, "0", nil)); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+	store := &failingStore{inner: inner, failCount: 2}
 	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
 	events := []listwatch.WatchEvent[widget]{
 		{Type: listwatch.Added, Object: widget{Namespace: "ns", Name: "a"}, ResourceVersion: "1"},
@@ -200,7 +242,11 @@ func TestRunner_Backpressure_PausesOnWriteFailure_ResumesOnSuccess(t *testing.T)
 }
 
 func TestRunner_Backpressure_BoundedReplayWindow(t *testing.T) {
-	store := &failingStore{inner: checkpoint.NewMemoryStore(), failCount: 5}
+	inner := checkpoint.NewMemoryStore()
+	if err := inner.Save(context.Background(), widgetCheckpoint(t, "0", nil)); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+	store := &failingStore{inner: inner, failCount: 5}
 	lw := &stubListWatcher[widget]{listResp: listwatch.ListResponse[widget]{ResourceVersion: "0"}}
 	var events []listwatch.WatchEvent[widget]
 	for i := 1; i <= 10; i++ {
@@ -234,7 +280,7 @@ func TestRunner_Backpressure_BoundedReplayWindow(t *testing.T) {
 
 func TestRunner_TransientReconnect_UsesInMemoryCheckpoint_NotPersisted(t *testing.T) {
 	store := checkpoint.NewMemoryStore()
-	if err := store.Save(context.Background(), checkpoint.Record{Kind: "Widget", ResourceVersion: "10"}); err != nil {
+	if err := store.Save(context.Background(), widgetCheckpoint(t, "10", nil)); err != nil {
 		t.Fatalf("seed Save: %v", err)
 	}
 
@@ -275,6 +321,65 @@ func TestRunner_TransientReconnect_UsesInMemoryCheckpoint_NotPersisted(t *testin
 	}
 	if lw.watchRVs[1] != "20" {
 		t.Errorf("reconnect Watch resourceVersion = %q, want 20 (in-memory cursor, not persisted 10)", lw.watchRVs[1])
+	}
+}
+
+func TestRunner_WatchOpenExpiry_RelistsImmediately(t *testing.T) {
+	store := checkpoint.NewMemoryStore()
+	if err := store.Save(context.Background(), widgetCheckpoint(t, "10", nil)); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+	lw := &stubListWatcher[widget]{
+		listResp:      listwatch.ListResponse[widget]{ResourceVersion: "20"},
+		watchErrQueue: []error{listwatch.ErrWatchExpired},
+	}
+	r, _, _ := newRunner(t, lw, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	deadline := time.After(400 * time.Millisecond)
+	for lw.listCalls.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("expected immediate re-list after Watch rejected expired cursor")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+}
+
+func TestRunner_ReconnectCancellation_PerformsFinalFlush(t *testing.T) {
+	inner := checkpoint.NewMemoryStore()
+	if err := inner.Save(context.Background(), widgetCheckpoint(t, "0", nil)); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+	store := &failingStore{inner: inner}
+	watcher := newStubWatcher([]listwatch.WatchEvent[widget]{
+		{Type: listwatch.Bookmark, ResourceVersion: "1"},
+	}, errors.New("transient"))
+	watcher.closeNow()
+	lw := &stubListWatcher[widget]{watchers: []*stubWatcher[widget]{watcher}}
+	r, _, _ := newRunner(t, lw, store)
+	r.FlushIntervalEvents = 100
+	r.MaxBackoff = time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	rec, err := inner.Load(context.Background(), "Widget")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if rec.ResourceVersion != "1" {
+		t.Errorf("final checkpoint ResourceVersion = %q, want 1", rec.ResourceVersion)
 	}
 }
 

--- a/specs/036-controller-startup-resume/checklists/requirements.md
+++ b/specs/036-controller-startup-resume/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Controller Startup Resume
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.

--- a/specs/036-controller-startup-resume/contracts/checkpoint-store-api.md
+++ b/specs/036-controller-startup-resume/contracts/checkpoint-store-api.md
@@ -9,6 +9,8 @@
 type Record struct {
     Kind            string
     ResourceVersion string
+    Snapshot        json.RawMessage
+    ReplayKeys      []types.WorkItemKey
     WrittenAt       time.Time
 }
 
@@ -38,7 +40,7 @@ func NewFilesystemStore(dir string) (*FilesystemStore, error) // MkdirAll(dir, 0
 
 - One file per kind: `<Dir>/<kind>.checkpoint.json`.
 - `Save`: marshal `Record` to JSON, write to a temp file in `Dir` (`os.CreateTemp`), `Sync`, `Close`, then `os.Rename` to the final path. Rename is atomic on the same filesystem — this is the write-temp-then-rename guarantee required by FR-006 and the "killed mid-write" edge case.
-- `Load`: `os.ReadFile` the final path; `json.Unmarshal`. Both a missing file (`os.IsNotExist`) and a malformed-JSON file surface as a returned `error` — no sentinel differentiation.
+- `Load`: `os.ReadFile` the final path; `json.Unmarshal`; validate the kind, non-empty cursor, cache snapshot, and replay-key kinds. Missing, malformed, or semantically invalid files surface as a returned `error` — no sentinel differentiation.
 - A write or corrupted file for one kind MUST NOT affect any other kind's file (structurally guaranteed — distinct file paths).
 
 ### MemoryStore
@@ -55,5 +57,6 @@ func NewMemoryStore() *MemoryStore
 
 1. Call `Load(ctx, kind)` exactly once, at the start of `Run(ctx)`, to decide bootstrap vs. resume (FR-007/FR-008).
 2. Never call `Load` again during the lifetime of a single `Run(ctx)` call — reconnects use the in-memory cursor (FR-011, see `runner-contract.md`).
-3. Call `Save` at the configured flush interval and on clean shutdown (FR-005). On `Save` error, retry with backoff before consuming the next watch event (backpressure — FR-005, SC-004) rather than treating the failure as fatal.
-4. On `ErrWatchExpired` recovery, call `Save` with the fresh `resourceVersion` from the re-list before resuming `Watch` (FR-009).
+3. Persist the bootstrap list snapshot before marking the cache synced or opening the watch.
+4. Call `Save` at the configured flush interval and on clean shutdown (FR-005). Each record includes the current cache snapshot and deletion replay keys so a restart can rebuild volatile state and replay work that may not have completed before the process stopped. On `Save` error, retry with backoff before consuming the next watch event (backpressure — FR-005, SC-004) rather than treating the failure as fatal.
+5. On `ErrWatchExpired` recovery, call `Save` with the fresh `resourceVersion` and rebuilt snapshot from the re-list before resuming `Watch` (FR-009).

--- a/specs/036-controller-startup-resume/contracts/checkpoint-store-api.md
+++ b/specs/036-controller-startup-resume/contracts/checkpoint-store-api.md
@@ -1,0 +1,59 @@
+# Contract: CheckpointStore
+
+**Package**: `github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint`
+**Stability**: New in this spec
+
+## Interface
+
+```go
+type Record struct {
+    Kind            string
+    ResourceVersion string
+    WrittenAt       time.Time
+}
+
+type Store interface {
+    // Load returns the persisted Record for kind. Returns a non-nil error if
+    // no record exists, the file/entry cannot be read, or its contents cannot
+    // be parsed. Callers MUST treat every error identically — there is no
+    // distinction between "missing" and "corrupt" (FR-008).
+    Load(ctx context.Context, kind string) (Record, error)
+
+    // Save persists rec, keyed by rec.Kind. MUST be atomic: a concurrent Load
+    // for the same kind observes either the fully-written new Record or the
+    // previous one — never a partial write (FR-006).
+    Save(ctx context.Context, rec Record) error
+}
+```
+
+## Implementations
+
+### FilesystemStore
+
+```go
+type FilesystemStore struct { Dir string }
+
+func NewFilesystemStore(dir string) (*FilesystemStore, error) // MkdirAll(dir, 0o755)
+```
+
+- One file per kind: `<Dir>/<kind>.checkpoint.json`.
+- `Save`: marshal `Record` to JSON, write to a temp file in `Dir` (`os.CreateTemp`), `Sync`, `Close`, then `os.Rename` to the final path. Rename is atomic on the same filesystem — this is the write-temp-then-rename guarantee required by FR-006 and the "killed mid-write" edge case.
+- `Load`: `os.ReadFile` the final path; `json.Unmarshal`. Both a missing file (`os.IsNotExist`) and a malformed-JSON file surface as a returned `error` — no sentinel differentiation.
+- A write or corrupted file for one kind MUST NOT affect any other kind's file (structurally guaranteed — distinct file paths).
+
+### MemoryStore
+
+```go
+type MemoryStore struct{} // internally: mutex-guarded map[string]Record
+
+func NewMemoryStore() *MemoryStore
+```
+
+- Same `Store` interface; `Save` overwrites the map entry for `rec.Kind` under a write lock, `Load` reads under a read lock. Used only in tests — no production wiring.
+
+## Caller Obligations (the `Runner`)
+
+1. Call `Load(ctx, kind)` exactly once, at the start of `Run(ctx)`, to decide bootstrap vs. resume (FR-007/FR-008).
+2. Never call `Load` again during the lifetime of a single `Run(ctx)` call — reconnects use the in-memory cursor (FR-011, see `runner-contract.md`).
+3. Call `Save` at the configured flush interval and on clean shutdown (FR-005). On `Save` error, retry with backoff before consuming the next watch event (backpressure — FR-005, SC-004) rather than treating the failure as fatal.
+4. On `ErrWatchExpired` recovery, call `Save` with the fresh `resourceVersion` from the re-list before resuming `Watch` (FR-009).

--- a/specs/036-controller-startup-resume/contracts/listwatcher-interface.md
+++ b/specs/036-controller-startup-resume/contracts/listwatcher-interface.md
@@ -1,0 +1,74 @@
+# Contract: ListWatcher / Watcher Transport Abstraction
+
+**Package**: `github.com/gitstore-dev/gitstore/controller-manager/internal/listwatch`
+**Stability**: New in this spec. No concrete production implementation ships here — see research.md §1. Implementors targeting a real `T` (e.g. `CategoryTaxonomy` for issue #244) provide their own type satisfying these interfaces.
+
+## Interfaces
+
+```go
+type EventType int
+const (
+    Added EventType = iota
+    Modified
+    Deleted
+    Bookmark
+)
+
+type WatchEvent[T any] struct {
+    Type            EventType
+    Object          T       // zero value when Type == Bookmark; MUST NOT be read
+    ResourceVersion string  // always populated
+}
+
+type ListResponse[T any] struct {
+    Items           []T
+    ResourceVersion string  // cursor a subsequent Watch call resumes from with no gap, no dup
+}
+
+var ErrWatchExpired = errors.New("watch cursor expired: event log compacted")
+
+type Watcher[T any] interface {
+    // Events delivers watch notifications in resourceVersion order per-key
+    // (cross-key interleaving is permitted). The channel is closed when the
+    // watch ends (error, expiry, or Stop() called).
+    Events() <-chan WatchEvent[T]
+
+    // Err returns the reason Events() closed. Valid only after the channel is
+    // closed (reading it earlier is undefined). errors.Is(Err(), ErrWatchExpired)
+    // signals a compacted cursor; any other non-nil value (or nil, e.g. on a
+    // clean Stop()) signals a transient/ordinary close.
+    Err() error
+
+    // Stop ends the watch. Safe to call multiple times. MUST cause Events()
+    // to close (if not already closed) so callers blocked on it unblock.
+    Stop()
+}
+
+type ListWatcher[T any] interface {
+    // List returns a full snapshot. Implementations do not retry internally —
+    // the caller (Runner) retries with exponential backoff on error (FR-014).
+    List(ctx context.Context) (ListResponse[T], error)
+
+    // Watch opens a stream starting after resourceVersion. An empty
+    // resourceVersion means "from the beginning" (only used by the bootstrap
+    // path immediately after a successful List, using that List's own
+    // ResourceVersion — never actually empty in this spec's usage).
+    Watch(ctx context.Context, resourceVersion string) (Watcher[T], error)
+}
+```
+
+## Implementor Obligations
+
+1. `List` MUST return a `ResourceVersion` such that `Watch(ctx, thatVersion)` delivers every change that occurred after the list snapshot was taken, with no gap (FR-003).
+2. `Watch` MUST deliver events for a single resource key in `ResourceVersion` order. Interleaving across different keys is permitted (spec Edge Cases — ordering guarantees).
+3. `Watch` MUST emit `Bookmark` events (if the underlying transport supports them) carrying only `ResourceVersion` — `Object` MUST be the zero value and callers MUST NOT dereference it.
+4. When the requested `resourceVersion` has been compacted out of the transport's retained history, `Watch` (or the subsequently-closed `Watcher.Err()`) MUST return/expose an error satisfying `errors.Is(err, ErrWatchExpired)` — not a generic error — so `Runner` can distinguish "re-list required" from "just reconnect."
+5. `Stop()` MUST be idempotent and MUST NOT block indefinitely.
+
+## Caller Obligations (the `Runner`)
+
+1. MUST NOT call `Watch` before either `List` (bootstrap) or `Store.Load` (resume) has produced a starting `resourceVersion`.
+2. MUST retry `List` with exponential backoff on error, and MUST NOT call `Watch`, `Cache.MarkSynced`, or enqueue any work item until `List` succeeds (FR-014).
+3. On `Watcher.Err()` satisfying `errors.Is(err, ErrWatchExpired)`, MUST discard the current checkpoint for that kind and re-list (FR-009) rather than reconnecting at the same cursor.
+4. On any other `Watcher.Err()` (or nil, e.g. context cancellation), MUST reconnect via `Watch` using the in-memory cursor with exponential backoff capped at the configured maximum (FR-011) — MUST NOT re-list.
+5. MUST call `Stop()` on the current `Watcher` before opening a replacement one, and on `ctx.Done()`.

--- a/specs/036-controller-startup-resume/contracts/runner-contract.md
+++ b/specs/036-controller-startup-resume/contracts/runner-contract.md
@@ -1,0 +1,57 @@
+# Contract: Runner[T] — List-Then-Watch Orchestration
+
+**Package**: `github.com/gitstore-dev/gitstore/controller-manager/internal/listwatch`
+**Stability**: New in this spec. `Runner[T]` is constructed and started by `cmd/controller/main.go`, one instance per registered kind, alongside (not inside) `Manager.Register`/`Manager.Start`.
+
+## Interface
+
+```go
+type Runner[T any] struct {
+    Kind         string
+    ListWatcher  ListWatcher[T]
+    Cache        *cache.Cache[T]           // mutable — Runner is the sole writer (Set/Delete/MarkSynced)
+    Store        checkpoint.Store
+    Enqueue      func(types.WorkItemKey) error
+    KeyFunc      func(T) types.WorkItemKey
+    RevisionFunc func(T) string
+
+    FlushIntervalEvents int
+    MaxBackoff           time.Duration
+
+    Log *zap.Logger
+}
+
+// Run blocks until ctx is cancelled or an unrecoverable error occurs.
+// Exactly one Run call MUST be active per Kind at a time (FR-012) — the
+// caller (main.go) is responsible for not starting a second Runner for the
+// same kind; Runner itself does not defend against this.
+func (r *Runner[T]) Run(ctx context.Context) error
+```
+
+## Dispatch-Side Obligations (mirrors spec 026's Reconciler dispatch contract)
+
+1. `Run` MUST NOT call `Cache.MarkSynced()` until the bootstrap `List` (or a resume/re-list) has fully populated the cache via `Cache.Set` for every returned item (FR-002).
+2. `Run` MUST NOT call `Enqueue` for any key before `Cache.MarkSynced()` has been called for that kind (FR-002) — this is the producer-side half of the same gate `manager.runDispatchLoop` already enforces on the consumer side via `syncChecker`.
+3. A resource returned by the bootstrap `List` and also delivered as an `Added` `WatchEvent` for the same key during the list-to-watch transition window MUST be enqueued exactly once, not twice (FR-003, SC-008). Mechanism: `Run` retains the set of keys enqueued during bootstrap until the first watch event with a `ResourceVersion` strictly newer than the list's `ResourceVersion` is observed for that key; an `Added` event whose `ResourceVersion` matches (or is not newer than) the list snapshot is treated as a duplicate and only updates the cache (`Cache.Set`), without a second `Enqueue`.
+4. `Bookmark` events MUST update `currentRV` and, at the next flush boundary, the persisted checkpoint — MUST NOT call `Enqueue` (FR-010).
+5. `Deleted` events MUST call `Cache.Delete` before `Enqueue`, so a reconciler that reads the cache after dequeue observes the deletion (mirrors spec 026's `CacheAccessor.Get` returning `(zero, false)` → `TerminalFailure` convention).
+6. A resource deleted between `List` completing and `Watch` opening MUST NOT be enqueued from the list snapshot once the corresponding `Deleted` event arrives — `Run` MUST apply `Cache.Delete` and skip/cancel the pending enqueue for that key if it has not yet been dispatched (spec Edge Cases). In practice: the `Deleted` event's `Cache.Delete` + `Enqueue` still fires (the reconciler will observe `(zero, false)` from its cache read and return `TerminalFailure`/no-op) — `Run` does not need special-case suppression here because the reconcile contract already handles "key present in queue, absent in cache" correctly.
+
+## Checkpoint Obligations
+
+1. Exactly one `Store.Load` call per `Run` invocation, at entry, to decide bootstrap vs. resume (FR-007, FR-008).
+2. `Store.Save` at every `FlushIntervalEvents`-th processed event and once more on `ctx.Done()` (best-effort — a failed final flush on shutdown is logged, not retried indefinitely, since the process is exiting) (FR-005).
+3. On `Store.Save` failure at a flush boundary, `Run` MUST retry with backoff and MUST NOT consume the next `WatchEvent` from `Watcher.Events()` until a `Save` succeeds (backpressure — FR-005, SC-004). `Run` MUST increment `health.CheckpointWriteFailuresTotal{kind}` on every failed attempt and MUST NOT halt the process or the loop entirely — only pause event consumption (FR-013 edge case: "continues processing events without halting").
+4. On successful `Save`, `Run` MUST set `health.CheckpointLastWriteTimestamp{kind}` to the current Unix timestamp.
+
+## Reconnect / Expiry Obligations
+
+1. A transient `Watcher` close (`Err()` not `ErrWatchExpired`, including a `nil` `Err()` from a clean `Stop()` during shutdown) triggers a reconnect at the in-memory `currentRV` — MUST NOT call `Store.Load` (FR-011, research.md §5).
+2. Reconnect backoff MUST be exponential, capped at `MaxBackoff`, and MUST be retried indefinitely (not bounded by an attempt count) until `ctx` is cancelled — connection retries are architecturally distinct from the bounded-attempt `internal/retry` package used for per-item reconcile retries (research.md §3 in plan.md's Technical Context; a connection that never recovers should not "quarantine," it should keep trying).
+3. An `ErrWatchExpired` close triggers: discard in-memory `currentRV` and any pending flush state → re-list (retried with backoff per FR-014's pattern, reusing the bootstrap retry path) → for each re-listed item, `Cache.Set` always; `Enqueue` only if `RevisionFunc(item)` differs from the previously cached object's revision (or the key was absent) → `Store.Save` the new list's `ResourceVersion` → resume `Watch` at the new cursor (FR-009, US3 AC2).
+4. Repeated expiry (the re-list's own subsequent `Watch` immediately expiring again) MUST NOT lose work items — each re-list cycle is independently correct via the same diff-and-enqueue logic (US3 AC3); `Run`'s single-loop structure means repeated expiry simply repeats step 3 with no additional state to reset.
+
+## Test Fixtures Expected
+
+- `stubListWatcher[T]` — in-memory `ListWatcher[T]` implementation for tests, configurable to: return a fixed `ListResponse[T]`, fail N times before succeeding (to test FR-014 retry), and produce a scripted sequence of `WatchEvent[T]` (including `Bookmark` and a forced `ErrWatchExpired` close) via a test-controlled channel.
+- Mirrors the existing test-double convention in `tests/contract/` (e.g. `stubReconciler`, `stateReadingReconciler` from spec 026) — no mocking framework, hand-written structs implementing the interface directly.

--- a/specs/036-controller-startup-resume/data-model.md
+++ b/specs/036-controller-startup-resume/data-model.md
@@ -1,0 +1,241 @@
+# Data Model: Controller Startup Resume (spec 036)
+
+## Entities
+
+### Checkpoint (`Record`)
+
+**Package**: `github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint`
+
+**Description**: A persisted record binding a resource kind to the `resourceVersion` of the last event (or list completion) successfully processed. Spec's "Checkpoint" entity.
+
+```go
+type Record struct {
+    Kind            string
+    ResourceVersion string
+    WrittenAt       time.Time
+}
+```
+
+**Invariants**:
+- `Kind` MUST be non-empty and MUST match the file/map key it is stored under.
+- `ResourceVersion` is an opaque string — never parsed numerically or compared with `<`/`>` (per spec Assumptions); only equality and "cursor to resume from" semantics apply.
+- `WrittenAt` is informational (used to derive checkpoint age for FR-013/US4); it is NOT used for correctness decisions.
+
+---
+
+### CheckpointStore
+
+**Package**: `internal/checkpoint`
+
+**Description**: The storage abstraction responsible for reading and writing `Record`s. Writes are atomic. Two implementations: filesystem (production) and in-memory (tests).
+
+```go
+type Store interface {
+    Load(ctx context.Context, kind string) (Record, error)
+    Save(ctx context.Context, rec Record) error
+}
+```
+
+| Method | Behaviour |
+|--------|-----------|
+| `Load` | Returns a non-nil error if the record for `kind` is missing, unreadable, or corrupt. Callers (the `Runner`) treat every error identically — fall back to bootstrap (FR-008). No distinct error types are exposed for "missing" vs. "corrupt"; the spec does not require differentiated handling. |
+| `Save` | MUST be atomic: the record for `kind` is either fully written and readable, or the previous record is unchanged — never partially written (FR-006). |
+
+**Implementations**:
+
+| Type | Storage | Isolation |
+|------|---------|-----------|
+| `FilesystemStore{Dir string}` | One JSON file per kind: `<Dir>/<kind>.checkpoint.json`. `Save` writes to a temp file in `Dir` then `os.Rename`s into place. | A write or corrupted file for kind A never touches kind B's file (per clarification: one file per kind). |
+| `MemoryStore` | `map[string]Record` guarded by `sync.RWMutex`. | Per-process; used only in tests. |
+
+**Relationships**: One `Store` instance is shared across all kinds (both implementations key internally by `kind`); each `Runner[T]` calls `Load`/`Save` passing its own kind name.
+
+---
+
+### ListResponse[T]
+
+**Package**: `internal/listwatch`
+
+**Description**: The result of a full list request to the API for a given kind: a snapshot of all current resources and the `resourceVersion` at the time of the snapshot.
+
+```go
+type ListResponse[T any] struct {
+    Items           []T
+    ResourceVersion string
+}
+```
+
+**Invariants**: `ResourceVersion` MUST be the cursor value that a subsequent `Watch` call at this version will resume from with no gap and no duplicate relative to the moment the list snapshot was taken (FR-003).
+
+---
+
+### WatchEvent[T] / EventType
+
+**Package**: `internal/listwatch`
+
+**Description**: A streaming change notification delivered after a list.
+
+```go
+type EventType int
+const (
+    Added EventType = iota
+    Modified
+    Deleted
+    Bookmark
+)
+
+type WatchEvent[T any] struct {
+    Type            EventType
+    Object          T       // zero value when Type == Bookmark
+    ResourceVersion string
+}
+```
+
+**Invariants**:
+- Every variant carries `ResourceVersion`; `Bookmark` carries only the version (`Object` is the zero value and MUST NOT be interpreted).
+- Events for a single resource (same key) are delivered in `ResourceVersion` order; events for different resources may interleave (spec Edge Cases).
+- `Bookmark` events update the checkpoint cursor but MUST NOT cause an enqueue (FR-010).
+
+---
+
+### ListWatcher[T] / Watcher[T]
+
+**Package**: `internal/listwatch`
+
+**Description**: The transport abstraction the `Runner` depends on. No concrete implementation ships in this spec (see research.md §1) — production wiring is deferred to the spec that introduces the first real `T` (e.g. issue #244).
+
+```go
+type Watcher[T any] interface {
+    Events() <-chan WatchEvent[T]
+    Err() error   // valid only after Events() is closed; may be ErrWatchExpired
+    Stop()
+}
+
+type ListWatcher[T any] interface {
+    List(ctx context.Context) (ListResponse[T], error)
+    Watch(ctx context.Context, resourceVersion string) (Watcher[T], error)
+}
+
+var ErrWatchExpired = errors.New("watch cursor expired: event log compacted")
+```
+
+**Contract**:
+- `List` errors are retried by the caller with exponential backoff (FR-014) — `ListWatcher` implementations do not retry internally.
+- `Watch` returning a `Watcher` whose `Events()` channel closes with `Err() == ErrWatchExpired` (checked via `errors.Is`) signals a compacted cursor (FR-009); any other non-nil `Err()` (or context cancellation) signals a transient disconnect (FR-011).
+- `Stop()` MUST be safe to call multiple times and MUST cause `Events()` to close if not already closed.
+
+---
+
+### Runner[T] (orchestration entity — the spec's "controller manager" bootstrap/resume actor)
+
+**Package**: `internal/listwatch`
+
+**Description**: Per-kind orchestration loop. Owns the *mutable* `*cache.Cache[T]` (distinct from the read-only `CacheAccessor[T]` reconcilers receive per spec 026) and drives `Manager.Enqueue`. Exactly one `Runner[T]` instance runs per registered kind, on a single dedicated goroutine (FR-012, research.md §2/§6).
+
+```go
+type Runner[T any] struct {
+    Kind            string
+    ListWatcher     ListWatcher[T]
+    Cache           *cache.Cache[T]
+    Store           checkpoint.Store
+    Enqueue         func(types.WorkItemKey) error
+    KeyFunc         func(T) types.WorkItemKey
+    RevisionFunc    func(T) string   // extracts resourceVersion from an object, for expiry-recovery diffing
+
+    FlushIntervalEvents int            // default 100
+    MaxBackoff           time.Duration // default 30s
+
+    Log *zap.Logger
+    // currentRV (unexported) — in-memory watch cursor, source of truth for
+    // same-process reconnects (FR-011); distinct from the last value persisted
+    // to Store, which may lag by up to FlushIntervalEvents-1 events.
+}
+
+func (r *Runner[T]) Run(ctx context.Context) error
+```
+
+**State machine**:
+
+```
+Run(ctx) entry
+  │
+  ├─ Store.Load(kind) succeeds ──────────────► resume: skip to WATCH at loaded ResourceVersion
+  │
+  └─ Store.Load(kind) fails (missing/corrupt) ─► BOOTSTRAP
+                                                    │
+                                                    ▼
+BOOTSTRAP: retry List with backoff until success (FR-014; never MarkSynced/enqueue/watch before success)
+  → cache.Set every item → cache.MarkSynced() → Enqueue every listed key (FR-001, FR-002)
+  → Store.Save(ResourceVersion from list)
+  → currentRV = list.ResourceVersion
+  → fall through to WATCH
+
+WATCH(currentRV): open Watch(ctx, currentRV)
+  loop: select on Events()
+    Added/Modified   → cache.Set    → Enqueue(key)   → currentRV = event.ResourceVersion
+    Deleted          → cache.Delete → Enqueue(key)   → currentRV = event.ResourceVersion
+    Bookmark         →                (no enqueue)   → currentRV = event.ResourceVersion
+    (every branch)   → eventsSinceFlush++; if >= FlushIntervalEvents: flushWithBackoff (blocks further
+                        event consumption until Store.Save succeeds — FR-005, SC-004)
+    ctx.Done()       → best-effort final flush → return
+  Events() channel closes:
+    Err() is ErrWatchExpired → discard checkpoint → BOOTSTRAP-style re-list, but only enqueue items whose
+                                 RevisionFunc differs from the cached value (FR-009, US3 AC2) → WATCH(new RV)
+    Err() is anything else / nil (incl. ctx cancellation) → reconnect: WATCH(currentRV) with exponential
+                                 backoff capped at MaxBackoff (FR-011) — uses in-memory currentRV, NOT
+                                 Store.Load (research.md §5)
+```
+
+**Invariants**:
+- No `Enqueue` call happens before `Cache.MarkSynced()` for that kind (FR-002, mirrors the existing `syncChecker` gate in `manager.runDispatchLoop` — this is the producer-side half of the same guarantee).
+- A resource present in both the bootstrap `List` response and an early `Watch` `Added` event for the same key is enqueued exactly once across the transition (SC-008) — the `Runner` tracks the set of keys enqueued during bootstrap and suppresses a duplicate `Added` enqueue for a key it just listed, until the first watch event for that key that is *not* a duplicate of the list snapshot arrives (see contracts/runner-contract.md for the precise suppression window).
+- `Runner` never enqueues from a `Bookmark` event.
+- `Runner` never resumes a same-process reconnect from `Store.Load` — only from `currentRV`.
+
+---
+
+## Config Additions (`internal/config.ControllerConfig`)
+
+| Field | Type | mapstructure key | Env var | Default | Notes |
+|-------|------|-------------------|---------|---------|-------|
+| `CheckpointDir` | `string` | `checkpoint_dir` | `GITSTORE_CONTROLLER__CHECKPOINT_DIR` | `.gitstore/checkpoints` | Directory for `FilesystemStore`; created with `os.MkdirAll` at startup if absent |
+| `CheckpointFlushIntervalEvents` | `int` | `checkpoint_flush_interval_events` | `GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS` | `100` | Event count, not a duration (research.md §8) |
+| `MaxWatchBackoffStr` / `MaxWatchBackoff` | `string` / `time.Duration` | `max_watch_backoff` / `-` | `GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF` | `30s` | Parsed in `validate()`, same idiom as `DefaultStallThresholdStr` |
+
+No new env var prefix — all three live under the existing `GITSTORE_CONTROLLER__` namespace, per the spec's Assumptions.
+
+## Prometheus Metrics Additions (`internal/health/metrics.go`)
+
+| Metric | Type | Labels | Set/incremented when |
+|--------|------|--------|----------------------|
+| `gitstore_controller_checkpoint_last_write_timestamp_seconds` | Gauge | `kind` | Every successful `Store.Save` — set to `time.Now().Unix()` |
+| `gitstore_controller_checkpoint_write_failures_total` | Counter | `kind` | Every failed `Store.Save` attempt inside `flushWithBackoff` |
+| `gitstore_controller_checkpoint_replay_backlog` | Gauge | `kind` | Mirrors the kind's existing queue-depth value from `Manager.KindStats()` (research.md §7) — not independently tracked |
+
+No changes to `internal/health/handler.go`'s `/health` JSON response or `internal/api/poison.go` — Prometheus-only exposure per the spec's clarification.
+
+## Relationships Diagram
+
+```
+cmd/controller/main.go
+  ├─ mgr := manager.New()...            (spec 025/026, unchanged)
+  ├─ store := checkpoint.NewFilesystemStore(cfg.Controller.CheckpointDir)
+  └─ for each kind:
+       c := cache.New[T]()
+       mgr.Register(manager.ReconcilerRegistration{Kind: kind, Cache: c, Reconciler: ...})
+       runner := &listwatch.Runner[T]{
+           Kind: kind, Cache: c, Store: store,
+           Enqueue: func(k types.WorkItemKey) error { return mgr.Enqueue(k) },
+           ListWatcher: <transport impl — out of scope for this spec>,
+           FlushIntervalEvents: cfg.Controller.CheckpointFlushIntervalEvents,
+           MaxBackoff: cfg.Controller.MaxWatchBackoff,
+       }
+       go runner.Run(ctx)   // parallel to, not part of, mgr.Start(ctx)
+  mgr.Start(ctx)                          (blocks; dispatch loops gated on c.HasSynced())
+
+Runner[T]
+  ├─ owns *cache.Cache[T]    (mutable: Set/Delete/MarkSynced — Runner is the sole writer)
+  ├─ owns checkpoint.Store   (Load once at Run() entry; Save every FlushIntervalEvents events + on shutdown)
+  ├─ owns currentRV string   (in-memory cursor; source of truth for reconnects)
+  └─ calls Enqueue(WorkItemKey)  →  manager.Queue (existing, unchanged)
+```

--- a/specs/036-controller-startup-resume/data-model.md
+++ b/specs/036-controller-startup-resume/data-model.md
@@ -6,12 +6,14 @@
 
 **Package**: `github.com/gitstore-dev/gitstore/controller-manager/internal/checkpoint`
 
-**Description**: A persisted record binding a resource kind to the `resourceVersion` of the last event (or list completion) successfully processed. Spec's "Checkpoint" entity.
+**Description**: A persisted restart record binding a resource kind to its watch cursor, informer-cache snapshot, and deletion replay keys.
 
 ```go
 type Record struct {
     Kind            string
     ResourceVersion string
+    Snapshot        json.RawMessage
+    ReplayKeys      []types.WorkItemKey
     WrittenAt       time.Time
 }
 ```
@@ -19,6 +21,8 @@ type Record struct {
 **Invariants**:
 - `Kind` MUST be non-empty and MUST match the file/map key it is stored under.
 - `ResourceVersion` is an opaque string — never parsed numerically or compared with `<`/`>` (per spec Assumptions); only equality and "cursor to resume from" semantics apply.
+- `Snapshot` MUST encode the complete cache state at `ResourceVersion`; resume restores it before marking the cache synced.
+- Every `ReplayKeys` entry MUST match `Kind`. The set contains deletion tombstones; current resources are replayed directly from `Snapshot`.
 - `WrittenAt` is informational (used to derive checkpoint age for FR-013/US4); it is NOT used for correctness decisions.
 
 ---

--- a/specs/036-controller-startup-resume/plan.md
+++ b/specs/036-controller-startup-resume/plan.md
@@ -1,0 +1,170 @@
+# Implementation Plan: Controller Startup Resume — List-Then-Watch and resourceVersion Checkpointing
+
+**Branch**: `036-controller-startup-resume` | **Date**: 2026-08-06 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/036-controller-startup-resume/spec.md`
+
+## Summary
+
+Extend `gitstore-controller-manager` with a list-then-watch bootstrap sequence and `resourceVersion` checkpointing so the controller can populate its informer cache on first start, resume a watch stream from a persisted checkpoint after a restart, recover from compacted watch cursors by re-listing, and expose checkpoint health via Prometheus metrics. The primary new components are a generic `ListWatcher[T]` abstraction (the first "talk to the API" interface for list/watch, greenfield per spec's own Assumptions), a per-kind `Runner[T]` orchestration loop that owns the mutable `*cache.Cache[T]` and drives `Manager.Enqueue`, and a pluggable `CheckpointStore` (filesystem: one atomically-written file per kind; in-memory for tests). No changes to the `Reconciler`/`ReconcileResult` contract from spec 026 — this spec is purely a producer of `WorkItemKey`s into the existing queue.
+
+## Technical Context
+
+**Language/Version**: Go 1.25
+**Primary Dependencies**: `go.uber.org/zap`, `github.com/cenkalti/backoff/v5 v5.0.3` (unbounded reconnect backoff, distinct usage from the bounded-attempt `internal/retry` package), `github.com/prometheus/client_golang v1.23.2`, `github.com/spf13/viper v1.21.0` — no new external dependencies
+**Storage**: Filesystem checkpoint files (new — first persistence introduced in this module; one JSON file per registered kind, atomic write-temp-then-rename) + in-memory backend for tests
+**Testing**: `go test ./...`; contract tests in `tests/contract/`, unit tests co-located in `internal/`
+**Target Platform**: Linux server (controller manager binary)
+**Project Type**: Service (internal Go packages consumed by `cmd/controller/main.go`)
+**Performance Goals**: Resume begins dispatching within 5s with no re-list (SC-001); cold bootstrap of 10,000 resources completes within 60s (SC-002); checkpoint writes complete in <50ms under normal load (SC-005); expiry recovery resumes within 30s (SC-003); reconnect completes within the configured backoff window, default max 30s (SC-007)
+**Constraints**: Replay window never exceeds the configured flush interval (default 100 events), even under sustained checkpoint-write failures — enforced via backpressure, not best-effort (SC-004); zero duplicate work items enqueued across a single list-to-watch transition (SC-008)
+**Scale/Scope**: One controller-manager process; one `Runner[T]` goroutine per registered kind; O(10,000) resources per kind at bootstrap
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Test-First | ✅ | Contract tests written before implementation for `checkpoint`, `listwatch` packages. Existing `tests/contract/health_test.go` extended with checkpoint-metric assertions |
+| II. API-First | ✅ | `contracts/` defines `CheckpointStore`, `ListWatcher[T]`/`Watcher[T]`, and the `Runner` obligations contract before implementation |
+| III. Clear Contracts | ✅ | New interfaces are additive; no breaking change to `Reconciler`, `ReconcileResult`, or `syncChecker` from specs 025/026 (per this spec's own Assumptions) |
+| IV. Observability | ✅ | Structured logging on every list/watch/checkpoint transition; three new Prometheus metrics (FR-013) follow the existing `gitstore_controller_<noun>{kind}` naming convention |
+| V. User Story Driven | ✅ | P1=US1 (bootstrap list) + US2 (resume/checkpoint), P2=US3 (expiry recovery), P3=US4 (observability). Tasks labelled US1–US4 |
+| VI. Incremental Delivery | ✅ | US1+US2 (P1) deliver a working bootstrap+resume cycle without US3/US4. US3 and US4 are additive |
+| VII. Simplicity/YAGNI | ✅ | No new external dependencies. Single-goroutine-per-kind `Runner` design satisfies FR-012 (one active list-or-watch loop per kind) by construction — no mutex/singleflight primitive needed. `ReplayBacklog` metric aliases the existing per-kind queue depth rather than introducing separate bookkeeping (see research.md §7) |
+
+**Post-design re-check**: No violations. `internal/checkpoint` and `internal/listwatch` are new packages justified by the `CheckpointStore` and `ListWatcher[T]`/`Runner[T]` entities (FR-001–FR-015). No fourth service introduced — all additions are additive to the existing `gitstore-controller-manager` module.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/036-controller-startup-resume/
+├── plan.md              ✅ (this file)
+├── research.md          ✅ Phase 0 output
+├── data-model.md         ✅ Phase 1 output
+├── quickstart.md         ✅ Phase 1 output
+├── contracts/
+│   ├── checkpoint-store-api.md     ✅ Phase 1 output
+│   ├── listwatcher-interface.md    ✅ Phase 1 output
+│   └── runner-contract.md          ✅ Phase 1 output
+└── tasks.md             ⬜ Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code
+
+```text
+gitstore-controller-manager/
+├── internal/
+│   ├── checkpoint/
+│   │   ├── checkpoint.go             NEW: Record type, Store interface
+│   │   ├── filesystem.go             NEW: FilesystemStore — one file per kind, atomic write-temp-then-rename
+│   │   └── memory.go                 NEW: MemoryStore — mutex-guarded map, for tests
+│   ├── listwatch/
+│   │   ├── types.go                  NEW: ListResponse[T], WatchEvent[T], EventType, ErrWatchExpired
+│   │   ├── listwatcher.go            NEW: ListWatcher[T], Watcher[T] interfaces
+│   │   └── runner.go                 NEW: Runner[T] — bootstrap list, resume, checkpoint flush/backpressure,
+│   │                                       reconnect, expiry-recovery re-list, cache Set/Delete/MarkSynced
+│   ├── config/
+│   │   └── config.go                 MODIFY: add CheckpointDir, CheckpointFlushIntervalEvents,
+│   │                                       MaxWatchBackoffStr/MaxWatchBackoff
+│   ├── health/
+│   │   └── metrics.go                MODIFY: add CheckpointLastWriteTimestamp, CheckpointReplayBacklog,
+│   │                                       CheckpointWriteFailuresTotal
+│   ├── cache/, manager/, queue/,
+│   │   worker/, retry/, status/,
+│   │   types/, api/                  unchanged
+├── tests/
+│   ├── checkpoint/
+│   │   ├── filesystem_test.go        NEW: atomic write, corrupt/missing fallback, one-file-per-kind isolation
+│   │   └── memory_test.go            NEW
+│   └── contract/
+│       ├── listwatch_bootstrap_test.go     NEW: US1 — full list, MarkSynced, enqueue-all, no-dup at transition
+│       ├── listwatch_resume_test.go        NEW: US2 — checkpoint resume, flush interval, backpressure
+│       ├── listwatch_expiry_test.go        NEW: US3 — ErrWatchExpired → re-list → diff-enqueue
+│       └── health_test.go                  MODIFY: add checkpoint metric assertions
+└── cmd/
+    └── controller/
+        └── main.go                   MODIFY: construct checkpoint.FilesystemStore + listwatch.Runner[T]
+                                             per kind before mgr.Start(ctx)
+```
+
+**Structure Decision**: Single project (`gitstore-controller-manager`). All new code is additive within two new internal packages (`checkpoint/`, `listwatch/`) plus small extensions to `config/` and `health/`. No new external dependencies, no new service/module.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications required.
+
+## Implementation Phases
+
+### Phase 1 — Checkpoint Store (US2 foundation — P1)
+
+Goal: Pluggable, atomic, per-kind checkpoint persistence.
+
+**Files**: `internal/checkpoint/checkpoint.go` (new), `internal/checkpoint/filesystem.go` (new), `internal/checkpoint/memory.go` (new), `internal/config/config.go`
+
+**Key changes**:
+1. `Record{Kind, ResourceVersion string; WrittenAt time.Time}` and `Store` interface (`Load`, `Save`) in `checkpoint.go`.
+2. `FilesystemStore{Dir string}` — `Save` writes to `os.CreateTemp(dir, kind+".tmp-*")`, `json.Marshal`, `os.Rename` into `<kind>.checkpoint.json`. `Load` returns a non-nil error for missing, unreadable, or corrupt (JSON-unmarshal-failure) files — callers treat *any* `Load` error identically (fall back to list-then-watch), matching FR-008.
+3. `MemoryStore` — mutex-guarded `map[string]Record`, for tests (mirrors `internal/cache.Cache` style).
+4. `ControllerConfig.CheckpointDir string` (default `.gitstore/checkpoints`), env `GITSTORE_CONTROLLER__CHECKPOINT_DIR`.
+
+**Test-first**: `TestFilesystemStore_SaveThenLoad_RoundTrips`, `TestFilesystemStore_AtomicWrite_NoPartialFileOnCrash` (verify temp file never observed at final path), `TestFilesystemStore_CorruptFile_ReturnsError`, `TestFilesystemStore_MissingFile_ReturnsError`, `TestFilesystemStore_OneFilePerKind_Isolated` (writing kind A never touches kind B's file), `TestMemoryStore_SaveThenLoad`.
+
+### Phase 2 — ListWatcher Abstraction & Bootstrap Loop (US1 — P1)
+
+Goal: Define the list/watch transport abstraction; implement the cold-start bootstrap path.
+
+**Files**: `internal/listwatch/types.go` (new), `internal/listwatch/listwatcher.go` (new), `internal/listwatch/runner.go` (new)
+
+**Key changes**:
+1. `EventType` enum (`Added`, `Modified`, `Deleted`, `Bookmark`), `WatchEvent[T]{Type EventType; Object T; ResourceVersion string}`, `ListResponse[T]{Items []T; ResourceVersion string}`.
+2. `Watcher[T]{Events() <-chan WatchEvent[T]; Err() error; Stop()}` and `ListWatcher[T]{List(ctx) (ListResponse[T], error); Watch(ctx, resourceVersion string) (Watcher[T], error)}` interfaces. `ErrWatchExpired` sentinel for compacted cursors (FR-009).
+3. `Runner[T]{KeyFunc func(T) types.WorkItemKey; RevisionFunc func(T) string; ListWatcher ListWatcher[T]; Cache *cache.Cache[T]; Enqueue func(types.WorkItemKey) error; ...}`.
+4. Bootstrap path: retry `List` with exponential backoff on failure (FR-014, no watch/MarkSynced/enqueue until success) → `cache.Set` every item → `cache.MarkSynced()` → enqueue a work item for every listed resource (FR-001, FR-002) → open `Watch` at the list response's `resourceVersion` (FR-003) → for the brief window between list completion and watch open, dedupe against the just-listed set so an early watch `Added` for an already-listed key is not double-enqueued (SC-008).
+
+**Test-first**: `TestRunner_Bootstrap_ListsAndEnqueuesAll`, `TestRunner_Bootstrap_NoDispatchBeforeSynced`, `TestRunner_Bootstrap_NoDuplicateAcrossListWatchTransition`, `TestRunner_Bootstrap_ListFailure_RetriesWithBackoff_NeverMarksSynced`.
+
+### Phase 3 — Resume, Flush Interval & Backpressure (US2 — P1)
+
+Goal: Skip the list phase on a valid checkpoint; persist the in-memory cursor on a schedule; backpressure on write failure.
+
+**Files**: `internal/listwatch/runner.go`, `internal/config/config.go`
+
+**Key changes**:
+1. On `Runner.Run(ctx)` start: `checkpoint.Store.Load(kind)`. Error (missing/corrupt/unreadable) → bootstrap path (Phase 2). Success → skip `List`, open `Watch` directly at the checkpointed `resourceVersion` (FR-007).
+2. Every watch event updates an in-memory `currentRV` (FR-004) regardless of type (including `Bookmark`, without enqueuing — FR-010).
+3. `eventsSinceFlush` counter; at `CheckpointFlushIntervalEvents` (default 100, `mapstructure:"checkpoint_flush_interval_events"`, env `GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS`) and on clean shutdown (`ctx.Done()`), call `flushWithBackoff`.
+4. `flushWithBackoff`: loop calling `Store.Save`; on error, increment `health.CheckpointWriteFailuresTotal`, log, backoff-sleep, retry — the event-processing loop does not read the next event from `Watcher.Events()` until a save succeeds, so replay never exceeds the flush interval even under a sustained outage (FR-005, SC-004). On success, update `health.CheckpointLastWriteTimestamp` and reset the counter.
+5. `MaxWatchBackoffStr`/`MaxWatchBackoff time.Duration` config (default `30s`, same duration-string idiom as `DefaultStallThresholdStr`), env `GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF`.
+6. Transient watch-stream disconnects (network error, not `ErrWatchExpired`) reconnect using `currentRV` (in-memory), never the last-persisted value, with unbounded exponential backoff capped at `MaxWatchBackoff` (FR-011).
+
+**Test-first**: `TestRunner_Resume_SkipsListPhase`, `TestRunner_Resume_WatchesFromCheckpointedVersion`, `TestRunner_Flush_PersistsAfterNEvents`, `TestRunner_Flush_PersistsOnCleanShutdown`, `TestRunner_Backpressure_PausesOnWriteFailure_ResumesOnSuccess`, `TestRunner_Backpressure_BoundedReplayWindow`, `TestRunner_TransientReconnect_UsesInMemoryCheckpoint_NotPersisted`, `TestRunner_TransientReconnect_BackoffCappedAtMax`.
+
+### Phase 4 — Expiry Recovery (US3 — P2)
+
+Goal: Detect a compacted watch cursor, re-list, enqueue only changed resources, resume watching.
+
+**Files**: `internal/listwatch/runner.go`
+
+**Key changes**:
+1. `Watcher.Err()` returning `ErrWatchExpired` (or an `errors.Is` match) after the events channel closes triggers: discard the in-memory/persisted checkpoint for the kind, run `List` again (retried with backoff per FR-014's pattern), write a fresh checkpoint from the new list's `resourceVersion` (FR-009).
+2. Re-list diff: for each item in the new `ListResponse`, compare `RevisionFunc(item)` against the cached object's revision via `cache.Get` — enqueue only if absent or the revision differs (US3 AC2); always `cache.Set` regardless, to keep the cache accurate.
+3. Single-goroutine `Runner.Run` loop means expiry recovery is inherently serialized per kind — no explicit coalescing primitive is added (FR-012 satisfied by construction; see research.md §6).
+
+**Test-first**: `TestRunner_ExpiryRecovery_DiscardsCheckpointAndRelists`, `TestRunner_ExpiryRecovery_EnqueuesOnlyChangedResources`, `TestRunner_ExpiryRecovery_RepeatedExpiry_NoLostWorkItems`.
+
+### Phase 5 — Checkpoint Observability (US4 — P3)
+
+Goal: Expose checkpoint age, replay backlog, and write-failure count via the existing Prometheus surface.
+
+**Files**: `internal/health/metrics.go`, `internal/listwatch/runner.go`
+
+**Key changes**:
+1. `CheckpointLastWriteTimestamp = promauto.NewGaugeVec({Name: "gitstore_controller_checkpoint_last_write_timestamp_seconds"}, []string{"kind"})` — set to `float64(time.Now().Unix())` on every successful `Save` (operators compute age via `time() - metric`, standard Prometheus idiom).
+2. `CheckpointWriteFailuresTotal = promauto.NewCounterVec({Name: "gitstore_controller_checkpoint_write_failures_total"}, []string{"kind"})` — incremented once per failed `Save` attempt inside `flushWithBackoff`.
+3. `CheckpointReplayBacklog = promauto.NewGaugeVec({Name: "gitstore_controller_checkpoint_replay_backlog"}, []string{"kind"})` — set from the same per-kind queue-depth value `Manager.KindStats()` already computes; this is a deliberate simplification (see research.md §7), not a second bookkeeping mechanism.
+4. No changes to `internal/api/poison.go` or `internal/health/handler.go`'s `/health` JSON surface — Prometheus-only, per the spec's clarification.
+
+**Test-first**: `TestHealth_CheckpointLastWriteTimestamp_UpdatesOnSave`, `TestHealth_CheckpointWriteFailuresTotal_IncrementsOnFailure`, `TestHealth_CheckpointReplayBacklog_TracksQueueDepth`.

--- a/specs/036-controller-startup-resume/quickstart.md
+++ b/specs/036-controller-startup-resume/quickstart.md
@@ -97,14 +97,14 @@ if err := mgr.Start(ctx); err != nil {
 
 ```
 No checkpoint file at cfg.Controller.CheckpointDir/MyResource.checkpoint.json
-  → Runner performs a full List, populates cache, MarkSynced, enqueues everything,
-    writes a fresh checkpoint.
+  → Runner performs a full List, populates the cache, persists the snapshot and replay keys,
+    then marks the cache synced and enqueues everything.
 
 Valid checkpoint file present
-  → Runner skips List entirely, opens Watch directly at the checkpointed resourceVersion.
-    Dispatch begins as soon as the first batch of resumed events is processed — no re-list (SC-001).
+  → Runner restores the cache snapshot, marks it synced, re-enqueues snapshot resources and
+    deletion replay keys, and opens Watch directly at the checkpointed resourceVersion — no re-list.
 
-Checkpoint file missing/corrupt/unreadable
+Checkpoint file missing/corrupt/unreadable/semantically invalid
   → Treated identically to "no checkpoint" — falls back to full List-then-watch (FR-008).
 ```
 

--- a/specs/036-controller-startup-resume/quickstart.md
+++ b/specs/036-controller-startup-resume/quickstart.md
@@ -1,0 +1,131 @@
+# Quickstart: Wiring List-Then-Watch and Checkpointing (spec 036)
+
+## Prerequisites
+
+- `gitstore-controller-manager` built: `go build ./...` from `gitstore-controller-manager/`
+- A `ListWatcher[T]` implementation for your resource type. This spec ships no concrete transport (see research.md §1) — for tests, use a hand-written stub; for production, implement `ListWatcher[T]`/`Watcher[T]` against whatever transport the consuming spec chooses (e.g. a GraphQL subscription).
+- A `*cache.Cache[T]` and a registered `Reconciler` for the kind (spec 026) — the `Runner` populates the same cache the reconciler reads from.
+
+## Wiring a Kind's List-Then-Watch Loop
+
+### 1. Implement (or stub) a ListWatcher
+
+```go
+package mycontroller
+
+import (
+    "context"
+
+    "github.com/gitstore-dev/gitstore/controller-manager/internal/listwatch"
+)
+
+type MyResource struct {
+    Namespace, Name, ResourceVersion string
+    // ... resource-specific fields
+}
+
+type myListWatcher struct{ /* holds a GraphQL client, gRPC stream, etc. */ }
+
+func (lw *myListWatcher) List(ctx context.Context) (listwatch.ListResponse[MyResource], error) {
+    // Fetch a full snapshot + the resourceVersion at snapshot time.
+    ...
+}
+
+func (lw *myListWatcher) Watch(ctx context.Context, resourceVersion string) (listwatch.Watcher[MyResource], error) {
+    // Open a stream starting after resourceVersion. Return ErrWatchExpired-
+    // wrapping errors when the cursor has been compacted.
+    ...
+}
+```
+
+### 2. Construct the CheckpointStore once, shared across kinds
+
+```go
+// cmd/controller/main.go
+store, err := checkpoint.NewFilesystemStore(cfg.Controller.CheckpointDir)
+if err != nil {
+    log.Fatal("failed to init checkpoint store", zap.Error(err))
+}
+```
+
+### 3. Register the reconciler (spec 026, unchanged) and construct the Runner
+
+```go
+myCache := cache.New[MyResource]()
+
+if err := mgr.Register(manager.ReconcilerRegistration{
+    Kind:       "MyResource",
+    Reconciler: mycontroller.NewMyReconciler(myCache, statusClient),
+    Cache:      myCache, // same cache instance — Runner writes it, Reconciler reads it read-only
+}); err != nil {
+    log.Fatal("failed to register reconciler", zap.Error(err))
+}
+
+runner := &listwatch.Runner[MyResource]{
+    Kind:        "MyResource",
+    ListWatcher: &myListWatcher{},
+    Cache:       myCache,
+    Store:       store,
+    Enqueue:     func(k types.WorkItemKey) error { return mgr.Enqueue(k) },
+    KeyFunc: func(obj MyResource) types.WorkItemKey {
+        return types.WorkItemKey{Kind: "MyResource", Namespace: obj.Namespace, Name: obj.Name}
+    },
+    RevisionFunc:         func(obj MyResource) string { return obj.ResourceVersion },
+    FlushIntervalEvents:  cfg.Controller.CheckpointFlushIntervalEvents,
+    MaxBackoff:           cfg.Controller.MaxWatchBackoff,
+    Log:                  log,
+}
+```
+
+### 4. Start the Runner alongside the Manager
+
+```go
+go func() {
+    if err := runner.Run(ctx); err != nil && ctx.Err() == nil {
+        log.Error("list-watch runner exited unexpectedly", zap.String("kind", "MyResource"), zap.Error(err))
+    }
+}()
+
+if err := mgr.Start(ctx); err != nil {
+    log.Fatal("manager exited", zap.Error(err))
+}
+```
+
+`Runner.Run` and `Manager.Start` run concurrently: `Run` populates `myCache` and calls `mgr.Enqueue`; `Manager.Start`'s dispatch loop for `"MyResource"` blocks on `myCache.HasSynced()` until `Run`'s bootstrap (or resume) completes, exactly as it already does for any other cache-sync gate (spec 025/026 — unmodified).
+
+## What Happens On Restart
+
+```
+No checkpoint file at cfg.Controller.CheckpointDir/MyResource.checkpoint.json
+  → Runner performs a full List, populates cache, MarkSynced, enqueues everything,
+    writes a fresh checkpoint.
+
+Valid checkpoint file present
+  → Runner skips List entirely, opens Watch directly at the checkpointed resourceVersion.
+    Dispatch begins as soon as the first batch of resumed events is processed — no re-list (SC-001).
+
+Checkpoint file missing/corrupt/unreadable
+  → Treated identically to "no checkpoint" — falls back to full List-then-watch (FR-008).
+```
+
+## Running Tests
+
+```bash
+# From gitstore-controller-manager/
+go test ./...                        # all tests
+go test ./tests/contract/...         # contract tests, including listwatch_bootstrap/resume/expiry
+go test ./tests/checkpoint/...       # filesystem/memory store tests
+go test ./internal/...               # unit tests only
+```
+
+## Verifying Checkpoint Metrics
+
+```bash
+make controller   # starts on :5001
+curl -s http://localhost:5001/metrics | grep checkpoint
+# gitstore_controller_checkpoint_last_write_timestamp_seconds{kind="MyResource"} 1.7...e+09
+# gitstore_controller_checkpoint_write_failures_total{kind="MyResource"} 0
+# gitstore_controller_checkpoint_replay_backlog{kind="MyResource"} 0
+```
+
+Checkpoint age is derived, not stored directly: `time() - gitstore_controller_checkpoint_last_write_timestamp_seconds{kind="MyResource"}` in a Prometheus query, the standard idiom for "time since last X" gauges.

--- a/specs/036-controller-startup-resume/research.md
+++ b/specs/036-controller-startup-resume/research.md
@@ -1,0 +1,140 @@
+# Research: Controller Startup Resume (spec 036)
+
+## 1. ListWatcher Transport Abstraction
+
+**Decision**: Define a minimal generic pair of interfaces — `ListWatcher[T]` (constructs a `Watcher[T]` and performs the initial `List`) and `Watcher[T]` (an open watch stream: `Events() <-chan WatchEvent[T]`, `Err() error`, `Stop()`) — in a new `internal/listwatch` package. No concrete GraphQL/gRPC transport is implemented in this spec.
+
+**Rationale**: The spec's own Assumptions section states the concrete transport (GraphQL subscription vs. dedicated watch endpoint) "is not specified here," and research confirms this is accurate: `gitstore-api`'s GraphQL schema (`shared/schemas/*.graphqls`) has no `type Subscription` anywhere, and `gitstore-controller-manager` has zero existing GraphQL client code — `Config.Controller.ApiURI` is read into config but never dialed. Building a concrete transport would require schema work on the `gitstore-api` side that is out of scope for this spec (not listed in Dependencies) and would risk the plan quietly expanding beyond issue #182. The interface-first approach lets `internal/listwatch` and its `Runner[T]` be fully tested against an in-memory stub `ListWatcher[T]` (mirroring how spec 026 tested `Reconciler` against `stubReconciler`), while the concrete GraphQL-subscription-backed implementation is deferred to whichever spec first needs a real `T` (e.g. issue #244, CategoryTaxonomy Controller Reconciliation) or a dedicated "watch transport" spec.
+
+**Design**:
+```go
+// internal/listwatch/types.go
+type EventType int
+const (
+    Added EventType = iota
+    Modified
+    Deleted
+    Bookmark
+)
+
+type WatchEvent[T any] struct {
+    Type            EventType
+    Object          T       // zero value for Bookmark
+    ResourceVersion string
+}
+
+type ListResponse[T any] struct {
+    Items           []T
+    ResourceVersion string
+}
+
+var ErrWatchExpired = errors.New("watch cursor expired: event log compacted")
+
+// internal/listwatch/listwatcher.go
+type Watcher[T any] interface {
+    Events() <-chan WatchEvent[T]
+    Err() error   // non-nil (possibly ErrWatchExpired) after Events() closes
+    Stop()
+}
+
+type ListWatcher[T any] interface {
+    List(ctx context.Context) (ListResponse[T], error)
+    Watch(ctx context.Context, resourceVersion string) (Watcher[T], error)
+}
+```
+
+**Alternatives considered**: A single `Sync(ctx, resourceVersion string) (<-chan WatchEvent[T], error)` method that transparently does list-then-watch internally — rejected because US1's independent test explicitly requires listing and watching to be separately observable/testable steps ("stub API that serves a static list response... no watch stream... required"), and FR-007 requires the caller (the `Runner`) to skip `List` entirely on resume, which is only expressible if `List` and `Watch` are separate calls.
+
+---
+
+## 2. Runner Orchestration Loop & Single-Active-Loop Guarantee (FR-012)
+
+**Decision**: One `Runner[T]` per registered kind, running its entire lifecycle (bootstrap-or-resume → watch loop → reconnect/expiry recovery) on a single dedicated goroutine, owned by `main.go` the same way `Manager.Start` owns one dispatch goroutine per kind.
+
+**Rationale**: FR-012 requires "at most one active list-or-watch loop at a time" per kind and coalesced expiry recoveries. A single-goroutine-per-kind design satisfies this by construction — there is no second goroutine that could concurrently open a competing `Watch` or trigger a second re-list, so no mutex, singleflight, or leader-election-style primitive is needed. This mirrors the existing `runDispatchLoop` pattern (`internal/manager/manager.go`) where one goroutine per kind already owns dequeue+dispatch. Concurrent *multi-instance* operation (two controller-manager processes) is explicitly out of scope per the spec's Assumptions ("leader election... out of scope").
+
+**Design**: `Runner[T].Run(ctx context.Context) error` is a blocking call, spawned once per kind from `main.go` in its own goroutine (parallel to, not part of, `Manager.Start`). Internally it is a single `for` loop: bootstrap-or-resume once, then loop on `select { case ev := <-watcher.Events(): ...; case <-ctx.Done(): flush and return }`; on channel close, check `watcher.Err()` to decide between `ErrWatchExpired` (→ re-list) and any other error / nil (→ reconnect with backoff, same `resourceVersion` cursor).
+
+**Alternatives considered**: A supervisor + worker-goroutine split (like spec 026's deferred `HotRegister` channel design) — rejected as premature; spec 026 itself deferred that complexity because there was no concrete need, and the same reasoning applies here: kinds are statically registered before `Start()`, there is no hot-add-a-kind requirement in this spec.
+
+---
+
+## 3. Checkpoint Backpressure Mechanism (FR-005, SC-004)
+
+**Decision**: The `Runner`'s event-processing loop does not `case ev := <-watcher.Events()` again until the most recent flush attempt (at the configured interval boundary) has succeeded. A failed `Store.Save` retries in a tight backoff loop *before* the loop proceeds to read the next event.
+
+**Rationale**: This was clarified explicitly in the spec (see spec.md Clarifications, session 2026-08-06): SC-004's "replay window is bounded and never unbounded" is only true if the controller stops advancing its position once persistence can no longer keep up. Because `Watcher[T]` is a channel, "pausing dispatch" is naturally expressed as "don't drain the channel" — the transport implementation (whatever it turns out to be) is responsible for its own internal buffering/backpressure once the controller stops calling `Events()`; the `Runner` itself does no polling or busy-waiting beyond the retry-backoff sleep between `Save` attempts.
+
+**Design**: Pseudocode inside the watch loop:
+```go
+eventsSinceFlush++
+if eventsSinceFlush >= flushInterval {
+    for {
+        if err := store.Save(ctx, record); err != nil {
+            health.CheckpointWriteFailuresTotal.WithLabelValues(kind).Inc()
+            log.Warn("checkpoint write failed; pausing watch consumption", zap.Error(err))
+            select {
+            case <-ctx.Done():
+                return ctx.Err()
+            case <-time.After(backoff.NextBackOff()):
+                continue
+            }
+        }
+        health.CheckpointLastWriteTimestamp.WithLabelValues(kind).Set(float64(time.Now().Unix()))
+        eventsSinceFlush = 0
+        break
+    }
+}
+```
+
+**Alternatives considered**: Best-effort (advance in-memory checkpoint regardless of write success, accept unbounded replay on crash) — this was presented as an explicit option in clarification and rejected by the user specifically because it contradicts SC-004 as written. Circuit-breaker (halt entirely after M consecutive failures) — also presented and rejected in favor of the simpler always-retry backpressure model; nothing in the accepted answer calls for a hard stop, and a hard stop would conflict with FR-013's requirement that "the controller continues processing events without halting" (edge case: a single write failure increments the counter but does not halt — sustained failure delays, it does not stop, consumption).
+
+---
+
+## 4. Filesystem CheckpointStore — One File Per Kind, Atomic Write
+
+**Decision**: `FilesystemStore{Dir string}`; `Save(ctx, Record)` writes JSON to `os.CreateTemp(dir, "<kind>.checkpoint.*.tmp")`, `fsync`s, then `os.Rename` to `<dir>/<kind>.checkpoint.json`. `Load(ctx, kind)` reads and unmarshals `<dir>/<kind>.checkpoint.json`; any error (not-exist, permission, malformed JSON) is returned as-is — the `Runner` treats every `Load` error identically per FR-008 ("missing, unreadable, or corrupt").
+
+**Rationale**: Confirmed via clarification (spec.md Clarifications) that each kind gets its own file rather than one combined file — this directly satisfies FR-012's per-kind independence (a write or corruption for one kind's file structurally cannot affect another kind's file) and keeps `Save`/`Load` trivially generic over `T` (the store itself is untyped — it persists `Record{Kind, ResourceVersion, WrittenAt}`, not `T`). `os.Rename` within the same directory is atomic on POSIX filesystems (the standard write-temp-then-rename idiom already implied by FR-006 and the edge cases section), avoiding any need for file locking. `CheckpointDir` is a single new config field (`ControllerConfig.CheckpointDir`), consistent with the spec's Assumption that "no new top-level environment variables are introduced" — it lives under the existing `GITSTORE_CONTROLLER__` prefix.
+
+**Alternatives considered**: A single combined JSON file (map of kind → Record) — presented as an explicit option in clarification and rejected in favor of one-file-per-kind, specifically because a single file means every write (regardless of which kind changed) rewrites the whole file, and a single corrupt read affects every registered kind rather than just one.
+
+---
+
+## 5. Reconnect vs. Restart — Which Checkpoint Value To Resume From (FR-011)
+
+**Decision**: A transient watch-stream disconnect within the same controller-manager process (network blip, server restart on the API side) reconnects using the `Runner`'s in-memory `currentRV` field — updated on every event per FR-004 — never the last value written to `CheckpointStore`. Only an actual process restart (a new `Runner` constructed from scratch, calling `Store.Load` at `Run()` entry) resumes from the persisted checkpoint.
+
+**Rationale**: This was the second explicit clarification in the session. The spec's original wording ("resume from the last persisted checkpoint") was ambiguous about same-process reconnects, and since `currentRV` is updated synchronously on every watch event (FR-004) while `Store.Save` only happens every N events (FR-005), the in-memory value is always >= the persisted value. Resuming a same-process reconnect from the (older) persisted value would deterministically replay up to N already-handled events on every transient network blip — a correctness regression relative to just holding the in-memory cursor, which requires no additional state.
+
+**Design**: `Runner` holds `currentRV string` (unexported field, updated under no additional lock — the watch loop is single-goroutine so no synchronization is needed). The reconnect path calls `listwatcher.Watch(ctx, currentRV)`, not `store.Load(ctx, kind)`. `store.Load` is called exactly once, at `Run()` entry, before the loop starts.
+
+---
+
+## 6. Expiry Recovery and FR-012 Coalescing
+
+**Decision**: No explicit coalescing primitive (mutex, singleflight, dedup-token) is introduced for concurrent expiry recoveries. The single-goroutine-per-kind `Runner` design (research.md §2) makes concurrent expiry recovery for the same kind structurally impossible — there is only ever one call stack that could observe `ErrWatchExpired` and only one place (the top of the `Runner.Run` loop) that triggers a re-list.
+
+**Rationale**: FR-012's requirement ("concurrent expiry recoveries for the same kind MUST be coalesced into a single re-list") reads as a safety requirement against a multi-goroutine design where two paths could each detect expiry and race to re-list. Since this plan's `Runner` never has more than one goroutine per kind, the requirement is satisfied trivially rather than through an explicit coalescing mechanism — consistent with Principle VII (Simplicity/YAGNI): don't add a mutex to solve a race that the chosen architecture doesn't have.
+
+**Alternatives considered**: A supervisor goroutine fanning out per-kind watch loops with a shared "recovery in progress" flag per kind — rejected, this is the multi-goroutine design the single-goroutine `Runner` was chosen specifically to avoid.
+
+---
+
+## 7. ReplayBacklog Metric — Reuse Queue Depth, Don't Add New Bookkeeping
+
+**Decision**: `gitstore_controller_checkpoint_replay_backlog{kind}` is set from the same per-kind queue-depth value already computed by `Manager.KindStats()` (`ks.q.Len()`), not from a new independent counter inside `Runner`.
+
+**Rationale**: The spec's Key Entities section defines `ReplayBacklog` as "the count of events received on the watch stream that have been enqueued as work items but not yet dispatched" — this is definitionally the work queue's depth for that kind. `Manager` already tracks and exposes this exact quantity via `QueueDepth` (`internal/health/metrics.go`) for the *general* per-kind queue-depth metric; introducing a second, checkpoint-specific counter that tracks the same underlying number would be duplicate bookkeeping with a real risk of drifting out of sync (e.g. if the `Runner` incremented its own counter but the actual `Manager.Enqueue` call failed). The `Runner` reads `Manager.KindStats()[kind].QueueDepth` (or an equivalent narrow accessor) once per checkpoint metric update and republishes it under the new checkpoint-specific metric name, so operators distinguishing "checkpoint backlog" from "general queue depth" get a stable value without a second source of truth. If the two metrics need to diverge in the future (e.g. only counting items enqueued *during* a replay burst, not steady-state traffic), that is a follow-up refinement, not a blocker for this spec's SC-006.
+
+**Alternatives considered**: A dedicated atomic counter incremented in the `Runner`'s enqueue path and decremented via a callback from `Manager.dispatch` — rejected as unjustified complexity (a second counter tracking a quantity `Manager` already tracks) given Principle VII, unless/until the metrics are shown to need different semantics.
+
+---
+
+## 8. Config Additions — Flush Interval as Event Count, Not Duration
+
+**Decision**: `ControllerConfig.CheckpointFlushIntervalEvents int` (`mapstructure:"checkpoint_flush_interval_events"`, default `100`), distinct in kind from the existing `DefaultStallThresholdStr`/`MaxWatchBackoffStr` duration-string idiom.
+
+**Rationale**: FR-005 specifies the flush trigger as "every configurable number of events (default: 100)" — an event count, not a time interval. Reusing the duration-string-plus-parsed-field idiom (`Str string` + parsed `time.Duration`) from `DefaultStallThresholdStr` would be a type mismatch; a plain `int` with a `viper` default is the correct fit and needs no post-`Unmarshal` parsing step (unlike durations, ints unmarshal directly). `MaxWatchBackoffStr`/`MaxWatchBackoff time.Duration`, by contrast, *is* duration-shaped (FR-011's "maximum backoff interval MUST be configurable") and does follow the existing idiom exactly, parsed in `validate()` the same way `DefaultStallThresholdStr` is today.
+
+**Alternatives considered**: Time-based flush interval (flush every N seconds instead of every N events) — rejected, contradicts the spec's explicit wording and its SC-004 bound, which is defined in terms of event count, not wall-clock time.

--- a/specs/036-controller-startup-resume/spec.md
+++ b/specs/036-controller-startup-resume/spec.md
@@ -1,0 +1,164 @@
+# Feature Specification: Controller Startup Resume — List-Then-Watch and resourceVersion Checkpointing
+
+**Feature Branch**: `036-controller-startup-resume`  
+**Created**: 2026-07-17  
+**Status**: Draft  
+**Input**: User description: "Controller Startup Resume: List-Then-Watch and resourceVersion Checkpointing" (initiative #165 sub-issue #182)
+
+## Clarifications
+
+### Session 2026-08-06
+
+- Q: SC-004 claims the replay window is "bounded and never unbounded," but FR-013 only counts checkpoint write failures without specifying what happens if writes keep failing (e.g. storage outage) for longer than the flush interval. What should happen when checkpoint writes fail repeatedly beyond the configured flush interval? → A: Backpressure until write succeeds — pause enqueuing/dispatching further watch events once a checkpoint write fails, resume only after a write succeeds.
+- Q: FR-011 and the edge cases say a watch reconnect after a transient network error resumes "from the last persisted checkpoint." Should a same-process transient reconnect resume from the in-memory checkpoint or the persisted one? → A: In-memory checkpoint — only an actual process restart resumes from the persisted checkpoint; a same-process reconnect resumes from the freshest in-memory value.
+- Q: Checkpoint age, replay backlog, and write-failure count should be exposed via which surface — Prometheus metrics, the health/poison HTTP API, or both? → A: Prometheus metrics only, via the existing `prometheus/client_golang` surface from spec 025; no new HTTP fields are added.
+- Q: Should each registered kind get its own checkpoint file, or should all kinds share one combined file? → A: One file per kind, each with independent atomic write-temp-then-rename semantics.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Controller Boots and Reconciles All Existing Resources (Priority: P1)
+
+When the controller manager starts for the first time against a live API, it lists every resource for each registered kind, populates the informer cache from that snapshot, marks the cache synced, and enqueues a reconcile work item for every resource seen during the list — ensuring no pre-existing resource is silently skipped.
+
+**Why this priority**: An unreliable bootstrap sequence directly undermines the entire controller model. Resources that exist before the controller starts will accumulate silent drift if they are never reconciled. This is the most fundamental correctness requirement of the feature.
+
+**Independent Test**: Can be fully tested by pre-creating five resources via the API, starting the controller manager against a stub API that serves a static list response, and asserting that a work item is enqueued for each of the five resources within one bootstrap cycle — with no watch stream or checkpoint file required.
+
+**Acceptance Scenarios**:
+
+1. **Given** fifty resources of kind `CategoryTaxonomy` exist before the controller starts, **When** the controller starts and completes its initial list, **Then** a reconcile work item is enqueued for each of the fifty resources.
+2. **Given** the initial list completes successfully, **When** the cache is populated from the list response, **Then** `HasSynced()` returns `true` and dispatch begins; no reconcile is dispatched before `HasSynced()` is `true` for that kind.
+3. **Given** a resource is created in the API after the list request is issued but before the watch stream starts, **When** the watch stream delivers the creation event, **Then** a work item is enqueued exactly once (no duplicate with the list result).
+
+---
+
+### User Story 2 — Controller Resumes After Restart Without Re-Processing Unchanged Resources (Priority: P1)
+
+When the controller manager restarts, it reads a persisted `resourceVersion` checkpoint to resume the watch stream at the point it left off — replaying only the changes that occurred while it was down, rather than re-listing and re-reconciling every resource.
+
+**Why this priority**: Without checkpointing, every restart triggers a full reconcile sweep that scales with the total resource count, not the change volume. On large installations this creates a burst of unnecessary work. Correctness on restart is as important as correctness on first boot.
+
+**Independent Test**: Can be fully tested by starting the controller, processing events up to a checkpoint value, stopping the controller, restarting it with the checkpoint in place, and asserting that only events after the checkpoint are replayed — with no events before that version reprocessed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the controller has checkpointed `resourceVersion=500`, **When** it restarts, **Then** the watch stream opens at `resourceVersion=500` and only events with version > 500 are delivered; no events before that version are replayed.
+2. **Given** a valid checkpoint exists, **When** the controller starts, **Then** the initial list phase is skipped and the controller moves directly to the watch phase using the checkpointed version.
+3. **Given** the checkpoint file is missing or corrupt, **When** the controller starts, **Then** it falls back to a full list-and-watch cycle as in User Story 1, discards the corrupt checkpoint, and writes a new valid checkpoint after the list completes.
+4. **Given** the checkpoint is written after every N events (configurable), **When** the controller crashes between checkpoints, **Then** at most N events are re-processed on restart (bounded replay window).
+
+---
+
+### User Story 3 — Controller Handles Expired Watch Cursor and Reconnects Gracefully (Priority: P2)
+
+When the API signals that the requested watch cursor is no longer available because the event log has been compacted, the controller manager detects this condition, falls back to a full re-list, writes a new checkpoint, and resumes watching — without requiring a manual restart or operator intervention.
+
+**Why this priority**: Long-running controllers will inevitably encounter compacted event histories. An unhandled expiry would halt reconciliation silently until a human intervenes. Automatic recovery is required for unattended production operation.
+
+**Independent Test**: Can be fully tested by wiring a stub API that rejects the first watch request as expired, then returns a valid list and event stream on the next attempt; asserting the controller re-lists, updates the checkpoint, and resumes reconciliation without crashing or requiring a restart.
+
+**Acceptance Scenarios**:
+
+1. **Given** the controller sends a watch request with a `resourceVersion` that has been compacted, **When** the API rejects it as expired, **Then** the controller discards the stale checkpoint, performs a full re-list, writes a new checkpoint, and resumes watching.
+2. **Given** a full re-list is triggered by an expiry recovery, **When** the list completes, **Then** only resources whose state has changed since the last checkpoint are enqueued for reconciliation.
+3. **Given** a watch cursor expiry occurs repeatedly (aggressive API compaction), **When** the controller falls back to list-then-watch each time, **Then** reconciliation remains correct and no work items are permanently lost.
+
+---
+
+### User Story 4 — Operator Monitors Checkpoint Age and Replay Backlog (Priority: P3)
+
+A platform operator can observe checkpoint health — how recent the last successful checkpoint write was and how many events remain in the current replay backlog — through the existing Prometheus metrics surface, so that stale checkpoints or growing backlogs are detectable before they cause operational problems.
+
+**Why this priority**: Checkpoint staleness is an invisible operational risk. Without metrics, an operator cannot distinguish a healthy controller from one that has been unable to persist checkpoints for hours.
+
+**Independent Test**: Can be fully tested by starting the controller, injecting a delay in checkpoint writes, and asserting that the Prometheus metrics surface reports a non-zero checkpoint age within one metrics scrape interval — without requiring a full API stack.
+
+**Acceptance Scenarios**:
+
+1. **Given** the controller has written a checkpoint, **When** the Prometheus metrics surface is queried, **Then** it reports the age of the last successful checkpoint write for each registered kind.
+2. **Given** the controller is processing a replay burst after a restart, **When** the Prometheus metrics surface is queried, **Then** it reports the number of events remaining in the replay backlog.
+3. **Given** a checkpoint write fails (e.g. storage unavailable), **When** the Prometheus metrics surface is queried, **Then** a checkpoint write failure counter has been incremented; the controller applies backpressure (pausing further dispatch for the affected kind) rather than halting entirely, and resumes once a write succeeds.
+
+---
+
+### Edge Cases
+
+- What happens when the API is unavailable during the initial list? The controller must retry the list with exponential backoff and not start the watch or mark the cache synced until the list succeeds.
+- What happens when the watch stream closes unexpectedly (network error, server restart)? The controller must detect the disconnection, re-open the watch from the current in-memory checkpoint (or the last persisted checkpoint if the controller process itself restarted), and apply backoff between reconnect attempts.
+- What happens when two controller instances start concurrently and both attempt to write a checkpoint for the same kind? Each kind's checkpoint lives in its own file; the checkpoint store must use atomic writes (write-to-temp, rename) so a partial write is never read as valid, and concurrent-write semantics for that single file are defined per backend.
+- What happens when a checkpoint write fails repeatedly (e.g. storage unavailable) beyond the configured flush interval? The controller must apply backpressure — pausing further watch-event dispatch for the affected kind — until a write succeeds, so the replay window never grows unbounded; the write-failure counter increments on each failed attempt.
+- What happens on a transient watch-stream reconnect within the same controller process (no restart)? The controller resumes from the current in-memory checkpoint, not the last value written to disk, so events already processed in this run are never replayed; only a process restart falls back to the persisted checkpoint.
+- What happens when a bookmark event arrives on the watch stream? Bookmark events carry a `resourceVersion` and must update the checkpoint without enqueuing a work item.
+- What happens when a delete event arrives for a resource during the list phase (before the watch stream starts)? The delete must be detected at the list-to-watch transition and the deleted resource must not be enqueued for reconciliation.
+- What ordering guarantees does the watch stream provide? Events for a single resource must be processed in `resourceVersion` order; events for different resources may interleave.
+- What happens if the controller is killed mid-checkpoint-write? Atomic write (write-to-temp, rename) ensures a partially-written checkpoint is never read.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: On first start (no checkpoint), the controller MUST perform a full list of all resources for each registered kind and populate the informer cache before opening the watch stream.
+- **FR-002**: After the initial list completes, the controller MUST mark the kind's cache as synced (`MarkSynced`) and enqueue a work item for every resource returned in the list; no work item MUST be dispatched before `HasSynced` is `true` for that kind.
+- **FR-003**: The transition from list phase to watch phase MUST use the `resourceVersion` returned by the list response as the starting cursor for the watch stream, so no events between list completion and watch-stream open are lost.
+- **FR-004**: On every watch event, the controller MUST update the in-memory checkpoint for the affected kind to the event's `resourceVersion`.
+- **FR-005**: The controller MUST persist the in-memory checkpoint to durable storage after every configurable number of events (default: 100) and after each clean shutdown. If a checkpoint write fails, the controller MUST apply backpressure — pausing further watch-event dispatch for the affected kind — until a subsequent write succeeds, so the replay window never exceeds the configured flush interval even during a sustained write outage.
+- **FR-006**: Checkpoint writes MUST be atomic: written to a temporary location and renamed into place so a crash during write never leaves a partially-written checkpoint readable.
+- **FR-007**: On restart with a valid checkpoint, the controller MUST skip the list phase and open the watch stream at the checkpointed `resourceVersion` directly.
+- **FR-008**: On restart with a missing, unreadable, or corrupt checkpoint, the controller MUST fall back to a full list-then-watch cycle and write a new valid checkpoint after the list completes.
+- **FR-009**: When the API signals that the requested watch cursor is expired (event log compacted), the controller MUST discard the stale checkpoint for the affected kind, perform a full re-list, write a new checkpoint, and resume watching — without requiring a restart.
+- **FR-010**: Bookmark events on the watch stream MUST update the in-memory (and, at flush intervals, the persisted) checkpoint `resourceVersion` without enqueuing a work item.
+- **FR-011**: Watch stream reconnections after a transient network error (same process, no restart) MUST resume from the current in-memory checkpoint — not the last persisted value — so events already processed in this run are never replayed; reconnects MUST apply exponential backoff between attempts, and the maximum backoff interval MUST be configurable. Only a full process restart resumes from the last *persisted* checkpoint (per FR-007).
+- **FR-012**: A single registered kind MUST have at most one active list-or-watch loop at a time; concurrent expiry recoveries for the same kind MUST be coalesced into a single re-list.
+- **FR-013**: The controller MUST expose per-kind checkpoint health via the existing Prometheus metrics surface (`prometheus/client_golang`, per spec 025) only: last successful checkpoint write time, current replay backlog size, and a total checkpoint write failure counter. No new fields are added to the health/poison HTTP API.
+- **FR-014**: When the initial list request fails, the controller MUST retry with exponential backoff and MUST NOT start the watch stream, mark the cache synced, or enqueue any work items until the list succeeds.
+- **FR-015**: The checkpoint storage backend MUST be swappable at construction time; a filesystem backend (for production) and an in-memory backend (for testing) MUST be provided. The filesystem backend MUST store each registered kind's checkpoint in its own file, independently subject to the atomic write-temp-then-rename rule in FR-006, so a write or corruption affecting one kind's file never impacts another kind's checkpoint.
+
+### Key Entities
+
+- **Checkpoint**: A persisted record binding a resource kind to the `resourceVersion` of the last event (or list completion) successfully processed by the controller. Used to resume a watch stream after a restart without replaying the full history.
+- **CheckpointStore**: The storage abstraction responsible for reading and writing checkpoints. Writes are atomic. The filesystem implementation stores one checkpoint file per registered kind (independent atomic write-temp-then-rename per file); an in-memory backend is also provided for testing.
+- **ListResponse**: The result of a full list request to the API for a given kind: a snapshot of all current resources and the `resourceVersion` at the time of the snapshot.
+- **WatchEvent**: A streaming change notification delivered by the API after a list. One of `ADDED`, `MODIFIED`, `DELETED`, or `BOOKMARK`. Each event carries a `resourceVersion`; `BOOKMARK` carries only the version.
+- **ReplayBacklog**: The count of events received on the watch stream that have been enqueued as work items but not yet dispatched. Used to measure recovery progress after a restart.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A controller restarting with a valid checkpoint begins dispatching reconcile work within 5 seconds of startup, with no full re-list performed.
+- **SC-002**: A controller starting cold (no checkpoint) with 10,000 pre-existing resources completes its initial list, populates the cache, and enqueues all work items within 60 seconds.
+- **SC-003**: After a watch cursor expiry recovery, the controller resumes normal reconciliation within 30 seconds of the error; no manual intervention is required.
+- **SC-004**: At most N events are re-processed after an unclean restart, where N is the configurable checkpoint flush interval (default: 100); the replay window is bounded and never unbounded, including during sustained checkpoint-write failures, because watch-event dispatch backpressures until a write succeeds.
+- **SC-005**: Checkpoint writes complete in under 50 milliseconds under normal load; a write failure is surfaced in the Prometheus metrics surface within one scrape interval (default: 15 seconds).
+- **SC-006**: The Prometheus metrics surface reports accurate checkpoint age and replay backlog within 5 seconds of any state change.
+- **SC-007**: A watch stream reconnection after a transient network error completes within the configured backoff window (max: 30 seconds default) and resumes processing without operator action.
+- **SC-008**: Zero duplicate work items are enqueued for a given resource during a single list-to-watch transition, even if the resource appears in both the list response and an early watch event.
+
+## Assumptions
+
+- The API supports standard list-and-watch semantics: list returns a resource snapshot with a `resourceVersion`, watch accepts a `resourceVersion` cursor, and the API signals when the cursor is no longer available due to compaction.
+- `resourceVersion` values are opaque strings that the controller must not interpret numerically; they are used only as cursors and compared for equality.
+- The informer cache interface (`HasSynced`, `MarkSynced`, `SyncedCh`, `Set`, `Delete`, `List`) is as implemented in spec 025 and is not modified by this spec.
+- The checkpoint flush interval (default: 100 events) and maximum reconnect backoff (default: 30 seconds) are configurable via the existing `viper`-based config system; no new config file formats are introduced.
+- The filesystem checkpoint store uses a directory configurable via the existing controller config; no new top-level environment variables are introduced.
+- Concurrent multi-instance operation (leader election) is out of scope; only single-active-instance operation is covered.
+- Bookmark event support requires the API to emit bookmark events on the watch stream; this spec defines the controller-side handling and assumes the API already produces them.
+- The watch stream transport is consumed via an interface abstraction; the concrete transport (GraphQL subscription or dedicated watch endpoint) is not specified here.
+
+## Dependencies
+
+- **Spec 025** (`025-controller-manager-runtime`): Provides the informer cache (`HasSynced`, `MarkSynced`, `SyncedCh`), work queue, worker pool, and health surface. This spec extends the bootstrap path without modifying core dispatch logic. ✅ Merged.
+- **Spec 026** (`026-reconcile-handler`): Defines the reconciler interface and dispatch contract that consumes work items produced by this spec's list-and-watch loop. ✅ Merged.
+- **Issue #182** (this feature): Controller Startup Resume — sub-issue of initiative #165.
+- **Issue #183** (downstream): Controller Integration Tests + Operations Runbook — blocked by this spec. Startup and resume paths must be defined before integration tests can exercise them.
+- **Issue #244** (downstream): CategoryTaxonomy Controller Reconciliation — depends on the cache being reliably populated by the startup sequence defined here.
+
+### Sub-issues of #165 (updated status)
+
+| #    | Title                                                                         | Status             |
+|------|-------------------------------------------------------------------------------|--------------------|
+| #180 | Controller Manager Runtime: Queueing, Workers, Retry/Backoff, Idempotency    | ✅ Closed          |
+| #181 | Reconcile Handler Contract for Core + CRD Kinds                              | ✅ Closed          |
+| #182 | Controller Startup Resume: List-Then-Watch and resourceVersion Checkpointing | 🔵 This spec       |
+| #183 | Controller Integration Tests + Operations Runbook                             | ⬜ Open (blocked)  |
+| #244 | CategoryTaxonomy Controller Reconciliation                                    | ⬜ Open (blocked)  |

--- a/specs/036-controller-startup-resume/tasks.md
+++ b/specs/036-controller-startup-resume/tasks.md
@@ -1,0 +1,214 @@
+# Tasks: Controller Startup Resume — List-Then-Watch and resourceVersion Checkpointing
+
+**Input**: Design documents from `/specs/036-controller-startup-resume/`
+**Branch**: `036-controller-startup-resume`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: Test-First Development (Constitution Principle I — NON-NEGOTIABLE). Tests MUST be written before implementation and verified to fail before proceeding.
+
+**Scope notes**:
+- No concrete `ListWatcher[T]` transport implementation ships in this spec — `gitstore-api`'s GraphQL schema has no `Subscription` type today, and this is explicitly greenfield per the spec's own Assumptions (see research.md §1). All tests use a hand-written `stubListWatcher[T]` test double. Production wiring of a real kind's `Runner[T]` is deferred to the spec that introduces the first concrete kind (e.g. issue #244).
+- No changes to `Reconciler`, `ReconcileResult`, or `syncChecker` from specs 025/026 — this spec is purely a producer of `WorkItemKey`s into the existing `Manager`/`Queue`.
+- No changes to `internal/api/poison.go` or the `/health` JSON surface — checkpoint health is Prometheus-only per the spec's clarification.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: User story label (US1–US4)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Scaffold the two new packages. No new external dependencies.
+
+- [X] T001 Create `gitstore-controller-manager/internal/checkpoint/` package with empty `checkpoint.go`, `filesystem.go`, `memory.go` files (package declaration only)
+- [X] T002 [P] Create `gitstore-controller-manager/internal/listwatch/` package with empty `types.go`, `listwatcher.go`, `runner.go` files (package declaration only)
+- [X] T003 [P] Create `gitstore-controller-manager/tests/checkpoint/` directory (for filesystem/memory store tests)
+- [X] T004 Verify `go build ./...` and `go test ./...` still pass after scaffolding (no behavior change)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared types, interfaces, and config/metrics declarations every user story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete and `go build ./...` passes.
+
+- [X] T005 Define `Record{Kind, ResourceVersion string; WrittenAt time.Time}` struct and `Store interface{ Load(ctx, kind string) (Record, error); Save(ctx, Record) error }` in `gitstore-controller-manager/internal/checkpoint/checkpoint.go` per contracts/checkpoint-store-api.md
+- [X] T006 [P] Implement `MemoryStore` (mutex-guarded `map[string]Record`) satisfying `Store` in `gitstore-controller-manager/internal/checkpoint/memory.go`, mirroring the style of `internal/cache.Cache`
+- [X] T007 [P] Define `EventType` enum (`Added`, `Modified`, `Deleted`, `Bookmark`), `WatchEvent[T]{Type EventType; Object T; ResourceVersion string}`, `ListResponse[T]{Items []T; ResourceVersion string}`, and `var ErrWatchExpired = errors.New(...)` in `gitstore-controller-manager/internal/listwatch/types.go` per data-model.md
+- [X] T008 [P] Define `Watcher[T]{Events() <-chan WatchEvent[T]; Err() error; Stop()}` and `ListWatcher[T]{List(ctx) (ListResponse[T], error); Watch(ctx, resourceVersion string) (Watcher[T], error)}` interfaces in `gitstore-controller-manager/internal/listwatch/listwatcher.go` per contracts/listwatcher-interface.md
+- [X] T009 Add `CheckpointDir string` (`mapstructure:"checkpoint_dir"`, default `.gitstore/checkpoints`), `CheckpointFlushIntervalEvents int` (`mapstructure:"checkpoint_flush_interval_events"`, default `100`), and `MaxWatchBackoffStr string`/`MaxWatchBackoff time.Duration` (`mapstructure:"max_watch_backoff"`/`"-"`, default `"30s"`) fields to `ControllerConfig` in `gitstore-controller-manager/internal/config/config.go`; parse `MaxWatchBackoffStr` into `MaxWatchBackoff` inside `validate()` following the existing `DefaultStallThresholdStr` idiom
+- [X] T010 [P] Add `TestLoad_Defaults` and `TestLoad_EnvOverrides` assertions for the three new config fields to `gitstore-controller-manager/internal/config/config_test.go`, using the existing `setenv(t, pairs...)` helper
+- [X] T011 [P] Declare `CheckpointLastWriteTimestamp` (`GaugeVec`, `gitstore_controller_checkpoint_last_write_timestamp_seconds`), `CheckpointWriteFailuresTotal` (`CounterVec`, `gitstore_controller_checkpoint_write_failures_total`), and `CheckpointReplayBacklog` (`GaugeVec`, `gitstore_controller_checkpoint_replay_backlog`) — each labeled `["kind"]` — in `gitstore-controller-manager/internal/health/metrics.go`, following the existing `promauto.New*Vec` pattern
+- [X] T012 Define the `Runner[T]` struct (fields: `Kind string`, `ListWatcher ListWatcher[T]`, `Cache *cache.Cache[T]`, `Store checkpoint.Store`, `Enqueue func(types.WorkItemKey) error`, `KeyFunc func(T) types.WorkItemKey`, `RevisionFunc func(T) string`, `FlushIntervalEvents int`, `MaxBackoff time.Duration`, `Log *zap.Logger`, plus an unexported `currentRV string` field) in `gitstore-controller-manager/internal/listwatch/runner.go` — type only, no `Run` method body yet
+
+**Checkpoint**: `go build ./...` must pass before proceeding.
+
+---
+
+## Phase 3: User Story 1 — Controller Boots and Reconciles All Existing Resources (Priority: P1) 🎯 MVP
+
+**Goal**: On first start, the controller lists every resource for a kind, populates the cache, marks it synced, enqueues a work item for every listed resource, then opens a watch stream at the list's resourceVersion with no duplicate enqueue across the transition.
+
+**Independent Test**: Pre-create five resources via a stub `ListWatcher[T]` that serves a static list response; start `Runner.Run` against it with no watch stream required; assert a work item is enqueued for each of the five resources within one bootstrap cycle.
+
+### Tests for User Story 1 (write first, verify they FAIL before T017)
+
+- [X] T013 [P] [US1] Create `gitstore-controller-manager/tests/contract/listwatch_bootstrap_test.go` with a hand-written `stubListWatcher[T]` test double (configurable `List` response/error/failure-count and a test-controlled `Watch` channel, mirroring the `stubReconciler` convention from spec 026) and `TestRunner_Bootstrap_ListsAndEnqueuesAll`: 50 stub items, run `Runner.Run` with a `checkpoint.MemoryStore`, assert 50 `Enqueue` calls and `cache.HasSynced() == true`
+- [X] T014 [P] [US1] Add `TestRunner_Bootstrap_NoDispatchBeforeSynced` to the same file: `stubListWatcher.List` fails until told to succeed; assert zero `Enqueue` calls and `HasSynced() == false` while `List` is still failing
+- [X] T015 [P] [US1] Add `TestRunner_Bootstrap_NoDuplicateAcrossListWatchTransition` to the same file: `List` returns an item with key K at `ResourceVersion="5"`; the stub `Watch` stream immediately delivers an `Added` event for K at `ResourceVersion="5"` (same as the list snapshot); assert K is enqueued exactly once
+- [X] T016 [P] [US1] Add `TestRunner_Bootstrap_ListFailure_RetriesWithBackoff_NeverMarksSynced` to the same file: `List` fails 3 times then succeeds; assert `MarkSynced`/`Enqueue`/`Watch` only happen after the successful call, never during the 3 failing attempts
+
+### Implementation for User Story 1
+
+- [X] T017 [US1] Implement the bootstrap branch of `Runner.Run(ctx)` in `gitstore-controller-manager/internal/listwatch/runner.go`: retry `ListWatcher.List` with unbounded exponential backoff (`cenkalti/backoff/v5`, same style as `internal/retry/retry.go` but no `MaxTries` — a list failure must never give up per FR-014) until success; `Cache.Set` every returned item; call `Cache.MarkSynced()`; `Enqueue(KeyFunc(item))` for every item; retain the enqueued-key set for the transition de-dup in T018
+- [X] T018 [US1] Implement list-to-watch transition de-dup in `Runner.Run`: after bootstrap, open `Watch(ctx, list.ResourceVersion)`; for a key whose first watch event carries a `ResourceVersion` that is not newer than the list's own `ResourceVersion`, only `Cache.Set` (suppress the duplicate `Enqueue`); once a key's event carries a strictly newer `ResourceVersion`, resume normal per-event enqueue behavior
+- [X] T019 [US1] Implement per-event handling inside the watch loop in `Runner.Run`: `Added`/`Modified` → `Cache.Set` + `Enqueue`; `Deleted` → `Cache.Delete` + `Enqueue`; `Bookmark` → update `currentRV` only, no `Enqueue` (FR-010) — flush/backpressure/reconnect logic is added in US2 (T028–T029); this task only wires the event-type switch and `currentRV` tracking
+
+**Checkpoint**: `go test ./tests/contract/ -run TestRunner_Bootstrap` passes. User Story 1 is independently functional and testable.
+
+---
+
+## Phase 4: User Story 2 — Controller Resumes After Restart Without Re-Processing Unchanged Resources (Priority: P1)
+
+**Goal**: On restart with a valid checkpoint, skip the list phase and resume the watch stream at the checkpointed resourceVersion. Persist the in-memory checkpoint every N events and on clean shutdown, atomically and per-kind. Backpressure event consumption when persistence fails so the replay window stays bounded. Same-process transient reconnects resume from the in-memory cursor, not the persisted one.
+
+**Independent Test**: Start `Runner.Run`, process events up to a checkpoint value, stop it, restart with the checkpoint file in place, and assert only events after the checkpoint are replayed with no re-list.
+
+### Tests for User Story 2 (write first, verify they FAIL before T026)
+
+- [X] T020 [P] [US2] Create `gitstore-controller-manager/tests/checkpoint/filesystem_test.go` with `TestFilesystemStore_SaveThenLoad_RoundTrips`, `TestFilesystemStore_AtomicWrite_NoPartialFileOnCrash` (assert the temp file is never observable at the final path), `TestFilesystemStore_CorruptFile_ReturnsError`, `TestFilesystemStore_MissingFile_ReturnsError`, and `TestFilesystemStore_OneFilePerKind_Isolated` (writing kind A's checkpoint never touches kind B's file)
+- [X] T021 [P] [US2] Create `gitstore-controller-manager/tests/checkpoint/memory_test.go` with `TestMemoryStore_SaveThenLoad`
+- [X] T022 [P] [US2] Create `gitstore-controller-manager/tests/contract/listwatch_resume_test.go` with `TestRunner_Resume_SkipsListPhase` and `TestRunner_Resume_WatchesFromCheckpointedVersion`: pre-populate a `checkpoint.MemoryStore` with `Record{Kind: "X", ResourceVersion: "500"}`; run `Runner.Run`; assert `stubListWatcher.List` is never called and `Watch` is called with `resourceVersion == "500"`
+- [X] T023 [P] [US2] Add `TestRunner_Flush_PersistsAfterNEvents` and `TestRunner_Flush_PersistsOnCleanShutdown` to the same file: configure `FlushIntervalEvents = 3`; feed 3 stub watch events; assert `Store.Save` is called once with the third event's `ResourceVersion`; cancel `ctx` after one more event and assert a final `Save` occurs with that event's version
+- [X] T024 [P] [US2] Add `TestRunner_Backpressure_PausesOnWriteFailure_ResumesOnSuccess` and `TestRunner_Backpressure_BoundedReplayWindow` to the same file: use a `Store` stub whose `Save` fails N times then succeeds at the flush boundary; assert no further events are drained from the stub `Watch` channel while `Save` is failing, `CheckpointWriteFailuresTotal` increments per failed attempt, and at most `FlushIntervalEvents` events are ever unpersisted at once even across repeated failures
+- [X] T025 [P] [US2] Add `TestRunner_TransientReconnect_UsesInMemoryCheckpoint_NotPersisted` and `TestRunner_TransientReconnect_BackoffCappedAtMax` to the same file: close the stub `Watcher` with a non-`ErrWatchExpired`, non-nil `Err()` after `currentRV` has advanced past the last persisted value; assert the next `Watch(ctx, resourceVersion)` call receives `currentRV` (not the stale persisted value) and that successive reconnect attempts back off exponentially, capped at `MaxBackoff`
+
+### Implementation for User Story 2
+
+- [X] T026 [US2] Implement `FilesystemStore{Dir string}` in `gitstore-controller-manager/internal/checkpoint/filesystem.go`: `NewFilesystemStore(dir) (*FilesystemStore, error)` (`os.MkdirAll(dir, 0o755)`); `Save` marshals `Record` to JSON, writes via `os.CreateTemp(dir, "<kind>.checkpoint.*.tmp")`, `Sync`s, `Close`s, then `os.Rename`s to `<dir>/<kind>.checkpoint.json`; `Load` does `os.ReadFile` + `json.Unmarshal` on that path, returning any error (not-exist, permission, malformed JSON) as-is
+- [X] T027 [US2] Implement the resume entry path in `Runner.Run` (`gitstore-controller-manager/internal/listwatch/runner.go`): call `Store.Load(ctx, Kind)` exactly once at the top of `Run`; on success, set `currentRV` from the loaded `Record.ResourceVersion` and skip directly to `Watch(ctx, currentRV)`, bypassing the T017 bootstrap branch entirely; on error (any kind), fall through to bootstrap
+- [X] T028 [US2] Implement `flushWithBackoff` in `Runner.Run`: an `eventsSinceFlush` counter incremented on every processed watch event (including `Bookmark`); at `FlushIntervalEvents` and once more on `ctx.Done()`, loop calling `Store.Save(ctx, Record{Kind, currentRV, time.Now()})`; on error, `health.CheckpointWriteFailuresTotal.WithLabelValues(Kind).Inc()`, log at WARN, and backoff-sleep before retrying — the watch loop's `select` MUST NOT read `Watcher.Events()` again until this call returns successfully (FR-005, SC-004); on success, `health.CheckpointLastWriteTimestamp.WithLabelValues(Kind).Set(float64(time.Now().Unix()))` and reset the counter
+- [X] T029 [US2] Implement transient-reconnect handling in `Runner.Run`: when `Watcher.Events()` closes and `Watcher.Err()` does not satisfy `errors.Is(err, listwatch.ErrWatchExpired)` (including a `nil` `Err()`, e.g. clean `ctx` cancellation), reopen `Watch(ctx, currentRV)` — never call `Store.Load` here — with unbounded exponential backoff (`cenkalti/backoff/v5`) between attempts, capped at `MaxBackoff`
+- [X] T030 [US2] Wire `cfg.Controller.CheckpointDir`, `cfg.Controller.CheckpointFlushIntervalEvents`, and `cfg.Controller.MaxWatchBackoff` through to `Runner` construction points by adding a documented example/comment block in `gitstore-controller-manager/cmd/controller/main.go` (no real kind is registered by this spec — see quickstart.md for the full per-kind wiring pattern a future kind-owning spec follows)
+
+**Checkpoint**: `go test ./tests/checkpoint/...` and `go test ./tests/contract/ -run 'TestRunner_(Resume|Flush|Backpressure|TransientReconnect)'` pass. User Stories 1 AND 2 both work independently.
+
+---
+
+## Phase 5: User Story 3 — Controller Handles Expired Watch Cursor and Reconnects Gracefully (Priority: P2)
+
+**Goal**: When the watch cursor is compacted, discard the stale checkpoint, re-list, enqueue only resources that changed since the last checkpoint, write a fresh checkpoint, and resume watching — repeatedly, without losing work items.
+
+**Independent Test**: A stub `ListWatcher` rejects the first `Watch` as expired, then serves a valid list and stream on the next attempt; assert the controller re-lists, updates the checkpoint, and resumes reconciliation without crashing or requiring a restart.
+
+### Tests for User Story 3 (write first, verify they FAIL before T034)
+
+- [X] T031 [P] [US3] Create `gitstore-controller-manager/tests/contract/listwatch_expiry_test.go` with `TestRunner_ExpiryRecovery_DiscardsCheckpointAndRelists`: stub `Watcher.Err()` returns `listwatch.ErrWatchExpired`; assert a fresh `List` call occurs and the stale in-memory cursor is not reused for the reconnect
+- [X] T032 [P] [US3] Add `TestRunner_ExpiryRecovery_EnqueuesOnlyChangedResources` to the same file: the re-list response contains one item whose `RevisionFunc` value is unchanged from what's already cached and one whose value differs; assert only the changed item is enqueued, while both are `Cache.Set`
+- [X] T033 [P] [US3] Add `TestRunner_ExpiryRecovery_RepeatedExpiry_NoLostWorkItems` to the same file: script two consecutive `ErrWatchExpired` closes with different changed resources each time; assert every distinct changed resource across both recovery cycles is eventually enqueued exactly once, with a bounded test timeout (no deadlock)
+
+### Implementation for User Story 3
+
+- [X] T034 [US3] Implement the expiry-recovery branch in `Runner.Run` (`gitstore-controller-manager/internal/listwatch/runner.go`): when `Watcher.Err()` satisfies `errors.Is(err, listwatch.ErrWatchExpired)`, discard `currentRV` and any pending flush state, then re-run the T017 bootstrap-retry `List` logic (extract a shared helper if not already factored out), replacing "enqueue every item" with "enqueue only if `RevisionFunc(item)` differs from the cached object's revision or the key is absent from the cache" — always `Cache.Set` regardless of the enqueue decision
+- [X] T035 [US3] After a successful expiry re-list, call `Store.Save` with the new list's `ResourceVersion` before reopening `Watch` at the new cursor (FR-009), reusing the T028 `flushWithBackoff` helper for the write
+
+**Note**: T034/T035 were implemented as part of `watchLoop`/`recoverFromExpiry` in Phase 4 (the watch loop's close-handling branches for expired vs. transient closes were designed together) — verified independently correct by the US3 test suite above, all passing.
+
+**Checkpoint**: `go test ./tests/contract/ -run TestRunner_ExpiryRecovery` passes. All three of US1/US2/US3 are independently functional.
+
+---
+
+## Phase 6: User Story 4 — Operator Monitors Checkpoint Age and Replay Backlog (Priority: P3)
+
+**Goal**: Checkpoint age, replay backlog, and write-failure count are all observable via the existing Prometheus metrics surface.
+
+**Independent Test**: Start the controller, inject a delay in checkpoint writes, and assert the metrics surface reports a non-zero checkpoint age within one metrics scrape interval.
+
+### Tests for User Story 4 (write first, verify they FAIL before T038)
+
+- [X] T036 [P] [US4] Add `TestHealth_CheckpointLastWriteTimestamp_UpdatesOnSave` and `TestHealth_CheckpointWriteFailuresTotal_IncrementsOnFailure` to `gitstore-controller-manager/tests/contract/health_test.go`: drive a `Runner` through one successful and one failing flush (reusing the T024 failing-`Store` stub) and assert both metrics via direct `.Write`/collector inspection, matching this file's existing assertion style
+- [X] T037 [P] [US4] Add `TestHealth_CheckpointReplayBacklog_TracksQueueDepth` to the same file: enqueue several items via `Manager.Enqueue` for a registered kind, call `Manager.KindStats()`, and assert `CheckpointReplayBacklog{kind}` equals `KindStats()[kind].QueueDepth`
+
+### Implementation for User Story 4
+
+- [X] T038 [US4] Set `health.CheckpointReplayBacklog.WithLabelValues(kind).Set(float64(depth))` inside the existing per-kind loop in `Manager.KindStats()` (`gitstore-controller-manager/internal/manager/manager.go`), alongside the existing `QueueDepth`/`ActiveWorkers`/`PoisonItemsTotal` sets — reuses the same `depth` value already computed there; no second bookkeeping mechanism (research.md §7)
+
+**Checkpoint**: `go test ./tests/contract/ -run TestHealth_Checkpoint` passes. All four user stories independently functional. Full `go test ./...` passes.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T039 [P] Construct a shared `checkpoint.FilesystemStore` from `cfg.Controller.CheckpointDir` in `gitstore-controller-manager/cmd/controller/main.go`, fatal-logging on construction error (same pattern as `config.Load`/`manager.InitLogger`); no per-kind `Runner` is registered here since no concrete kind/`ListWatcher` implementation exists yet (deferred — see Scope notes above)
+- [X] T040 [P] Run `make pr-ready` from the repo root; fix any lint, license-header, or test failures before marking the branch ready for review
+- [X] T041 [P] Verify every code snippet in `specs/036-controller-startup-resume/quickstart.md` against the final signatures in `internal/checkpoint/{checkpoint,filesystem,memory}.go` and `internal/listwatch/{types,listwatcher,runner}.go`; update any snippet that no longer matches
+- [X] T042 Update `docs/` (per repo guideline: "After implementing a feature update the documentation in `docs/`") to document the three new `GITSTORE_CONTROLLER__CHECKPOINT_DIR` / `GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS` / `GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF` env vars and the three new Prometheus metrics
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 — **blocks all user stories**
+- **Phase 3 (US1)**: Depends on Phase 2
+- **Phase 4 (US2)**: Depends on Phase 2; extends the same `Runner.Run` method US1 started (T017–T019) but is independently testable via its own resume/flush/backpressure/reconnect test file
+- **Phase 5 (US3)**: Depends on Phase 2 and on T017's extracted bootstrap-retry `List` helper (US1) being reusable; independently testable via its own expiry test file
+- **Phase 6 (US4)**: Depends on Phase 2 (metric declarations, T011) and reuses the T024 failing-`Store` stub from US2 for one test, but the implementation task (T038) only touches `Manager.KindStats()` — no dependency on US1/US2/US3 implementation being complete
+- **Phase 7 (Polish)**: Depends on Phases 3–6
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends only on Phase 2 — no other story dependencies. Fully independently testable with a stub `ListWatcher` and no checkpoint file (per spec's own Independent Test).
+- **US2 (P1)**: Depends on Phase 2 only at the test level (uses its own `MemoryStore`/`FilesystemStore` and stub `ListWatcher`); shares the `Runner.Run` method body with US1 but adds distinct branches (resume entry, flush, reconnect) that are additive, not overlapping, with US1's bootstrap branch.
+- **US3 (P2)**: Depends on Phase 2 and reuses US1's list-retry logic (extracted as a shared helper in T034) — test-level independence is preserved via its own `stubListWatcher` scripted to expire.
+- **US4 (P3)**: Depends on Phase 2 (metric declarations) and, for one test only, the US2 failing-`Store` stub pattern — implementation is a one-line addition to existing `Manager.KindStats()`, fully independent of US1/US3.
+
+### Parallel Opportunities
+
+Within Phase 2: T006–T008, T010–T011 can run in parallel (distinct files).
+Within Phase 3: T013–T016 (all tests) can run in parallel; T017–T019 are sequential (same method, same file).
+Within Phase 4: T020–T025 (all tests) can run in parallel; T026 can run in parallel with T020–T025; T027–T029 are sequential (same method).
+Within Phase 5: T031–T033 (all tests) can run in parallel; T034–T035 are sequential.
+Within Phase 6: T036–T037 (all tests) can run in parallel.
+Phases 3, 5, and 6 can be worked on in parallel by different developers after Phase 2 completes, provided Phase 4's `Runner.Run` scaffolding (T017) lands first as the shared method body they all extend.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write all US1 tests concurrently (same file, different test functions):
+Task: T013 — stubListWatcher + TestRunner_Bootstrap_ListsAndEnqueuesAll
+Task: T014 — TestRunner_Bootstrap_NoDispatchBeforeSynced
+Task: T015 — TestRunner_Bootstrap_NoDuplicateAcrossListWatchTransition
+Task: T016 — TestRunner_Bootstrap_ListFailure_RetriesWithBackoff_NeverMarksSynced
+
+# After tests fail, implement in order (same method body — sequential):
+Task: T017 — bootstrap List-retry + Set/MarkSynced/Enqueue
+Task: T018 — list-to-watch transition de-dup
+Task: T019 — per-event type switch (Added/Modified/Deleted/Bookmark)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (User Story 1 only)
+
+1. Phase 1: Setup (T001–T004)
+2. Phase 2: Foundational (T005–T012) — `go build ./...` must pass
+3. Phase 3: US1 tests (T013–T016, all failing) then implementation (T017–T019)
+4. **STOP**: `go test ./tests/contract/ -run TestRunner_Bootstrap` passes; manually verify with a synthetic 5-resource stub
+
+### Incremental Delivery
+
+1. Phase 2 → Phase 3 (US1): cold-start bootstrap, no persistence — **deploy-ready MVP** (US1 alone delivers correct behavior for a controller that never restarts)
+2. Phase 4 (US2): checkpoint persistence, resume, backpressure, transient reconnect — completes the restart story
+3. Phase 5 (US3): expiry recovery — additive, no changes to US1/US2 code paths beyond reusing the bootstrap-retry helper
+4. Phase 6 (US4): one new metric wired into existing `KindStats()` — additive, one-line implementation
+5. Phase 7: shared `FilesystemStore` construction in `main.go` + polish + `make pr-ready`


### PR DESCRIPTION
## Summary
- Adds a per-kind list-then-watch bootstrap/resume loop (`internal/listwatch`) and pluggable `resourceVersion` checkpoint persistence (`internal/checkpoint`) to `gitstore-controller-manager`.
- On first start, a `Runner[T]` lists all resources for a kind, populates the informer cache, marks it synced, and enqueues a work item per resource before opening a watch stream — with no duplicate enqueue across the list-to-watch transition.
- On restart with a valid checkpoint, the list phase is skipped entirely and the watch stream resumes directly at the checkpointed `resourceVersion`.
- Checkpoint writes are atomic (one JSON file per kind, write-temp-then-rename) and flush on a configurable event interval; a failed write applies backpressure (pauses further event consumption) so the replay window stays bounded even under a sustained storage outage.
- A compacted/expired watch cursor triggers automatic re-list and diff-based re-enqueue (only changed resources), with no operator intervention required.
- Checkpoint health (last write time, replay backlog, write-failure count) is exposed via three new Prometheus metrics on the existing `/metrics` endpoint.
- Closes issue #182 (initiative #165 sub-issue).

## Scope note
No concrete `ListWatcher[T]` transport ships in this PR — `gitstore-api`'s GraphQL schema has no `Subscription` type yet, so `Runner[T]`/`ListWatcher[T]` are interfaces only, backed by hand-written test doubles. Production wiring is deferred to the first spec introducing a concrete resource kind (e.g. #244), following the pattern documented in `specs/036-controller-startup-resume/quickstart.md`.

## Test plan
- [x] `make pr-ready` passes (lint, build, `go test -race -coverprofile`, license-header checks)
- [x] New unit/contract tests cover: bootstrap list-and-enqueue, cache-sync gating, list-to-watch transition dedup, list-retry-with-backoff; checkpoint resume/skip-list, flush-after-N-events, flush-on-shutdown, write-failure backpressure and bounded replay window, transient reconnect using in-memory cursor (not persisted); expired-cursor re-list/diff-enqueue/repeated-expiry; filesystem/memory checkpoint store atomicity and per-kind isolation; new Prometheus metrics
- [x] Full spec/plan/tasks artifacts in `specs/036-controller-startup-resume/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)