### PR TITLE
chore: remove deprecated clientMutationId

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -593,14 +593,12 @@ Creates a namespace.
 mutation CreateNamespace {
   createNamespace(
     input: {
-      clientMutationId: "create-gitstore-test"
-      identifier: "gitstore-test"
+            identifier: "gitstore-test"
       displayName: "GitStore Test"
       tier: USER
     }
   ) {
-    clientMutationId
-    namespace {
+        namespace {
       id
       identifier
       displayName
@@ -617,7 +615,6 @@ Input fields:
 | `identifier` | yes | Globally unique DNS-label namespace identifier |
 | `displayName` | no | Human-friendly name |
 | `tier` | yes | `USER` or `ORGANIZATION` |
-| `clientMutationId` | no | Relay request tracking |
 
 ### deleteNamespace
 
@@ -627,12 +624,10 @@ Deletes an empty namespace. Deletion is blocked if repositories remain.
 mutation DeleteNamespace {
   deleteNamespace(
     input: {
-      clientMutationId: "delete-gitstore-test"
-      identifier: "gitstore-test"
+            identifier: "gitstore-test"
     }
   ) {
-    clientMutationId
-    deletedIdentifier
+        deletedIdentifier
   }
 }
 ```
@@ -645,14 +640,12 @@ Creates a repository in a namespace.
 mutation CreateRepository($namespaceId: ID!) {
   createRepository(
     input: {
-      clientMutationId: "create-catalog"
-      namespaceId: $namespaceId
+            namespaceId: $namespaceId
       name: "catalog"
       defaultBranch: "main"
     }
   ) {
-    clientMutationId
-    repository {
+        repository {
       id
       name
       defaultBranch
@@ -671,13 +664,11 @@ mutation CreateRepository($namespaceId: ID!) {
 mutation RenameRepository($repositoryId: ID!) {
   renameRepository(
     input: {
-      clientMutationId: "rename-catalog"
-      repositoryId: $repositoryId
+            repositoryId: $repositoryId
       newName: "summer-catalog"
     }
   ) {
-    clientMutationId
-    repository {
+        repository {
       id
       name
     }
@@ -691,13 +682,11 @@ mutation RenameRepository($repositoryId: ID!) {
 mutation TransferRepository($repositoryId: ID!, $targetNamespaceId: ID!) {
   transferRepository(
     input: {
-      clientMutationId: "transfer-catalog"
-      repositoryId: $repositoryId
+            repositoryId: $repositoryId
       targetNamespaceId: $targetNamespaceId
     }
   ) {
-    clientMutationId
-    repository {
+        repository {
       id
       name
       namespace {
@@ -716,12 +705,10 @@ Deletes repository metadata and storage.
 mutation DeleteRepository($repositoryId: ID!) {
   deleteRepository(
     input: {
-      clientMutationId: "delete-catalog"
-      repositoryId: $repositoryId
+            repositoryId: $repositoryId
     }
   ) {
-    clientMutationId
-    deletedRepositoryId
+        deletedRepositoryId
   }
 }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -530,9 +530,8 @@ All namespace operations are GraphQL, consistent with the rest of the domain API
 ```graphql
 # Create a user namespace
 mutation {
-  createNamespace(input: { clientMutationId: "create-acme-corp", identifier: "acme-corp", tier: USER }) {
-    clientMutationId
-    namespace { id identifier tier createdAt createdBy }
+  createNamespace(input: { identifier: "acme-corp", tier: USER }) {
+        namespace { id identifier tier createdAt createdBy }
   }
 }
 
@@ -565,9 +564,8 @@ query {
 
 # Delete a namespace (owner or admin only)
 mutation {
-  deleteNamespace(input: { clientMutationId: "delete-acme-corp", identifier: "acme-corp" }) {
-    clientMutationId
-    deletedIdentifier
+  deleteNamespace(input: { identifier: "acme-corp" }) {
+        deletedIdentifier
   }
 }
 ```

--- a/gitstore-admin/src/components/categories/CategoryList.tsx
+++ b/gitstore-admin/src/components/categories/CategoryList.tsx
@@ -195,7 +195,6 @@ export function CategoryList({ onEdit, onDelete, onAddChild }: CategoryListProps
       // await reorderCategories({
       //   variables: {
       //     input: {
-      //       clientMutationId: uuidv4(),
       //       categoryIds: reorderedCategories.map(cat => cat.id),
       //     },
       //   },

--- a/gitstore-admin/src/components/collections/CollectionList.tsx
+++ b/gitstore-admin/src/components/collections/CollectionList.tsx
@@ -165,7 +165,6 @@ export function CollectionList({ onEdit, onDelete }: CollectionListProps) {
       // await reorderCollections({
       //   variables: {
       //     input: {
-      //       clientMutationId: uuidv4(),
       //       collectionIds: updated.map(c => c.id),
       //     },
       //   },

--- a/gitstore-admin/src/components/products/CreateProductPage.tsx
+++ b/gitstore-admin/src/components/products/CreateProductPage.tsx
@@ -41,7 +41,6 @@ export function CreateProductPage() {
       // const result = await createProduct({
       //   variables: {
       //     input: {
-      //       clientMutationId: uuidv4(),
       //       title: product.title,
       //       sku: product.sku,
       //       price: product.price,

--- a/gitstore-admin/src/components/products/EditProductPage.tsx
+++ b/gitstore-admin/src/components/products/EditProductPage.tsx
@@ -105,7 +105,6 @@ export function EditProductPage({ productId }: EditProductPageProps) {
       // const result = await updateProduct({
       //   variables: {
       //     input: {
-      //       clientMutationId: uuidv4(),
       //       id: productId,
       //       version: product.version, // Optimistic lock version
       //       title: updatedProduct.title,

--- a/gitstore-admin/src/graphql/README.md
+++ b/gitstore-admin/src/graphql/README.md
@@ -166,8 +166,6 @@ If the version doesn't match (concurrent modification), the mutation returns a `
 ## Relay Pattern
 
 All mutations follow the Relay pattern with:
-- Input object with `clientMutationId` for request tracking
-- Payload object with `clientMutationId` echoed back
 
 ```tsx
 const [createProduct] = useCreateProductMutation();
@@ -175,7 +173,6 @@ const [createProduct] = useCreateProductMutation();
 await createProduct({
   variables: {
     input: {
-      clientMutationId: 'unique-request-id',
       title: 'New Product',
       // ... other fields
     },

--- a/gitstore-admin/src/graphql/mutations.graphql
+++ b/gitstore-admin/src/graphql/mutations.graphql
@@ -2,7 +2,6 @@
 
 mutation CreateProduct($input: CreateProductInput!) {
   createProduct(input: $input) {
-    clientMutationId
     product {
       id
       title
@@ -25,7 +24,6 @@ mutation CreateProduct($input: CreateProductInput!) {
 
 mutation UpdateProduct($input: UpdateProductInput!) {
   updateProduct(input: $input) {
-    clientMutationId
     product {
       id
       title
@@ -54,7 +52,6 @@ mutation UpdateProduct($input: UpdateProductInput!) {
 
 mutation DeleteProduct($input: DeleteProductInput!) {
   deleteProduct(input: $input) {
-    clientMutationId
     deletedProductId
   }
 }
@@ -63,7 +60,6 @@ mutation DeleteProduct($input: DeleteProductInput!) {
 
 mutation CreateCategory($input: CreateCategoryInput!) {
   createCategory(input: $input) {
-    clientMutationId
     category {
       id
       name
@@ -81,7 +77,6 @@ mutation CreateCategory($input: CreateCategoryInput!) {
 
 mutation UpdateCategory($input: UpdateCategoryInput!) {
   updateCategory(input: $input) {
-    clientMutationId
     category {
       id
       name
@@ -105,14 +100,12 @@ mutation UpdateCategory($input: UpdateCategoryInput!) {
 
 mutation DeleteCategory($input: DeleteCategoryInput!) {
   deleteCategory(input: $input) {
-    clientMutationId
     deletedCategoryId
   }
 }
 
 mutation ReorderCategories($input: ReorderCategoriesInput!) {
   reorderCategories(input: $input) {
-    clientMutationId
     categories {
       id
       name
@@ -126,7 +119,6 @@ mutation ReorderCategories($input: ReorderCategoriesInput!) {
 
 mutation CreateCollection($input: CreateCollectionInput!) {
   createCollection(input: $input) {
-    clientMutationId
     collection {
       id
       name
@@ -144,7 +136,6 @@ mutation CreateCollection($input: CreateCollectionInput!) {
 
 mutation UpdateCollection($input: UpdateCollectionInput!) {
   updateCollection(input: $input) {
-    clientMutationId
     collection {
       id
       name
@@ -168,14 +159,12 @@ mutation UpdateCollection($input: UpdateCollectionInput!) {
 
 mutation DeleteCollection($input: DeleteCollectionInput!) {
   deleteCollection(input: $input) {
-    clientMutationId
     deletedCollectionId
   }
 }
 
 mutation ReorderCollections($input: ReorderCollectionsInput!) {
   reorderCollections(input: $input) {
-    clientMutationId
     collections {
       id
       name
@@ -189,7 +178,6 @@ mutation ReorderCollections($input: ReorderCollectionsInput!) {
 
 mutation PublishCatalog($input: PublishCatalogInput!) {
   publishCatalog(input: $input) {
-    clientMutationId
     tagName
     commitHash
     pushedAt

--- a/gitstore-admin/src/lib/mutation-hooks.ts
+++ b/gitstore-admin/src/lib/mutation-hooks.ts
@@ -36,7 +36,6 @@ export function useCreateProduct() {
   return useMutation(`
     mutation CreateProduct($input: CreateProductInput!) {
       createProduct(input: $input) {
-        clientMutationId
         product {
           id
           title
@@ -65,7 +64,6 @@ export function useUpdateProduct() {
   return useMutation(`
     mutation UpdateProduct($input: UpdateProductInput!) {
       updateProduct(input: $input) {
-        clientMutationId
         product {
           id
           title
@@ -94,7 +92,6 @@ export function useDeleteProduct() {
   return useMutation(`
     mutation DeleteProduct($input: DeleteProductInput!) {
       deleteProduct(input: $input) {
-        clientMutationId
         success
       }
     }
@@ -108,7 +105,6 @@ export function useCreateCategory() {
   return useMutation(`
     mutation CreateCategory($input: CreateCategoryInput!) {
       createCategory(input: $input) {
-        clientMutationId
         category {
           id
           name
@@ -132,7 +128,6 @@ export function useUpdateCategory() {
   return useMutation(`
     mutation UpdateCategory($input: UpdateCategoryInput!) {
       updateCategory(input: $input) {
-        clientMutationId
         category {
           id
           name
@@ -156,7 +151,6 @@ export function useDeleteCategory() {
   return useMutation(`
     mutation DeleteCategory($input: DeleteCategoryInput!) {
       deleteCategory(input: $input) {
-        clientMutationId
         success
       }
     }
@@ -170,7 +164,6 @@ export function useReorderCategories() {
   return useMutation(`
     mutation ReorderCategories($input: ReorderCategoriesInput!) {
       reorderCategories(input: $input) {
-        clientMutationId
         categories {
           id
           displayOrder
@@ -188,7 +181,6 @@ export function useCreateCollection() {
   return useMutation(`
     mutation CreateCollection($input: CreateCollectionInput!) {
       createCollection(input: $input) {
-        clientMutationId
         collection {
           id
           name
@@ -212,7 +204,6 @@ export function useUpdateCollection() {
   return useMutation(`
     mutation UpdateCollection($input: UpdateCollectionInput!) {
       updateCollection(input: $input) {
-        clientMutationId
         collection {
           id
           name
@@ -236,7 +227,6 @@ export function useDeleteCollection() {
   return useMutation(`
     mutation DeleteCollection($input: DeleteCollectionInput!) {
       deleteCollection(input: $input) {
-        clientMutationId
         success
       }
     }
@@ -250,7 +240,6 @@ export function useReorderCollections() {
   return useMutation(`
     mutation ReorderCollections($input: ReorderCollectionsInput!) {
       reorderCollections(input: $input) {
-        clientMutationId
         collections {
           id
           displayOrder

--- a/gitstore-admin/src/lib/publish.ts
+++ b/gitstore-admin/src/lib/publish.ts
@@ -5,7 +5,6 @@ import { Client } from 'urql';
 
 // Types matching GraphQL schema
 interface PublishCatalogInput {
-  clientMutationId?: string;
   version: string; // Required in schema
   message: string;
 }
@@ -24,7 +23,6 @@ interface CatalogVersion {
 }
 
 interface PublishCatalogPayload {
-  clientMutationId?: string | null;
   catalogVersion?: CatalogVersion | null;
 }
 
@@ -45,7 +43,6 @@ export async function publishCatalog(
   const PUBLISH_CATALOG_MUTATION = `
     mutation PublishCatalog($input: PublishCatalogInput!) {
       publishCatalog(input: $input) {
-        clientMutationId
         catalogVersion {
           tag
           commit
@@ -67,7 +64,6 @@ export async function publishCatalog(
       PUBLISH_CATALOG_MUTATION,
       {
         input: {
-          clientMutationId: generateClientMutationId(),
           version,
           message,
         },

--- a/gitstore-api/cmd/server/main_test.go
+++ b/gitstore-api/cmd/server/main_test.go
@@ -142,9 +142,7 @@ func TestGraphQLHandlerAcceptsBearerTokenForNamespaceMutation(t *testing.T) {
 	require.NotEmpty(t, loginResponse.Data.Login.Token.AccessToken)
 	assert.Equal(t, "Bearer", loginResponse.Data.Login.Token.TokenType)
 
-	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{
-		"query": "mutation { createNamespace(input: { identifier: \"alice\", tier: USER }) { clientMutationId namespace { identifier createdBy } } }"
-	}`))
+	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{"query":"mutation { createNamespace(input: { identifier: \"alice\", tier: USER }) { namespace { identifier createdBy } } }"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+loginResponse.Data.Login.Token.AccessToken)
 	w := httptest.NewRecorder()

--- a/gitstore-api/internal/graph/generated/auth.generated.go
+++ b/gitstore-api/internal/graph/generated/auth.generated.go
@@ -347,36 +347,6 @@ func (ec *executionContext) unmarshalInputLoginInput(ctx context.Context, obj an
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputLogoutInput(ctx context.Context, obj any) (model.LogoutInput, error) {
-	var it model.LogoutInput
-	if obj == nil {
-		return it, nil
-	}
-
-	asMap := map[string]any{}
-	for k, v := range obj.(map[string]any) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"clientMutationId"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
-		}
-	}
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputRefreshTokenInput(ctx context.Context, obj any) (model.RefreshTokenInput, error) {
 	var it model.RefreshTokenInput
 	if obj == nil {
@@ -659,11 +629,6 @@ func (ec *executionContext) marshalNLoginPayload2ᚖgithubᚗcomᚋgitstoreᚑde
 		return graphql.Null
 	}
 	return ec._LoginPayload(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalNLogoutInput2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLogoutInput(ctx context.Context, v any) (model.LogoutInput, error) {
-	res, err := ec.unmarshalInputLogoutInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalNLogoutPayload2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLogoutPayload(ctx context.Context, sel ast.SelectionSet, v model.LogoutPayload) graphql.Marshaler {

--- a/gitstore-api/internal/graph/generated/category.generated.go
+++ b/gitstore-api/internal/graph/generated/category.generated.go
@@ -1248,29 +1248,6 @@ func (ec *executionContext) fieldContext_CategoryTaxonomyStatus_resolved(_ conte
 	return fc, nil
 }
 
-func (ec *executionContext) _CreateCategoryPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.CreateCategoryPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_CreateCategoryPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_CreateCategoryPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("CreateCategoryPayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
 func (ec *executionContext) _CreateCategoryPayload_category(ctx context.Context, field graphql.CollectedField, obj *model.CreateCategoryPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1301,29 +1278,6 @@ func (ec *executionContext) fieldContext_CreateCategoryPayload_category(_ contex
 		},
 	}
 	return fc, nil
-}
-
-func (ec *executionContext) _DeleteCategoryPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.DeleteCategoryPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_DeleteCategoryPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_DeleteCategoryPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("DeleteCategoryPayload", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _DeleteCategoryPayload_deletedCategoryId(ctx context.Context, field graphql.CollectedField, obj *model.DeleteCategoryPayload) (ret graphql.Marshaler) {
@@ -1416,29 +1370,6 @@ func (ec *executionContext) _KeyValuePair_value(ctx context.Context, field graph
 }
 func (ec *executionContext) fieldContext_KeyValuePair_value(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("KeyValuePair", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
-func (ec *executionContext) _ReorderCategoriesPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.ReorderCategoriesPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_ReorderCategoriesPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_ReorderCategoriesPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("ReorderCategoriesPayload", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _ReorderCategoriesPayload_categories(ctx context.Context, field graphql.CollectedField, obj *model.ReorderCategoriesPayload) (ret graphql.Marshaler) {
@@ -1565,29 +1496,6 @@ func (ec *executionContext) fieldContext_ResolvedCategoryTaxonomy_productCount(_
 	return graphql.NewScalarFieldContext("ResolvedCategoryTaxonomy", field, false, false, errors.New("field of type Int does not have child fields"))
 }
 
-func (ec *executionContext) _UpdateCategoryPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.UpdateCategoryPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_UpdateCategoryPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_UpdateCategoryPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("UpdateCategoryPayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
 func (ec *executionContext) _UpdateCategoryPayload_category(ctx context.Context, field graphql.CollectedField, obj *model.UpdateCategoryPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1667,20 +1575,13 @@ func (ec *executionContext) unmarshalInputCreateCategoryInput(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "name", "slug", "parentId", "displayOrder", "body"}
+	fieldsInOrder := [...]string{"name", "slug", "parentId", "displayOrder", "body"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "name":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -1732,20 +1633,13 @@ func (ec *executionContext) unmarshalInputDeleteCategoryInput(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "id"}
+	fieldsInOrder := [...]string{"id"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "id":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
 			data, err := ec.unmarshalNID2string(ctx, v)
@@ -1769,20 +1663,13 @@ func (ec *executionContext) unmarshalInputReorderCategoriesInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "orderedIds", "parentId", "movedCategoryId", "newParentId"}
+	fieldsInOrder := [...]string{"orderedIds", "parentId", "movedCategoryId", "newParentId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "orderedIds":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("orderedIds"))
 			data, err := ec.unmarshalNID2ᚕstringᚄ(ctx, v)
@@ -1827,20 +1714,13 @@ func (ec *executionContext) unmarshalInputUpdateCategoryInput(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "id", "name", "slug", "parentId", "displayOrder", "body", "version"}
+	fieldsInOrder := [...]string{"id", "name", "slug", "parentId", "displayOrder", "body", "version"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "id":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
 			data, err := ec.unmarshalNID2string(ctx, v)
@@ -2404,8 +2284,6 @@ func (ec *executionContext) _CreateCategoryPayload(ctx context.Context, sel ast.
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CreateCategoryPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._CreateCategoryPayload_clientMutationId(ctx, field, obj)
 		case "category":
 			out.Values[i] = ec._CreateCategoryPayload_category(ctx, field, obj)
 		default:
@@ -2442,8 +2320,6 @@ func (ec *executionContext) _DeleteCategoryPayload(ctx context.Context, sel ast.
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("DeleteCategoryPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._DeleteCategoryPayload_clientMutationId(ctx, field, obj)
 		case "deletedCategoryId":
 			out.Values[i] = ec._DeleteCategoryPayload_deletedCategoryId(ctx, field, obj)
 		case "orphanedProductIds":
@@ -2526,8 +2402,6 @@ func (ec *executionContext) _ReorderCategoriesPayload(ctx context.Context, sel a
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ReorderCategoriesPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._ReorderCategoriesPayload_clientMutationId(ctx, field, obj)
 		case "categories":
 			out.Values[i] = ec._ReorderCategoriesPayload_categories(ctx, field, obj)
 		default:
@@ -2618,8 +2492,6 @@ func (ec *executionContext) _UpdateCategoryPayload(ctx context.Context, sel ast.
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("UpdateCategoryPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._UpdateCategoryPayload_clientMutationId(ctx, field, obj)
 		case "category":
 			out.Values[i] = ec._UpdateCategoryPayload_category(ctx, field, obj)
 		case "conflict":

--- a/gitstore-api/internal/graph/generated/collection.generated.go
+++ b/gitstore-api/internal/graph/generated/collection.generated.go
@@ -1418,29 +1418,6 @@ func (ec *executionContext) fieldContext_LabelSelectorRequirement_values(_ conte
 	return graphql.NewScalarFieldContext("LabelSelectorRequirement", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _PublishCatalogPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.PublishCatalogPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_PublishCatalogPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_PublishCatalogPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("PublishCatalogPayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
 func (ec *executionContext) _PublishCatalogPayload_catalogVersion(ctx context.Context, field graphql.CollectedField, obj *model.PublishCatalogPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1635,20 +1612,13 @@ func (ec *executionContext) unmarshalInputPublishCatalogInput(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "version", "message"}
+	fieldsInOrder := [...]string{"version", "message"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "version":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("version"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -2434,8 +2404,6 @@ func (ec *executionContext) _PublishCatalogPayload(ctx context.Context, sel ast.
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("PublishCatalogPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._PublishCatalogPayload_clientMutationId(ctx, field, obj)
 		case "catalogVersion":
 			out.Values[i] = ec._PublishCatalogPayload_catalogVersion(ctx, field, obj)
 		default:

--- a/gitstore-api/internal/graph/generated/namespace.generated.go
+++ b/gitstore-api/internal/graph/generated/namespace.generated.go
@@ -29,29 +29,6 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _CreateNamespacePayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.CreateNamespacePayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_CreateNamespacePayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_CreateNamespacePayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("CreateNamespacePayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
 func (ec *executionContext) _CreateNamespacePayload_namespace(ctx context.Context, field graphql.CollectedField, obj *model.CreateNamespacePayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -82,29 +59,6 @@ func (ec *executionContext) fieldContext_CreateNamespacePayload_namespace(_ cont
 		},
 	}
 	return fc, nil
-}
-
-func (ec *executionContext) _DeleteNamespacePayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.DeleteNamespacePayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_DeleteNamespacePayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_DeleteNamespacePayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("DeleteNamespacePayload", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _DeleteNamespacePayload_deletedIdentifier(ctx context.Context, field graphql.CollectedField, obj *model.DeleteNamespacePayload) (ret graphql.Marshaler) {
@@ -471,20 +425,13 @@ func (ec *executionContext) unmarshalInputCreateNamespaceInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "identifier", "displayName", "tier"}
+	fieldsInOrder := [...]string{"identifier", "displayName", "tier"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "identifier":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("identifier"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -522,20 +469,13 @@ func (ec *executionContext) unmarshalInputDeleteNamespaceInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "identifier"}
+	fieldsInOrder := [...]string{"identifier"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "identifier":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("identifier"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -604,8 +544,6 @@ func (ec *executionContext) _CreateNamespacePayload(ctx context.Context, sel ast
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CreateNamespacePayload")
-		case "clientMutationId":
-			out.Values[i] = ec._CreateNamespacePayload_clientMutationId(ctx, field, obj)
 		case "namespace":
 			out.Values[i] = ec._CreateNamespacePayload_namespace(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -645,8 +583,6 @@ func (ec *executionContext) _DeleteNamespacePayload(ctx context.Context, sel ast
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("DeleteNamespacePayload")
-		case "clientMutationId":
-			out.Values[i] = ec._DeleteNamespacePayload_clientMutationId(ctx, field, obj)
 		case "deletedIdentifier":
 			out.Values[i] = ec._DeleteNamespacePayload_deletedIdentifier(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/gitstore-api/internal/graph/generated/repository.generated.go
+++ b/gitstore-api/internal/graph/generated/repository.generated.go
@@ -29,29 +29,6 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _CreateRepositoryPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.CreateRepositoryPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_CreateRepositoryPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_CreateRepositoryPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("CreateRepositoryPayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
 func (ec *executionContext) _CreateRepositoryPayload_repository(ctx context.Context, field graphql.CollectedField, obj *model.CreateRepositoryPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -84,29 +61,6 @@ func (ec *executionContext) fieldContext_CreateRepositoryPayload_repository(_ co
 	return fc, nil
 }
 
-func (ec *executionContext) _DeleteRepositoryPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.DeleteRepositoryPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_DeleteRepositoryPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_DeleteRepositoryPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("DeleteRepositoryPayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
 func (ec *executionContext) _DeleteRepositoryPayload_deletedRepositoryId(ctx context.Context, field graphql.CollectedField, obj *model.DeleteRepositoryPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -128,29 +82,6 @@ func (ec *executionContext) _DeleteRepositoryPayload_deletedRepositoryId(ctx con
 }
 func (ec *executionContext) fieldContext_DeleteRepositoryPayload_deletedRepositoryId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("DeleteRepositoryPayload", field, false, false, errors.New("field of type ID does not have child fields"))
-}
-
-func (ec *executionContext) _RenameRepositoryPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.RenameRepositoryPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_RenameRepositoryPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_RenameRepositoryPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("RenameRepositoryPayload", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _RenameRepositoryPayload_repository(ctx context.Context, field graphql.CollectedField, obj *model.RenameRepositoryPayload) (ret graphql.Marshaler) {
@@ -566,29 +497,6 @@ func (ec *executionContext) fieldContext_RepositoryEdge_node(_ context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _TransferRepositoryPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.TransferRepositoryPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_TransferRepositoryPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_TransferRepositoryPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("TransferRepositoryPayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
 func (ec *executionContext) _TransferRepositoryPayload_repository(ctx context.Context, field graphql.CollectedField, obj *model.TransferRepositoryPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -636,20 +544,13 @@ func (ec *executionContext) unmarshalInputCreateRepositoryInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "namespaceId", "name", "defaultBranch"}
+	fieldsInOrder := [...]string{"namespaceId", "name", "defaultBranch"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "namespaceId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("namespaceId"))
 			data, err := ec.unmarshalNID2string(ctx, v)
@@ -687,20 +588,13 @@ func (ec *executionContext) unmarshalInputDeleteRepositoryInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "repositoryId"}
+	fieldsInOrder := [...]string{"repositoryId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "repositoryId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("repositoryId"))
 			data, err := ec.unmarshalNID2string(ctx, v)
@@ -724,20 +618,13 @@ func (ec *executionContext) unmarshalInputRenameRepositoryInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "repositoryId", "newName"}
+	fieldsInOrder := [...]string{"repositoryId", "newName"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "repositoryId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("repositoryId"))
 			data, err := ec.unmarshalNID2string(ctx, v)
@@ -842,20 +729,13 @@ func (ec *executionContext) unmarshalInputTransferRepositoryInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "repositoryId", "targetNamespaceId"}
+	fieldsInOrder := [...]string{"repositoryId", "targetNamespaceId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "repositoryId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("repositoryId"))
 			data, err := ec.unmarshalNID2string(ctx, v)
@@ -894,8 +774,6 @@ func (ec *executionContext) _CreateRepositoryPayload(ctx context.Context, sel as
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CreateRepositoryPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._CreateRepositoryPayload_clientMutationId(ctx, field, obj)
 		case "repository":
 			out.Values[i] = ec._CreateRepositoryPayload_repository(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -935,8 +813,6 @@ func (ec *executionContext) _DeleteRepositoryPayload(ctx context.Context, sel as
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("DeleteRepositoryPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._DeleteRepositoryPayload_clientMutationId(ctx, field, obj)
 		case "deletedRepositoryId":
 			out.Values[i] = ec._DeleteRepositoryPayload_deletedRepositoryId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -976,8 +852,6 @@ func (ec *executionContext) _RenameRepositoryPayload(ctx context.Context, sel as
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("RenameRepositoryPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._RenameRepositoryPayload_clientMutationId(ctx, field, obj)
 		case "repository":
 			out.Values[i] = ec._RenameRepositoryPayload_repository(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -1194,8 +1068,6 @@ func (ec *executionContext) _TransferRepositoryPayload(ctx context.Context, sel 
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("TransferRepositoryPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._TransferRepositoryPayload_clientMutationId(ctx, field, obj)
 		case "repository":
 			out.Values[i] = ec._TransferRepositoryPayload_repository(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/gitstore-api/internal/graph/generated/root_.generated.go
+++ b/gitstore-api/internal/graph/generated/root_.generated.go
@@ -186,8 +186,7 @@ type ComplexityRoot struct {
 	}
 
 	CreateCategoryPayload struct {
-		Category         func(childComplexity int) int
-		ClientMutationID func(childComplexity int) int
+		Category func(childComplexity int) int
 	}
 
 	CreateCollectionPayload struct {
@@ -195,17 +194,14 @@ type ComplexityRoot struct {
 	}
 
 	CreateNamespacePayload struct {
-		ClientMutationID func(childComplexity int) int
-		Namespace        func(childComplexity int) int
+		Namespace func(childComplexity int) int
 	}
 
 	CreateRepositoryPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Repository       func(childComplexity int) int
+		Repository func(childComplexity int) int
 	}
 
 	DeleteCategoryPayload struct {
-		ClientMutationID   func(childComplexity int) int
 		DeletedCategoryID  func(childComplexity int) int
 		OrphanedProductIds func(childComplexity int) int
 	}
@@ -215,12 +211,10 @@ type ComplexityRoot struct {
 	}
 
 	DeleteNamespacePayload struct {
-		ClientMutationID  func(childComplexity int) int
 		DeletedIdentifier func(childComplexity int) int
 	}
 
 	DeleteRepositoryPayload struct {
-		ClientMutationID    func(childComplexity int) int
 		DeletedRepositoryID func(childComplexity int) int
 	}
 
@@ -279,7 +273,7 @@ type ComplexityRoot struct {
 		DeleteNamespace    func(childComplexity int, input model.DeleteNamespaceInput) int
 		DeleteRepository   func(childComplexity int, input model.DeleteRepositoryInput) int
 		Login              func(childComplexity int, input model.LoginInput) int
-		Logout             func(childComplexity int, input model.LogoutInput) int
+		Logout             func(childComplexity int) int
 		PublishCatalog     func(childComplexity int, input model.PublishCatalogInput) int
 		RefreshToken       func(childComplexity int, input model.RefreshTokenInput) int
 		RenameRepository   func(childComplexity int, input model.RenameRepositoryInput) int
@@ -482,8 +476,7 @@ type ComplexityRoot struct {
 	}
 
 	PublishCatalogPayload struct {
-		CatalogVersion   func(childComplexity int) int
-		ClientMutationID func(childComplexity int) int
+		CatalogVersion func(childComplexity int) int
 	}
 
 	QuantityDefinition struct {
@@ -514,13 +507,11 @@ type ComplexityRoot struct {
 	}
 
 	RenameRepositoryPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Repository       func(childComplexity int) int
+		Repository func(childComplexity int) int
 	}
 
 	ReorderCategoriesPayload struct {
-		Categories       func(childComplexity int) int
-		ClientMutationID func(childComplexity int) int
+		Categories func(childComplexity int) int
 	}
 
 	Repository struct {
@@ -625,14 +616,12 @@ type ComplexityRoot struct {
 	}
 
 	TransferRepositoryPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Repository       func(childComplexity int) int
+		Repository func(childComplexity int) int
 	}
 
 	UpdateCategoryPayload struct {
-		Category         func(childComplexity int) int
-		ClientMutationID func(childComplexity int) int
-		Conflict         func(childComplexity int) int
+		Category func(childComplexity int) int
+		Conflict func(childComplexity int) int
 	}
 
 	UpdateCollectionPayload struct {
@@ -1348,26 +1337,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.CreateCategoryPayload.Category(childComplexity), true
 
-	case "CreateCategoryPayload.clientMutationId":
-		if e.ComplexityRoot.CreateCategoryPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.CreateCategoryPayload.ClientMutationID(childComplexity), true
-
 	case "CreateCollectionPayload.collection":
 		if e.ComplexityRoot.CreateCollectionPayload.Collection == nil {
 			break
 		}
 
 		return e.ComplexityRoot.CreateCollectionPayload.Collection(childComplexity), true
-
-	case "CreateNamespacePayload.clientMutationId":
-		if e.ComplexityRoot.CreateNamespacePayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.CreateNamespacePayload.ClientMutationID(childComplexity), true
 
 	case "CreateNamespacePayload.namespace":
 		if e.ComplexityRoot.CreateNamespacePayload.Namespace == nil {
@@ -1376,26 +1351,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.CreateNamespacePayload.Namespace(childComplexity), true
 
-	case "CreateRepositoryPayload.clientMutationId":
-		if e.ComplexityRoot.CreateRepositoryPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.CreateRepositoryPayload.ClientMutationID(childComplexity), true
-
 	case "CreateRepositoryPayload.repository":
 		if e.ComplexityRoot.CreateRepositoryPayload.Repository == nil {
 			break
 		}
 
 		return e.ComplexityRoot.CreateRepositoryPayload.Repository(childComplexity), true
-
-	case "DeleteCategoryPayload.clientMutationId":
-		if e.ComplexityRoot.DeleteCategoryPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.DeleteCategoryPayload.ClientMutationID(childComplexity), true
 
 	case "DeleteCategoryPayload.deletedCategoryId":
 		if e.ComplexityRoot.DeleteCategoryPayload.DeletedCategoryID == nil {
@@ -1418,26 +1379,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.DeleteCollectionPayload.DeletedCollectionID(childComplexity), true
 
-	case "DeleteNamespacePayload.clientMutationId":
-		if e.ComplexityRoot.DeleteNamespacePayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.DeleteNamespacePayload.ClientMutationID(childComplexity), true
-
 	case "DeleteNamespacePayload.deletedIdentifier":
 		if e.ComplexityRoot.DeleteNamespacePayload.DeletedIdentifier == nil {
 			break
 		}
 
 		return e.ComplexityRoot.DeleteNamespacePayload.DeletedIdentifier(childComplexity), true
-
-	case "DeleteRepositoryPayload.clientMutationId":
-		if e.ComplexityRoot.DeleteRepositoryPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.DeleteRepositoryPayload.ClientMutationID(childComplexity), true
 
 	case "DeleteRepositoryPayload.deletedRepositoryId":
 		if e.ComplexityRoot.DeleteRepositoryPayload.DeletedRepositoryID == nil {
@@ -1685,12 +1632,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			break
 		}
 
-		args, err := ec.field_Mutation_logout_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.ComplexityRoot.Mutation.Logout(childComplexity, args["input"].(model.LogoutInput)), true
+		return e.ComplexityRoot.Mutation.Logout(childComplexity), true
 
 	case "Mutation.publishCatalog":
 		if e.ComplexityRoot.Mutation.PublishCatalog == nil {
@@ -2607,13 +2549,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.PublishCatalogPayload.CatalogVersion(childComplexity), true
 
-	case "PublishCatalogPayload.clientMutationId":
-		if e.ComplexityRoot.PublishCatalogPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.PublishCatalogPayload.ClientMutationID(childComplexity), true
-
 	case "QuantityDefinition.max":
 		if e.ComplexityRoot.QuantityDefinition.Max == nil {
 			break
@@ -2810,13 +2745,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.RefreshTokenPayload.Token(childComplexity), true
 
-	case "RenameRepositoryPayload.clientMutationId":
-		if e.ComplexityRoot.RenameRepositoryPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.RenameRepositoryPayload.ClientMutationID(childComplexity), true
-
 	case "RenameRepositoryPayload.repository":
 		if e.ComplexityRoot.RenameRepositoryPayload.Repository == nil {
 			break
@@ -2830,13 +2758,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.ReorderCategoriesPayload.Categories(childComplexity), true
-
-	case "ReorderCategoriesPayload.clientMutationId":
-		if e.ComplexityRoot.ReorderCategoriesPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.ReorderCategoriesPayload.ClientMutationID(childComplexity), true
 
 	case "Repository.createdAt":
 		if e.ComplexityRoot.Repository.CreatedAt == nil {
@@ -3230,13 +3151,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.TokenResponse.TokenType(childComplexity), true
 
-	case "TransferRepositoryPayload.clientMutationId":
-		if e.ComplexityRoot.TransferRepositoryPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.TransferRepositoryPayload.ClientMutationID(childComplexity), true
-
 	case "TransferRepositoryPayload.repository":
 		if e.ComplexityRoot.TransferRepositoryPayload.Repository == nil {
 			break
@@ -3250,13 +3164,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.UpdateCategoryPayload.Category(childComplexity), true
-
-	case "UpdateCategoryPayload.clientMutationId":
-		if e.ComplexityRoot.UpdateCategoryPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.UpdateCategoryPayload.ClientMutationID(childComplexity), true
 
 	case "UpdateCategoryPayload.conflict":
 		if e.ComplexityRoot.UpdateCategoryPayload.Conflict == nil {
@@ -3335,7 +3242,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteNamespaceInput,
 		ec.unmarshalInputDeleteRepositoryInput,
 		ec.unmarshalInputLoginInput,
-		ec.unmarshalInputLogoutInput,
 		ec.unmarshalInputNamespaceBy,
 		ec.unmarshalInputProductBy,
 		ec.unmarshalInputProductNamespacePath,
@@ -3504,17 +3410,6 @@ type LoginPayload {
 }
 
 """
-Logout mutation input (Relay pattern)
-"""
-input LogoutInput {
-  """
-  TODO: Is it safe to remove and empty Input?
-  Client mutation ID for request tracking (Relay pattern)
-  """
-  clientMutationId: String
-}
-
-"""
 Logout mutation payload (Relay pattern)
 """
 type LogoutPayload {
@@ -3560,7 +3455,7 @@ extend type Mutation {
   """
   Logout and invalidate current session
   """
-  logout(input: LogoutInput!): LogoutPayload!
+  logout: LogoutPayload!
 
   """
   Refresh authentication token
@@ -3602,7 +3497,7 @@ extend type Mutation {
   Delete a category
   """
   deleteCategory(input: DeleteCategoryInput!): DeleteCategoryPayload!
-  
+
   """
   Reorder categories (drag-and-drop)
   """
@@ -3801,10 +3696,8 @@ type CategoryConnection {
 Input for creating a category
 """
 input CreateCategoryInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Category name
@@ -3836,10 +3729,8 @@ input CreateCategoryInput {
 Payload for createCategory mutation
 """
 type CreateCategoryPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   The created category
@@ -3851,10 +3742,8 @@ type CreateCategoryPayload {
 Input for updating a category
 """
 input UpdateCategoryInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Category ID to update
@@ -3897,10 +3786,8 @@ input UpdateCategoryInput {
 Payload for updateCategory mutation
 """
 type UpdateCategoryPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   The updated category
@@ -3917,10 +3804,8 @@ type UpdateCategoryPayload {
 Input for deleting a category
 """
 input DeleteCategoryInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Category ID to delete
@@ -3932,10 +3817,8 @@ input DeleteCategoryInput {
 Payload for deleteCategory mutation
 """
 type DeleteCategoryPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Deleted category ID
@@ -3952,10 +3835,8 @@ type DeleteCategoryPayload {
 Input for reordering categories (drag-and-drop)
 """
 input ReorderCategoriesInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Ordered list of category IDs within parent
@@ -3982,10 +3863,8 @@ input ReorderCategoriesInput {
 Payload for reorderCategories mutation
 """
 type ReorderCategoriesPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Updated categories
@@ -4332,13 +4211,11 @@ type DeleteCollectionPayload {
 # ============================================================================
 
 input PublishCatalogInput {
-  clientMutationId: String
   version: String!
   message: String!
 }
 
 type PublishCatalogPayload {
-  clientMutationId: String
   catalogVersion: CatalogVersion
 }
 
@@ -4474,11 +4351,6 @@ Input for creating a new namespace.
 """
 input CreateNamespaceInput {
   """
-  TODO: Remove, deprecated in relay
-  """
-  clientMutationId: String
-
-  """
   The human-readable identifier for the namespace.
   Must be globally unique across all tiers.
   DNS label format: lowercase alphanumeric and hyphens, 1–63 characters.
@@ -4505,11 +4377,6 @@ Input for deleting a namespace.
 """
 input DeleteNamespaceInput {
   """
-  TODO: Remove, deprecated in relay
-  """
-  clientMutationId: String
-
-  """
   The identifier of the namespace to delete.
   Deletion is blocked if any repositories exist within the namespace.
   Requires the caller to be the namespace owner (createdBy) or isAdmin.
@@ -4522,11 +4389,6 @@ Payload returned after successfully creating a namespace.
 """
 type CreateNamespacePayload {
   """
-  TODO: Remove, deprecated in relay
-  """
-  clientMutationId: String
-
-  """
   The newly created namespace.
   """
   namespace: Namespace!
@@ -4536,11 +4398,6 @@ type CreateNamespacePayload {
 Payload returned after successfully deleting a namespace.
 """
 type DeleteNamespacePayload {
-  """
-  TODO: Remove, deprecated in relay
-  """
-  clientMutationId: String
-
   """
   The identifier of the deleted namespace.
   """
@@ -5401,19 +5258,16 @@ extend type Mutation {
 }
 
 input CreateRepositoryInput {
-  clientMutationId: String
   namespaceId: ID!
   name: String!
   defaultBranch: String
 }
 
 type CreateRepositoryPayload {
-  clientMutationId: String
   repository: Repository!
 }
 
 input RenameRepositoryInput {
-  clientMutationId: String
   """
   Relay ID of the repository to rename.
   """
@@ -5422,12 +5276,10 @@ input RenameRepositoryInput {
 }
 
 type RenameRepositoryPayload {
-  clientMutationId: String
   repository: Repository!
 }
 
 input TransferRepositoryInput {
-  clientMutationId: String
   """
   Relay ID of the repository to transfer.
   """
@@ -5439,17 +5291,14 @@ input TransferRepositoryInput {
 }
 
 type TransferRepositoryPayload {
-  clientMutationId: String
   repository: Repository!
 }
 
 input DeleteRepositoryInput {
-  clientMutationId: String
   repositoryId: ID!
 }
 
 type DeleteRepositoryPayload {
-  clientMutationId: String
   deletedRepositoryId: ID!
 }
 `, BuiltIn: false},
@@ -5964,8 +5813,6 @@ func (ec *executionContext) childFields_CollectionStatus(ctx context.Context, fi
 
 func (ec *executionContext) childFields_CreateCategoryPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_CreateCategoryPayload_clientMutationId(ctx, field)
 	case "category":
 		return ec.fieldContext_CreateCategoryPayload_category(ctx, field)
 	}
@@ -5982,8 +5829,6 @@ func (ec *executionContext) childFields_CreateCollectionPayload(ctx context.Cont
 
 func (ec *executionContext) childFields_CreateNamespacePayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_CreateNamespacePayload_clientMutationId(ctx, field)
 	case "namespace":
 		return ec.fieldContext_CreateNamespacePayload_namespace(ctx, field)
 	}
@@ -5992,8 +5837,6 @@ func (ec *executionContext) childFields_CreateNamespacePayload(ctx context.Conte
 
 func (ec *executionContext) childFields_CreateRepositoryPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_CreateRepositoryPayload_clientMutationId(ctx, field)
 	case "repository":
 		return ec.fieldContext_CreateRepositoryPayload_repository(ctx, field)
 	}
@@ -6002,8 +5845,6 @@ func (ec *executionContext) childFields_CreateRepositoryPayload(ctx context.Cont
 
 func (ec *executionContext) childFields_DeleteCategoryPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_DeleteCategoryPayload_clientMutationId(ctx, field)
 	case "deletedCategoryId":
 		return ec.fieldContext_DeleteCategoryPayload_deletedCategoryId(ctx, field)
 	case "orphanedProductIds":
@@ -6022,8 +5863,6 @@ func (ec *executionContext) childFields_DeleteCollectionPayload(ctx context.Cont
 
 func (ec *executionContext) childFields_DeleteNamespacePayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_DeleteNamespacePayload_clientMutationId(ctx, field)
 	case "deletedIdentifier":
 		return ec.fieldContext_DeleteNamespacePayload_deletedIdentifier(ctx, field)
 	}
@@ -6032,8 +5871,6 @@ func (ec *executionContext) childFields_DeleteNamespacePayload(ctx context.Conte
 
 func (ec *executionContext) childFields_DeleteRepositoryPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_DeleteRepositoryPayload_clientMutationId(ctx, field)
 	case "deletedRepositoryId":
 		return ec.fieldContext_DeleteRepositoryPayload_deletedRepositoryId(ctx, field)
 	}
@@ -6516,8 +6353,6 @@ func (ec *executionContext) childFields_ProductVariantStatus(ctx context.Context
 
 func (ec *executionContext) childFields_PublishCatalogPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_PublishCatalogPayload_clientMutationId(ctx, field)
 	case "catalogVersion":
 		return ec.fieldContext_PublishCatalogPayload_catalogVersion(ctx, field)
 	}
@@ -6544,8 +6379,6 @@ func (ec *executionContext) childFields_RefreshTokenPayload(ctx context.Context,
 
 func (ec *executionContext) childFields_RenameRepositoryPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_RenameRepositoryPayload_clientMutationId(ctx, field)
 	case "repository":
 		return ec.fieldContext_RenameRepositoryPayload_repository(ctx, field)
 	}
@@ -6554,8 +6387,6 @@ func (ec *executionContext) childFields_RenameRepositoryPayload(ctx context.Cont
 
 func (ec *executionContext) childFields_ReorderCategoriesPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_ReorderCategoriesPayload_clientMutationId(ctx, field)
 	case "categories":
 		return ec.fieldContext_ReorderCategoriesPayload_categories(ctx, field)
 	}
@@ -6766,8 +6597,6 @@ func (ec *executionContext) childFields_TokenResponse(ctx context.Context, field
 
 func (ec *executionContext) childFields_TransferRepositoryPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_TransferRepositoryPayload_clientMutationId(ctx, field)
 	case "repository":
 		return ec.fieldContext_TransferRepositoryPayload_repository(ctx, field)
 	}
@@ -6776,8 +6605,6 @@ func (ec *executionContext) childFields_TransferRepositoryPayload(ctx context.Co
 
 func (ec *executionContext) childFields_UpdateCategoryPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_UpdateCategoryPayload_clientMutationId(ctx, field)
 	case "category":
 		return ec.fieldContext_UpdateCategoryPayload_category(ctx, field)
 	case "conflict":

--- a/gitstore-api/internal/graph/generated/schema.generated.go
+++ b/gitstore-api/internal/graph/generated/schema.generated.go
@@ -24,7 +24,7 @@ import (
 type MutationResolver interface {
 	PublishCatalog(ctx context.Context, input model.PublishCatalogInput) (*model.PublishCatalogPayload, error)
 	Login(ctx context.Context, input model.LoginInput) (*model.LoginPayload, error)
-	Logout(ctx context.Context, input model.LogoutInput) (*model.LogoutPayload, error)
+	Logout(ctx context.Context) (*model.LogoutPayload, error)
 	RefreshToken(ctx context.Context, input model.RefreshTokenInput) (*model.RefreshTokenPayload, error)
 	CreateCategory(ctx context.Context, input model.CreateCategoryInput) (*model.CreateCategoryPayload, error)
 	UpdateCategory(ctx context.Context, input model.UpdateCategoryInput) (*model.UpdateCategoryPayload, error)
@@ -180,20 +180,6 @@ func (ec *executionContext) field_Mutation_login_args(ctx context.Context, rawAr
 	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input",
 		func(ctx context.Context, v any) (model.LoginInput, error) {
 			return ec.unmarshalNLoginInput2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLoginInput(ctx, v)
-		})
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_logout_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input",
-		func(ctx context.Context, v any) (model.LogoutInput, error) {
-			return ec.unmarshalNLogoutInput2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLogoutInput(ctx, v)
 		})
 	if err != nil {
 		return nil, err
@@ -791,8 +777,7 @@ func (ec *executionContext) _Mutation_logout(ctx context.Context, field graphql.
 			return ec.fieldContext_Mutation_logout(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.Mutation().Logout(ctx, fc.Args["input"].(model.LogoutInput))
+			return ec.Resolvers.Mutation().Logout(ctx)
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.LogoutPayload) graphql.Marshaler {
@@ -802,7 +787,7 @@ func (ec *executionContext) _Mutation_logout(ctx context.Context, field graphql.
 		true,
 	)
 }
-func (ec *executionContext) fieldContext_Mutation_logout(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mutation_logout(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -811,17 +796,6 @@ func (ec *executionContext) fieldContext_Mutation_logout(ctx context.Context, fi
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_LogoutPayload(ctx, field)
 		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_logout_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
 	}
 	return fc, nil
 }

--- a/gitstore-api/internal/graph/model/models_gen.go
+++ b/gitstore-api/internal/graph/model/models_gen.go
@@ -284,8 +284,6 @@ type CollectionStatus struct {
 
 // Input for creating a category
 type CreateCategoryInput struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Category name
 	Name string `json:"name"`
 	// URL-friendly slug (must be unique)
@@ -300,8 +298,6 @@ type CreateCategoryInput struct {
 
 // Payload for createCategory mutation
 type CreateCategoryPayload struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The created category
 	Category *Category `json:"category,omitempty"`
 }
@@ -316,8 +312,6 @@ type CreateCollectionPayload struct {
 
 // Input for creating a new namespace.
 type CreateNamespaceInput struct {
-	// TODO: Remove, deprecated in relay
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The human-readable identifier for the namespace.
 	// Must be globally unique across all tiers.
 	// DNS label format: lowercase alphanumeric and hyphens, 1–63 characters.
@@ -334,36 +328,28 @@ type CreateNamespaceInput struct {
 
 // Payload returned after successfully creating a namespace.
 type CreateNamespacePayload struct {
-	// TODO: Remove, deprecated in relay
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The newly created namespace.
 	Namespace *Namespace `json:"namespace"`
 }
 
 type CreateRepositoryInput struct {
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	NamespaceID      string  `json:"namespaceId"`
-	Name             string  `json:"name"`
-	DefaultBranch    *string `json:"defaultBranch,omitempty"`
+	NamespaceID   string  `json:"namespaceId"`
+	Name          string  `json:"name"`
+	DefaultBranch *string `json:"defaultBranch,omitempty"`
 }
 
 type CreateRepositoryPayload struct {
-	ClientMutationID *string     `json:"clientMutationId,omitempty"`
-	Repository       *Repository `json:"repository"`
+	Repository *Repository `json:"repository"`
 }
 
 // Input for deleting a category
 type DeleteCategoryInput struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Category ID to delete
 	ID string `json:"id"`
 }
 
 // Payload for deleteCategory mutation
 type DeleteCategoryPayload struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Deleted category ID
 	DeletedCategoryID *string `json:"deletedCategoryId,omitempty"`
 	// Orphaned product IDs (products that referenced this category)
@@ -380,8 +366,6 @@ type DeleteCollectionPayload struct {
 
 // Input for deleting a namespace.
 type DeleteNamespaceInput struct {
-	// TODO: Remove, deprecated in relay
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The identifier of the namespace to delete.
 	// Deletion is blocked if any repositories exist within the namespace.
 	// Requires the caller to be the namespace owner (createdBy) or isAdmin.
@@ -390,20 +374,16 @@ type DeleteNamespaceInput struct {
 
 // Payload returned after successfully deleting a namespace.
 type DeleteNamespacePayload struct {
-	// TODO: Remove, deprecated in relay
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The identifier of the deleted namespace.
 	DeletedIdentifier string `json:"deletedIdentifier"`
 }
 
 type DeleteRepositoryInput struct {
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	RepositoryID     string  `json:"repositoryId"`
+	RepositoryID string `json:"repositoryId"`
 }
 
 type DeleteRepositoryPayload struct {
-	ClientMutationID    *string `json:"clientMutationId,omitempty"`
-	DeletedRepositoryID string  `json:"deletedRepositoryId"`
+	DeletedRepositoryID string `json:"deletedRepositoryId"`
 }
 
 // Gate that controls when a price template is eligible.
@@ -475,13 +455,6 @@ type LoginInput struct {
 type LoginPayload struct {
 	// OIDC-compatible token payload.
 	Token *TokenResponse `json:"token"`
-}
-
-// Logout mutation input (Relay pattern)
-type LogoutInput struct {
-	// TODO: Is it safe to remove and empty Input?
-	// Client mutation ID for request tracking (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 }
 
 // Logout mutation payload (Relay pattern)
@@ -833,14 +806,12 @@ type ProductVariantStatus struct {
 }
 
 type PublishCatalogInput struct {
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	Version          string  `json:"version"`
-	Message          string  `json:"message"`
+	Version string `json:"version"`
+	Message string `json:"message"`
 }
 
 type PublishCatalogPayload struct {
-	ClientMutationID *string         `json:"clientMutationId,omitempty"`
-	CatalogVersion   *CatalogVersion `json:"catalogVersion,omitempty"`
+	CatalogVersion *CatalogVersion `json:"catalogVersion,omitempty"`
 }
 
 // Inclusive quantity range that must be satisfied for a price template to apply.
@@ -870,21 +841,17 @@ type RefreshTokenPayload struct {
 }
 
 type RenameRepositoryInput struct {
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Relay ID of the repository to rename.
 	RepositoryID string `json:"repositoryId"`
 	NewName      string `json:"newName"`
 }
 
 type RenameRepositoryPayload struct {
-	ClientMutationID *string     `json:"clientMutationId,omitempty"`
-	Repository       *Repository `json:"repository"`
+	Repository *Repository `json:"repository"`
 }
 
 // Input for reordering categories (drag-and-drop)
 type ReorderCategoriesInput struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Ordered list of category IDs within parent
 	OrderedIds []string `json:"orderedIds"`
 	// Parent category ID (null for root categories)
@@ -897,8 +864,6 @@ type ReorderCategoriesInput struct {
 
 // Payload for reorderCategories mutation
 type ReorderCategoriesPayload struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Updated categories
 	Categories []*Category `json:"categories,omitempty"`
 }
@@ -1070,7 +1035,6 @@ type TokenResponse struct {
 }
 
 type TransferRepositoryInput struct {
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Relay ID of the repository to transfer.
 	RepositoryID string `json:"repositoryId"`
 	// Relay ID of the destination namespace.
@@ -1078,14 +1042,11 @@ type TransferRepositoryInput struct {
 }
 
 type TransferRepositoryPayload struct {
-	ClientMutationID *string     `json:"clientMutationId,omitempty"`
-	Repository       *Repository `json:"repository"`
+	Repository *Repository `json:"repository"`
 }
 
 // Input for updating a category
 type UpdateCategoryInput struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Category ID to update
 	ID string `json:"id"`
 	// New name
@@ -1105,8 +1066,6 @@ type UpdateCategoryInput struct {
 
 // Payload for updateCategory mutation
 type UpdateCategoryPayload struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// The updated category
 	Category *Category `json:"category,omitempty"`
 	// Conflict information (if optimistic lock failed)

--- a/gitstore-api/internal/graph/resolver/auth.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/auth.resolvers.go
@@ -17,8 +17,8 @@ func (r *mutationResolver) Login(ctx context.Context, input model.LoginInput) (*
 }
 
 // Logout is the resolver for the logout field.
-func (r *mutationResolver) Logout(ctx context.Context, input model.LogoutInput) (*model.LogoutPayload, error) {
-	return r.Resolver.Logout(ctx, input)
+func (r *mutationResolver) Logout(ctx context.Context) (*model.LogoutPayload, error) {
+	return r.Resolver.Logout(ctx)
 }
 
 // RefreshToken is the resolver for the refreshToken field.

--- a/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
+++ b/gitstore-api/internal/graph/resolver/auth_resolvers_test.go
@@ -96,7 +96,7 @@ func TestLogout_AuthenticatedBearer_ReturnsSuccess(t *testing.T) {
 	}
 	ctx := ctxWithPrincipal(principal)
 
-	payload, err := r.Logout(ctx, model.LogoutInput{})
+	payload, err := r.Logout(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, payload)
 	assert.True(t, payload.Success)
@@ -109,7 +109,7 @@ func TestLogout_AnonymousPrincipal_ReturnsError(t *testing.T) {
 
 	ctx := ctxWithPrincipal(authpkg.Anonymous())
 
-	_, err := r.Logout(ctx, model.LogoutInput{})
+	_, err := r.Logout(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authentication required")
 }
@@ -119,7 +119,7 @@ func TestLogout_NilPrincipal_ReturnsError(t *testing.T) {
 	reg, _ := newTestRegistry(t, cfg)
 	r := newTestResolver(t, reg)
 
-	_, err := r.Logout(context.Background(), model.LogoutInput{})
+	_, err := r.Logout(context.Background())
 	require.Error(t, err)
 }
 
@@ -137,7 +137,7 @@ func TestLogout_EmptyTokenID_NoOp_ReturnsSuccess(t *testing.T) {
 	}
 	ctx := ctxWithPrincipal(principal)
 
-	payload, err := r.Logout(ctx, model.LogoutInput{})
+	payload, err := r.Logout(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, payload)
 	assert.True(t, payload.Success)
@@ -310,7 +310,7 @@ func TestLogout_NilRegistry_ReturnsError(t *testing.T) {
 
 	principal := &authpkg.Principal{Subject: "admin", Roles: []string{"admin"}, AuthMethod: "static-admin", TokenID: "some-jti"}
 	ctx := ctxWithPrincipal(principal)
-	_, err = r.Logout(ctx, model.LogoutInput{})
+	_, err = r.Logout(ctx)
 	require.Error(t, err)
 }
 

--- a/gitstore-api/internal/graph/resolver/auth_service.go
+++ b/gitstore-api/internal/graph/resolver/auth_service.go
@@ -72,7 +72,7 @@ func (r *Resolver) Login(ctx context.Context, input model.LoginInput) (*model.Lo
 }
 
 // Logout implements the logout mutation on the base Resolver so it can be unit-tested directly.
-func (r *Resolver) Logout(ctx context.Context, input model.LogoutInput) (*model.LogoutPayload, error) {
+func (r *Resolver) Logout(ctx context.Context) (*model.LogoutPayload, error) {
 	if r.registry == nil {
 		return nil, gqlerror.Errorf("authentication service unavailable")
 	}

--- a/gitstore-api/internal/graph/resolver/namespace.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/namespace.resolvers.go
@@ -21,8 +21,7 @@ func (r *mutationResolver) CreateNamespace(ctx context.Context, input model.Crea
 	}
 
 	return &model.CreateNamespacePayload{
-		ClientMutationID: input.ClientMutationID,
-		Namespace:        datastoreNamespaceToModel(ns),
+		Namespace: datastoreNamespaceToModel(ns),
 	}, nil
 }
 
@@ -37,7 +36,6 @@ func (r *mutationResolver) DeleteNamespace(ctx context.Context, input model.Dele
 	}
 
 	return &model.DeleteNamespacePayload{
-		ClientMutationID:  input.ClientMutationID,
 		DeletedIdentifier: input.Identifier,
 	}, nil
 }

--- a/gitstore-api/internal/graph/resolver/repository.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/repository.resolvers.go
@@ -37,8 +37,7 @@ func (r *mutationResolver) CreateRepository(ctx context.Context, input model.Cre
 		zap.String("repo_id", repo.ID),
 	)
 	return &model.CreateRepositoryPayload{
-		ClientMutationID: input.ClientMutationID,
-		Repository:       datastoreRepositoryToModel(repo, ns, r.storageDataDir),
+		Repository: datastoreRepositoryToModel(repo, ns, r.storageDataDir),
 	}, nil
 }
 
@@ -61,8 +60,7 @@ func (r *mutationResolver) RenameRepository(ctx context.Context, input model.Ren
 		zap.String("new_name", input.NewName),
 	)
 	return &model.RenameRepositoryPayload{
-		ClientMutationID: input.ClientMutationID,
-		Repository:       datastoreRepositoryToModel(repo, ns, r.storageDataDir),
+		Repository: datastoreRepositoryToModel(repo, ns, r.storageDataDir),
 	}, nil
 }
 
@@ -89,8 +87,7 @@ func (r *mutationResolver) TransferRepository(ctx context.Context, input model.T
 		zap.String("to_namespace_id", targetNsID),
 	)
 	return &model.TransferRepositoryPayload{
-		ClientMutationID: input.ClientMutationID,
-		Repository:       datastoreRepositoryToModel(repo, ns, r.storageDataDir),
+		Repository: datastoreRepositoryToModel(repo, ns, r.storageDataDir),
 	}, nil
 }
 
@@ -105,7 +102,6 @@ func (r *mutationResolver) DeleteRepository(ctx context.Context, input model.Del
 	}
 	r.logger.Info("delete repository", zap.String("repo_id", repoID))
 	return &model.DeleteRepositoryPayload{
-		ClientMutationID:    input.ClientMutationID,
 		DeletedRepositoryID: mustEncodeNodeID(nodeKindRepository, repoID),
 	}, nil
 }

--- a/gitstore-api/internal/graph/resolver/schema.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/schema.resolvers.go
@@ -30,8 +30,7 @@ func (r *mutationResolver) PublishCatalog(ctx context.Context, input model.Publi
 		Stats:       stats,
 	}
 	return &model.PublishCatalogPayload{
-		ClientMutationID: input.ClientMutationID,
-		CatalogVersion:   version,
+		CatalogVersion: version,
 	}, nil
 }
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -527,7 +527,7 @@ Nodes (45): Fn, CatalogService, Send, Sync, make_blob(), MockCatalogService, Adm
 
 ### Community 17 - "Generated GraphQL Codegen & gRPC Clients"
 Cohesion: 0.06
-Nodes (37): gitstore-admin codegen.yml, Admin GraphQL codegen config (typescript, typescript-operations, typescript-react-apollo), gitstore-admin GraphQL Operations README, Generated Apollo hooks (use[Operation]Query/Mutation), Optimistic locking (version-based update conflicts), Relay mutation pattern (clientMutationId input/payload), CatalogServiceClient, CatalogServiceClient<T> (+29 more)
+Nodes (37): gitstore-admin codegen.yml, Admin GraphQL codegen config (typescript, typescript-operations, typescript-react-apollo), gitstore-admin GraphQL Operations README, Generated Apollo hooks (use[Operation]Query/Mutation), Optimistic locking (version-based update conflicts), Relay mutation pattern ( input/payload), CatalogServiceClient, CatalogServiceClient<T> (+29 more)
 
 ### Community 18 - "Git Upload-Pack Server (Rust)"
 Cohesion: 0.10

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -27461,7 +27461,7 @@
       "norm_label": ".fieldcontext_categorytaxonomystatus_resolved()"
     },
     {
-      "label": "._CreateCategoryPayload_clientMutationId()",
+      "label": "._CreateCategoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/category.generated.go",
       "source_location": "L1251",
@@ -27472,7 +27472,7 @@
       "norm_label": "._createcategorypayload_clientmutationid()"
     },
     {
-      "label": ".fieldContext_CreateCategoryPayload_clientMutationId()",
+      "label": ".fieldContext_CreateCategoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/category.generated.go",
       "source_location": "L1270",
@@ -27505,7 +27505,7 @@
       "norm_label": ".fieldcontext_createcategorypayload_category()"
     },
     {
-      "label": "._DeleteCategoryPayload_clientMutationId()",
+      "label": "._DeleteCategoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/category.generated.go",
       "source_location": "L1306",
@@ -27516,7 +27516,7 @@
       "norm_label": "._deletecategorypayload_clientmutationid()"
     },
     {
-      "label": ".fieldContext_DeleteCategoryPayload_clientMutationId()",
+      "label": ".fieldContext_DeleteCategoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/category.generated.go",
       "source_location": "L1325",
@@ -27615,7 +27615,7 @@
       "norm_label": ".fieldcontext_keyvaluepair_value()"
     },
     {
-      "label": "._ReorderCategoriesPayload_clientMutationId()",
+      "label": "._ReorderCategoriesPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/category.generated.go",
       "source_location": "L1421",
@@ -27626,7 +27626,7 @@
       "norm_label": "._reordercategoriespayload_clientmutationid()"
     },
     {
-      "label": ".fieldContext_ReorderCategoriesPayload_clientMutationId()",
+      "label": ".fieldContext_ReorderCategoriesPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/category.generated.go",
       "source_location": "L1440",
@@ -27758,7 +27758,7 @@
       "norm_label": ".fieldcontext_resolvedcategorytaxonomy_productcount()"
     },
     {
-      "label": "._UpdateCategoryPayload_clientMutationId()",
+      "label": "._UpdateCategoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/category.generated.go",
       "source_location": "L1568",
@@ -27769,7 +27769,7 @@
       "norm_label": "._updatecategorypayload_clientmutationid()"
     },
     {
-      "label": ".fieldContext_UpdateCategoryPayload_clientMutationId()",
+      "label": ".fieldContext_UpdateCategoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/category.generated.go",
       "source_location": "L1587",
@@ -29617,7 +29617,7 @@
       "norm_label": ".fieldcontext_labelselectorrequirement_values()"
     },
     {
-      "label": "._PublishCatalogPayload_clientMutationId()",
+      "label": "._PublishCatalogPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/collection.generated.go",
       "source_location": "L1421",
@@ -29639,7 +29639,7 @@
       "norm_label": "publishcatalogpayload"
     },
     {
-      "label": ".fieldContext_PublishCatalogPayload_clientMutationId()",
+      "label": ".fieldContext_PublishCatalogPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/collection.generated.go",
       "source_location": "L1440",
@@ -30387,7 +30387,7 @@
       "norm_label": "executioncontext"
     },
     {
-      "label": "._CreateNamespacePayload_clientMutationId()",
+      "label": "._CreateNamespacePayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/namespace.generated.go",
       "source_location": "L32",
@@ -30431,7 +30431,7 @@
       "norm_label": "marshaler"
     },
     {
-      "label": ".fieldContext_CreateNamespacePayload_clientMutationId()",
+      "label": ".fieldContext_CreateNamespacePayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/namespace.generated.go",
       "source_location": "L51",
@@ -30475,7 +30475,7 @@
       "norm_label": ".fieldcontext_createnamespacepayload_namespace()"
     },
     {
-      "label": "._DeleteNamespacePayload_clientMutationId()",
+      "label": "._DeleteNamespacePayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/namespace.generated.go",
       "source_location": "L87",
@@ -30486,7 +30486,7 @@
       "norm_label": "._deletenamespacepayload_clientmutationid()"
     },
     {
-      "label": ".fieldContext_DeleteNamespacePayload_clientMutationId()",
+      "label": ".fieldContext_DeleteNamespacePayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/namespace.generated.go",
       "source_location": "L106",
@@ -37636,7 +37636,7 @@
       "norm_label": "executioncontext"
     },
     {
-      "label": "._CreateRepositoryPayload_clientMutationId()",
+      "label": "._CreateRepositoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/repository.generated.go",
       "source_location": "L32",
@@ -37680,7 +37680,7 @@
       "norm_label": "marshaler"
     },
     {
-      "label": ".fieldContext_CreateRepositoryPayload_clientMutationId()",
+      "label": ".fieldContext_CreateRepositoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/repository.generated.go",
       "source_location": "L51",
@@ -37724,7 +37724,7 @@
       "norm_label": ".fieldcontext_createrepositorypayload_repository()"
     },
     {
-      "label": "._DeleteRepositoryPayload_clientMutationId()",
+      "label": "._DeleteRepositoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/repository.generated.go",
       "source_location": "L87",
@@ -37735,7 +37735,7 @@
       "norm_label": "._deleterepositorypayload_clientmutationid()"
     },
     {
-      "label": ".fieldContext_DeleteRepositoryPayload_clientMutationId()",
+      "label": ".fieldContext_DeleteRepositoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/repository.generated.go",
       "source_location": "L106",
@@ -37768,7 +37768,7 @@
       "norm_label": ".fieldcontext_deleterepositorypayload_deletedrepositoryid()"
     },
     {
-      "label": "._RenameRepositoryPayload_clientMutationId()",
+      "label": "._RenameRepositoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/repository.generated.go",
       "source_location": "L133",
@@ -37779,7 +37779,7 @@
       "norm_label": "._renamerepositorypayload_clientmutationid()"
     },
     {
-      "label": ".fieldContext_RenameRepositoryPayload_clientMutationId()",
+      "label": ".fieldContext_RenameRepositoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/repository.generated.go",
       "source_location": "L152",
@@ -38153,7 +38153,7 @@
       "norm_label": ".fieldcontext_repositoryedge_node()"
     },
     {
-      "label": "._TransferRepositoryPayload_clientMutationId()",
+      "label": "._TransferRepositoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/repository.generated.go",
       "source_location": "L569",
@@ -38164,7 +38164,7 @@
       "norm_label": "._transferrepositorypayload_clientmutationid()"
     },
     {
-      "label": ".fieldContext_TransferRepositoryPayload_clientMutationId()",
+      "label": ".fieldContext_TransferRepositoryPayload_()",
       "file_type": "code",
       "source_file": "gitstore-api/internal/graph/generated/repository.generated.go",
       "source_location": "L588",
@@ -70249,7 +70249,7 @@
       "id": "gitstore_admin_src_graphql_readme_optimistic_locking"
     },
     {
-      "label": "Relay mutation pattern (clientMutationId input/payload)",
+      "label": "Relay mutation pattern ( input/payload)",
       "file_type": "concept",
       "source_file": "gitstore-admin/src/graphql/README.md",
       "source_location": null,

--- a/shared/schemas/auth.graphqls
+++ b/shared/schemas/auth.graphqls
@@ -77,17 +77,6 @@ type LoginPayload {
 }
 
 """
-Logout mutation input (Relay pattern)
-"""
-input LogoutInput {
-  """
-  TODO: Is it safe to remove and empty Input?
-  Client mutation ID for request tracking (Relay pattern)
-  """
-  clientMutationId: String
-}
-
-"""
 Logout mutation payload (Relay pattern)
 """
 type LogoutPayload {
@@ -133,7 +122,7 @@ extend type Mutation {
   """
   Logout and invalidate current session
   """
-  logout(input: LogoutInput!): LogoutPayload!
+  logout: LogoutPayload!
 
   """
   Refresh authentication token

--- a/shared/schemas/category.graphqls
+++ b/shared/schemas/category.graphqls
@@ -32,7 +32,7 @@ extend type Mutation {
   Delete a category
   """
   deleteCategory(input: DeleteCategoryInput!): DeleteCategoryPayload!
-  
+
   """
   Reorder categories (drag-and-drop)
   """
@@ -231,10 +231,8 @@ type CategoryConnection {
 Input for creating a category
 """
 input CreateCategoryInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Category name
@@ -266,10 +264,8 @@ input CreateCategoryInput {
 Payload for createCategory mutation
 """
 type CreateCategoryPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   The created category
@@ -281,10 +277,8 @@ type CreateCategoryPayload {
 Input for updating a category
 """
 input UpdateCategoryInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Category ID to update
@@ -327,10 +321,8 @@ input UpdateCategoryInput {
 Payload for updateCategory mutation
 """
 type UpdateCategoryPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   The updated category
@@ -347,10 +339,8 @@ type UpdateCategoryPayload {
 Input for deleting a category
 """
 input DeleteCategoryInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Category ID to delete
@@ -362,10 +352,8 @@ input DeleteCategoryInput {
 Payload for deleteCategory mutation
 """
 type DeleteCategoryPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Deleted category ID
@@ -382,10 +370,8 @@ type DeleteCategoryPayload {
 Input for reordering categories (drag-and-drop)
 """
 input ReorderCategoriesInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Ordered list of category IDs within parent
@@ -412,10 +398,8 @@ input ReorderCategoriesInput {
 Payload for reorderCategories mutation
 """
 type ReorderCategoriesPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+
+
 
   """
   Updated categories

--- a/shared/schemas/collection.graphqls
+++ b/shared/schemas/collection.graphqls
@@ -310,13 +310,11 @@ type DeleteCollectionPayload {
 # ============================================================================
 
 input PublishCatalogInput {
-  clientMutationId: String
   version: String!
   message: String!
 }
 
 type PublishCatalogPayload {
-  clientMutationId: String
   catalogVersion: CatalogVersion
 }
 

--- a/shared/schemas/namespace.graphqls
+++ b/shared/schemas/namespace.graphqls
@@ -115,11 +115,6 @@ Input for creating a new namespace.
 """
 input CreateNamespaceInput {
   """
-  TODO: Remove, deprecated in relay
-  """
-  clientMutationId: String
-
-  """
   The human-readable identifier for the namespace.
   Must be globally unique across all tiers.
   DNS label format: lowercase alphanumeric and hyphens, 1–63 characters.
@@ -146,11 +141,6 @@ Input for deleting a namespace.
 """
 input DeleteNamespaceInput {
   """
-  TODO: Remove, deprecated in relay
-  """
-  clientMutationId: String
-
-  """
   The identifier of the namespace to delete.
   Deletion is blocked if any repositories exist within the namespace.
   Requires the caller to be the namespace owner (createdBy) or isAdmin.
@@ -163,11 +153,6 @@ Payload returned after successfully creating a namespace.
 """
 type CreateNamespacePayload {
   """
-  TODO: Remove, deprecated in relay
-  """
-  clientMutationId: String
-
-  """
   The newly created namespace.
   """
   namespace: Namespace!
@@ -177,11 +162,6 @@ type CreateNamespacePayload {
 Payload returned after successfully deleting a namespace.
 """
 type DeleteNamespacePayload {
-  """
-  TODO: Remove, deprecated in relay
-  """
-  clientMutationId: String
-
   """
   The identifier of the deleted namespace.
   """

--- a/shared/schemas/repository.graphqls
+++ b/shared/schemas/repository.graphqls
@@ -140,19 +140,16 @@ extend type Mutation {
 }
 
 input CreateRepositoryInput {
-  clientMutationId: String
   namespaceId: ID!
   name: String!
   defaultBranch: String
 }
 
 type CreateRepositoryPayload {
-  clientMutationId: String
   repository: Repository!
 }
 
 input RenameRepositoryInput {
-  clientMutationId: String
   """
   Relay ID of the repository to rename.
   """
@@ -161,12 +158,10 @@ input RenameRepositoryInput {
 }
 
 type RenameRepositoryPayload {
-  clientMutationId: String
   repository: Repository!
 }
 
 input TransferRepositoryInput {
-  clientMutationId: String
   """
   Relay ID of the repository to transfer.
   """
@@ -178,16 +173,13 @@ input TransferRepositoryInput {
 }
 
 type TransferRepositoryPayload {
-  clientMutationId: String
   repository: Repository!
 }
 
 input DeleteRepositoryInput {
-  clientMutationId: String
   repositoryId: ID!
 }
 
 type DeleteRepositoryPayload {
-  clientMutationId: String
   deletedRepositoryId: ID!
 }

--- a/specs/001-git-backed-ecommerce/contracts/README.md
+++ b/specs/001-git-backed-ecommerce/contracts/README.md
@@ -32,8 +32,6 @@ Cursor-based pagination for lists:
 
 ### Mutation Pattern
 Standardized mutation input/payload structure:
-- Input: `clientMutationId` for request tracking
-- Payload: `clientMutationId` echo, entity result, errors array
 
 ## Key Features
 
@@ -118,7 +116,6 @@ query CategoryTree {
 ```graphql
 mutation CreateProduct($input: CreateProductInput!) {
   createProduct(input: $input) {
-    clientMutationId
     product {
       id
       sku
@@ -132,7 +129,6 @@ mutation CreateProduct($input: CreateProductInput!) {
 ```graphql
 mutation UpdateProduct($input: UpdateProductInput!) {
   updateProduct(input: $input) {
-    clientMutationId
     product {
       id
       title
@@ -151,7 +147,6 @@ mutation UpdateProduct($input: UpdateProductInput!) {
 ```graphql
 mutation PublishCatalog($input: PublishCatalogInput!) {
   publishCatalog(input: $input) {
-    clientMutationId
     catalogVersion {
       tag
       commit

--- a/specs/001-git-backed-ecommerce/contracts/category.graphql
+++ b/specs/001-git-backed-ecommerce/contracts/category.graphql
@@ -81,7 +81,6 @@ input CreateCategoryInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Category name
@@ -116,7 +115,6 @@ type CreateCategoryPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   The created category
@@ -131,7 +129,6 @@ input UpdateCategoryInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Category ID to update
@@ -176,7 +173,6 @@ type UpdateCategoryPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   The updated category
@@ -196,7 +192,6 @@ input DeleteCategoryInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Category ID to delete
@@ -211,7 +206,6 @@ type DeleteCategoryPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Deleted category ID
@@ -231,7 +225,6 @@ input ReorderCategoriesInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Ordered list of category IDs within parent
@@ -261,7 +254,6 @@ type ReorderCategoriesPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Updated categories

--- a/specs/001-git-backed-ecommerce/contracts/collection.graphql
+++ b/specs/001-git-backed-ecommerce/contracts/collection.graphql
@@ -66,7 +66,6 @@ input CreateCollectionInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Collection name
@@ -101,7 +100,6 @@ type CreateCollectionPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   The created collection
@@ -116,7 +114,6 @@ input UpdateCollectionInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Collection ID to update
@@ -161,7 +158,6 @@ type UpdateCollectionPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   The updated collection
@@ -181,7 +177,6 @@ input DeleteCollectionInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Collection ID to delete
@@ -196,7 +191,6 @@ type DeleteCollectionPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Deleted collection ID
@@ -211,7 +205,6 @@ input ReorderCollectionsInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Ordered list of collection IDs
@@ -226,7 +219,6 @@ type ReorderCollectionsPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Updated collections
@@ -270,7 +262,6 @@ input PublishCatalogInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Release version tag (e.g., v1.0.0)
@@ -290,7 +281,6 @@ type PublishCatalogPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   New catalog version

--- a/specs/001-git-backed-ecommerce/contracts/product.graphql
+++ b/specs/001-git-backed-ecommerce/contracts/product.graphql
@@ -121,7 +121,6 @@ input CreateProductInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Stock Keeping Unit (must be unique)
@@ -186,7 +185,6 @@ type CreateProductPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   The created product
@@ -201,7 +199,6 @@ input UpdateProductInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Product ID to update
@@ -281,7 +278,6 @@ type UpdateProductPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   The updated product
@@ -301,7 +297,6 @@ input DeleteProductInput {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Product ID to delete
@@ -316,7 +311,6 @@ type DeleteProductPayload {
   """
   Client mutation ID (Relay pattern)
   """
-  clientMutationId: String
 
   """
   Deleted product ID

--- a/specs/009-api-namespaces/contracts/namespace.graphqls
+++ b/specs/009-api-namespaces/contracts/namespace.graphqls
@@ -154,7 +154,6 @@ input CreateNamespaceInput {
   """
   Client mutation ID for request tracking (Relay pattern).
   """
-  clientMutationId: String
 
   """
   The human-readable identifier for the namespace.
@@ -191,7 +190,6 @@ input DeleteNamespaceInput {
   """
   Client mutation ID for request tracking (Relay pattern).
   """
-  clientMutationId: String
 
   """
   The identifier of the namespace to delete.
@@ -212,7 +210,6 @@ type CreateNamespacePayload {
   """
   Client mutation ID for request tracking (Relay pattern).
   """
-  clientMutationId: String
 
   """
   The newly created namespace.
@@ -227,7 +224,6 @@ type DeleteNamespacePayload {
   """
   Client mutation ID for request tracking (Relay pattern).
   """
-  clientMutationId: String
 
   """
   The identifier of the deleted namespace.
@@ -242,12 +238,10 @@ type DeleteNamespacePayload {
 # --- Create a user namespace ---
 # mutation CreateUserNamespace {
 #   createNamespace(input: {
-#     clientMutationId: "create-acme-corp"
 #     identifier: "acme-corp"
 #     displayName: "Acme Corporation"
 #     tier: USER
 #   }) {
-#     clientMutationId
 #     namespace {
 #       id
 #       identifier
@@ -261,12 +255,10 @@ type DeleteNamespacePayload {
 # --- Create an enterprise namespace (requires isAdmin) ---
 # mutation CreateEnterpriseNamespace {
 #   createNamespace(input: {
-#     clientMutationId: "create-acme-enterprise"
 #     identifier: "acme-enterprise"
 #     displayName: "Acme Enterprise"
 #     tier: ENTERPRISE
 #   }) {
-#     clientMutationId
 #     namespace {
 #       id
 #       identifier
@@ -280,12 +272,10 @@ type DeleteNamespacePayload {
 # --- Create an org namespace with parent enterprise ---
 # mutation CreateOrgWithEnterprise {
 #   createNamespace(input: {
-#     clientMutationId: "create-acme-engineering"
 #     identifier: "acme-engineering"
 #     tier: ORGANISATION
 #     parentEnterpriseIdentifier: "acme-enterprise"
 #   }) {
-#     clientMutationId
 #     namespace {
 #       id
 #       identifier
@@ -334,8 +324,6 @@ type DeleteNamespacePayload {
 
 # --- Delete a namespace ---
 # mutation DeleteNamespace {
-#   deleteNamespace(input: { clientMutationId: "delete-acme-corp", identifier: "acme-corp" }) {
-#     clientMutationId
 #     deletedIdentifier
 #   }
 # }

--- a/specs/009-api-namespaces/quickstart.md
+++ b/specs/009-api-namespaces/quickstart.md
@@ -66,7 +66,7 @@ curl -s -X POST http://localhost:4000/graphql \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{
-    "query": "mutation { createNamespace(input: { clientMutationId: \"create-alice\", identifier: \"alice\", tier: USER }) { clientMutationId namespace { id identifier tier createdAt createdBy } } }"
+    "query": "mutation { createNamespace(input: { identifier: \"alice\", tier: USER }) { namespace { id identifier tier createdAt createdBy } } }"
   }' | jq .
 ```
 
@@ -75,8 +75,7 @@ Expected response:
 {
   "data": {
     "createNamespace": {
-      "clientMutationId": "create-alice",
-      "namespace": {
+            "namespace": {
         "id": "<uuid>",
         "identifier": "alice",
         "tier": "USER",
@@ -98,7 +97,7 @@ curl -s -X POST http://localhost:4000/graphql \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{
-    "query": "mutation { createNamespace(input: { clientMutationId: \"create-acme-enterprise\", identifier: \"acme-enterprise\", tier: ENTERPRISE, displayName: \"Acme Enterprise\" }) { clientMutationId namespace { id identifier tier } } }"
+    "query": "mutation { createNamespace(input: { identifier: \"acme-enterprise\", tier: ENTERPRISE, displayName: \"Acme Enterprise\" }) { namespace { id identifier tier } } }"
   }' | jq .
 
 # 2. Create the org namespace with the parent enterprise
@@ -106,7 +105,7 @@ curl -s -X POST http://localhost:4000/graphql \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{
-    "query": "mutation { createNamespace(input: { clientMutationId: \"create-acme-engineering\", identifier: \"acme-engineering\", tier: ORGANISATION, parentEnterpriseIdentifier: \"acme-enterprise\" }) { clientMutationId namespace { id identifier tier parentEnterpriseId } } }"
+    "query": "mutation { createNamespace(input: { identifier: \"acme-engineering\", tier: ORGANISATION, parentEnterpriseIdentifier: \"acme-enterprise\" }) { namespace { id identifier tier parentEnterpriseId } } }"
   }' | jq .
 ```
 
@@ -160,7 +159,7 @@ curl -s -X POST http://localhost:4000/graphql \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{
-    "query": "mutation { deleteNamespace(input: { clientMutationId: \"delete-alice\", identifier: \"alice\" }) { clientMutationId deletedIdentifier } }"
+    "query": "mutation { deleteNamespace(input: { identifier: \"alice\" }) { deletedIdentifier } }"
   }' | jq .
 ```
 
@@ -169,8 +168,7 @@ Expected:
 {
   "data": {
     "deleteNamespace": {
-      "clientMutationId": "delete-alice",
-      "deletedIdentifier": "alice"
+            "deletedIdentifier": "alice"
     }
   }
 }
@@ -187,7 +185,7 @@ Expected:
 curl -s -X POST http://localhost:4000/graphql \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
-  -d '{"query": "mutation { createNamespace(input: { clientMutationId: \"create-alice-duplicate\", identifier: \"alice\", tier: USER }) { clientMutationId namespace { id } } }"}' | jq .
+  -d '{"query": "mutation { createNamespace(input: { identifier: \"alice\", tier: USER }) { namespace { id } } }"}' | jq .
 # Expected: errors[0].message contains "already exists"
 ```
 
@@ -198,7 +196,7 @@ curl -s -X POST http://localhost:4000/graphql \
 curl -s -X POST http://localhost:4000/graphql \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
-  -d '{"query": "mutation { createNamespace(input: { clientMutationId: \"create-invalid\", identifier: \"Invalid Name!\", tier: USER }) { clientMutationId namespace { id } } }"}' | jq .
+  -d '{"query": "mutation { createNamespace(input: { identifier: \"Invalid Name!\", tier: USER }) { namespace { id } } }"}' | jq .
 # Expected: errors[0].message contains "invalid identifier"
 ```
 
@@ -212,7 +210,7 @@ Any authenticated user attempting to create an `ENTERPRISE` tier namespace when 
 curl -s -X POST http://localhost:4000/graphql \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
-  -d '{"query": "mutation { deleteNamespace(input: { clientMutationId: \"delete-unknown\", identifier: \"unknown-ns\" }) { clientMutationId deletedIdentifier } }"}' | jq .
+  -d '{"query": "mutation { deleteNamespace(input: { identifier: \"unknown-ns\" }) { deletedIdentifier } }"}' | jq .
 # Expected: errors[0].message contains "not found"
 ```
 

--- a/specs/010-repo-storage-identity/tasks.md
+++ b/specs/010-repo-storage-identity/tasks.md
@@ -24,7 +24,6 @@ description: "Task list for Repository Storage Identity and Path Strategy"
 **Purpose**: API-First gate (Constitution Principle II). All contracts must be committed before any implementation.
 
 - [X] T001 Update `shared/proto/gitstore/git/v1/git_service.proto` from `specs/010-repo-storage-identity/contracts/grpc.git_service.proto` — add `storage_class` field to `CreateRepositoryRequest`, `storage_path` to `CreateRepositoryResponse`, and update `repository_id` comments to reflect UUIDv7 semantics
-- [X] T002 [P] Add `specs/010-repo-storage-identity/contracts/graphql.repository.graphqls` content to `shared/schemas/repository.graphqls` (new file) — `Repository` type, `RepositoryEdge`, `RepositoryConnection`, `RepositoryBy`, `RepositoryNamespacePath`, all four mutations (`createRepository`, `renameRepository`, `transferRepository`, `deleteRepository`) with their input/payload types; add `clientMutationId: String` to every mutation input and payload type
 - [X] T003 Update `gitstore-api/internal/datastore/scylla/migrations/001_initial_schema.cql` in-place — add `repositories` table and `namespace_mappings` table as defined in `specs/010-repo-storage-identity/data-model.md` (D-003: no new migration files)
 - [X] T004 [P] Update `gitstore-api/internal/datastore/scylla/migrations/002_add_initial_indices.cql` in-place — add `repositories_by_namespace` and `mappings_by_repo_id` indices
 - [X] T005 Regenerate gRPC Go bindings from `shared/proto/gitstore/git/v1/git_service.proto` using `protoc` — verify generated files in `api/gen/gitstore/git/v1/`
@@ -244,7 +243,6 @@ Agent B: T024–T030 (Rust fanout resolver for US2)
 - Constitution Principle I (Test-First): every implementation task must be preceded by a failing test
 - Constitution Principle II (API-First): Phase 1 contracts must be committed before Phase 2+
 - Constitution Principle IV (Observability): all lookup, rename, transfer, and gRPC delegation calls must emit structured log entries
-- `clientMutationId: String` must appear in every GraphQL mutation input type AND every payload type
 - `StoragePath` is **derived, never stored** (D-005): compute it from `repo_id` on the fly in both Go and Rust
 - No migration files created — update `001_initial_schema.cql` and `002_add_initial_indices.cql` in-place (D-003, ALPHA)
 - `namespace` memdb table index uses `memdb.UUIDFieldIndex{Field: "ID"}` (already updated in last commit)

--- a/specs/030-remove-enterprise-namespace/contracts/namespace.graphqls
+++ b/specs/030-remove-enterprise-namespace/contracts/namespace.graphqls
@@ -124,7 +124,6 @@ input CreateNamespaceInput {
   """
   Client mutation ID for request tracking (Relay pattern).
   """
-  clientMutationId: String
 
   """
   The human-readable identifier for the namespace.
@@ -153,7 +152,6 @@ input DeleteNamespaceInput {
   """
   Client mutation ID for request tracking (Relay pattern).
   """
-  clientMutationId: String
 
   """
   The identifier of the namespace to delete.
@@ -170,7 +168,6 @@ type CreateNamespacePayload {
   """
   Client mutation ID for request tracking (Relay pattern).
   """
-  clientMutationId: String
 
   """
   The newly created namespace.
@@ -185,7 +182,6 @@ type DeleteNamespacePayload {
   """
   Client mutation ID for request tracking (Relay pattern).
   """
-  clientMutationId: String
 
   """
   The identifier of the deleted namespace.

--- a/specs/032-auth-phase-3/contracts/session-lifecycle-interfaces.md
+++ b/specs/032-auth-phase-3/contracts/session-lifecycle-interfaces.md
@@ -30,14 +30,12 @@ type LoginPayload {
 }
 
 input LogoutInput {
-  clientMutationId: String   # retained for schema compatibility; ignored in Phase 3
 }
 type LogoutPayload {
   success: Boolean!
 }
 
 input RefreshTokenInput {
-  clientMutationId: String   # retained for schema compatibility; ignored in Phase 3
 }
 type RefreshTokenPayload {
   session: AuthSession

--- a/specs/032-auth-phase-3/plan.md
+++ b/specs/032-auth-phase-3/plan.md
@@ -140,7 +140,6 @@ Key resolved decisions:
 
 ### No schema changes
 
-`shared/schemas/auth.graphqls` is unchanged. `clientMutationId` fields in `LogoutInput` and `RefreshTokenInput` are retained as-is.
 
 ## Complexity Tracking
 

--- a/specs/032-auth-phase-3/spec.md
+++ b/specs/032-auth-phase-3/spec.md
@@ -131,7 +131,6 @@ non-admin user (once non-admin users exist) must receive `user.isAdmin: false`.
 ## Assumptions
 
 - The `static-admin` provider's `RevokeSession` and `RefreshSession` implementations (added in Phase 1) are correct and require no functional changes; Phase 3 only wires the resolvers to call them.
-- The `clientMutationId` fields in `LogoutInput` and `RefreshTokenInput` are intentionally left in the schema for this phase; removal is a separate schema-hygiene task.
 - The in-memory blacklist loses its state on server restart — this is an accepted limitation for single-instance deployments. Persistent blacklist storage is deferred to a later phase.
 - No new GraphQL schema types or fields are required; the `logout` and `refreshToken` mutations are already defined in `shared/schemas/auth.graphqls`.
 - The `refreshToken` mutation uses the caller's current bearer token as the old-token input; no separate `oldToken` argument is needed in the schema.


### PR DESCRIPTION
## What changed

- Removed deprecated `clientMutationId` from the active GraphQL schemas and resolver implementations.
- Regenerated gqlgen server artifacts and updated admin GraphQL operations, hooks, publishing code, tests, and examples.
- Removed the field from current documentation and historical specifications.
- Refreshed tracked Graphify metadata so repository-wide searches are clean.

## Impact

This is an intentional breaking GraphQL contract cleanup. Clients that send or select `clientMutationId` must remove it.

## Validation

- `go generate ./...` — passed
- `go test ./...` in `gitstore-api` — passed
- `ASTRO_TELEMETRY_DISABLED=1 npm run build` — passed
- Repository-wide `clientMutationId` / `ClientMutationID` scan — zero matches
- Admin GraphQL codegen is currently blocked by 101 unrelated pre-existing schema/document mismatches.
- Admin Vitest is currently blocked by Playwright suites being loaded under Vitest.
