### PR TITLE
docs: add OPA authorization and collection materialization designs

### DIFF
--- a/docs/implementation/001-GIT_PROTOCOL_IMPLEMENTATION_PLAN.md
+++ b/docs/implementation/001-GIT_PROTOCOL_IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 # Git Protocol Implementation Plan (Native git://)
 
 **Goal**: Implement a full git:// protocol server in Rust for GitStore's built-in git engine.  
-**Status** 🚫 Obsolete
+**Status**: 🚫 Obsolete
 
 **Reference**: [Git Protocol Documentation](https://git-scm.com/book/en/v2/Git-Internals-Transfer-Protocols)
 

--- a/docs/implementation/006-api-datastore-abstraction.md
+++ b/docs/implementation/006-api-datastore-abstraction.md
@@ -1,4 +1,5 @@
 # Feature 006: API Datastore Abstraction
+**Status**: ✅ Shipped
 
 ## Overview
 

--- a/docs/implementation/010-repo-storage-identity.md
+++ b/docs/implementation/010-repo-storage-identity.md
@@ -1,4 +1,5 @@
 # Repository Storage Identity and Path Strategy
+**Status**: ✅ Shipped
 
 ## Overview
 

--- a/docs/implementation/019-pluggable_auth_design.md
+++ b/docs/implementation/019-pluggable_auth_design.md
@@ -1,11 +1,7 @@
 # Pluggable Identity and Access Design
+**Status**: 🚫 SUPERSEDED by [020 (pluggable auth architecture)](020-pluggable_auth_architecture.md)
 
 This document defines the target design for making authentication and authorisation pluggable in GitStore, while keeping user management independent.
-
-## Status
-
-- Proposed
-- No backwards compatibility required (alpha)
 
 ## Goals
 

--- a/docs/implementation/020-pluggable_auth_architecture.md
+++ b/docs/implementation/020-pluggable_auth_architecture.md
@@ -1,7 +1,10 @@
 # GitStore Pluggable AuthN/AuthZ Architecture Design
+**Status**: ⚠️ In Progress
 
 > Generated 2026-06-20 via deep-research workflow (110 agents, 27 sources, 20 verified claims).
 > This document supersedes the open decisions in `019-pluggable_auth_design.md`.
+> `022-opa-data-authorization.md` extends and supersedes this document's Phase 8 OPA
+> deployment/evaluation details, and defines GraphQL read scopes plus hybrid IAM data ownership.
 
 **Research-verified findings driving key decisions:**
 - `go-oidc/v3` is a required new dependency (golang-jwt/v5 already in go.mod cannot perform JWKS-backed RSA/EC verification)
@@ -1068,7 +1071,11 @@ fn default_http_auth_mode() -> String { "header".into() }
 
 **Trade-off weighed:** External gRPC/webhook providers (e.g., OPA sidecar, OpenFGA server) offer greater policy flexibility and are production-grade. However, they introduce a mandatory external service dependency that violates the `local-fast` profile constraint (must run with zero external services). Implementing the HTTP client wrappers and circuit-breaker logic for external providers before the interface contracts are stable adds risk to an already broad phase-1 scope.
 
-**Constraint on future providers:** Every external provider (OPA, OpenFGA, webhook) must implement the same `AuthZProvider` or `AuthNProvider` interface defined in §1a. The only addition is an `IsRemote() bool` method on the interface (for startup dependency health-checks) — this is additive and backward-compatible with in-process providers that return `false`.
+**Constraint on future providers:** Every provider (embedded OPA, external OpenFGA, webhook, or
+otherwise) must implement the same `AuthZProvider` or `AuthNProvider` interface defined in §1a.
+An external provider may expose remote-health metadata through a separate optional capability;
+the core interfaces do not require an `IsRemote()` method. The selected OPA design is embedded and
+therefore has no remote dependency. See `022-opa-data-authorization.md` §6 and §14.
 
 ### Decision 2: Policy decision logs — datastore or log stream only?
 
@@ -1084,7 +1091,14 @@ fn default_http_auth_mode() -> String { "header".into() }
 
 **Trade-off weighed:** OpenFGA is purpose-built for Relationship-Based Access Control (ReBAC) and excels at "does user X have permission Y on object Z via a chain of relationships?" — exactly the model needed if GitStore later implements org membership hierarchies, inherited repository permissions, or team-scoped access. OPA uses Rego, a general-purpose policy language, and its policy file model maps directly onto the `rbac-local` YAML schema used in phase 1, making the migration from `rbac-local` → OPA a matter of translating the YAML policy into Rego without changing the `AuthZProvider` interface or the action name vocabulary. OpenFGA requires a running relational store (PostgreSQL/MySQL) and a tuple-loading pipeline from GitStore's data — infrastructure that does not exist today.
 
-**Constraint on future providers:** The action name vocabulary (`namespace.delete.any`, `repository.write`, etc.) and `ResourceContext` struct are the contract between resolvers and the AuthZ provider. OPA Rego policies must receive these as structured input; the OPA provider must serialize `(principal, action, ResourceContext)` into the OPA input document before calling the policy engine. If OpenFGA is added in phase 4, its tuple schema must be derived from the same `ResourceContext` fields — no action name changes.
+**Constraint on future providers:** The action name vocabulary (`namespace.delete.any`,
+`repository.write`, etc.) and `ResourceContext` struct are the contract between GraphQL middleware
+and the AuthZ provider. OPA Rego receives a minimized, typed projection of `(principal, action,
+ResourceContext)` plus allowlisted GraphQL field metadata. The raw GraphQL operation, schema,
+credentials, claims map, and unrelated variables are not policy input. `AuthZProvider.Authorize`
+remains unchanged; `Decision` may carry additive, validated semantic scopes for data-aware reads.
+If OpenFGA is added later, its tuple schema must derive from the same action/resource fields—no
+action-name changes. See `022-opa-data-authorization.md` §5–§9.
 
 ---
 
@@ -1166,10 +1180,25 @@ BasicAuthenticator → RepoResolver → GitHttpAuthorizer → [PushContextInsert
 
 ### Phase 8 — OPA production AuthZ provider
 **Milestone:** `auth-framework-v3`
-**Deliverable:** `OPAProvider` calling the OPA sidecar HTTP API; production `.env` profile wires `GITSTORE_AUTH__AUTHZ__PROVIDER=opa`; Rego policy equivalent to `policy.yaml` bundled.
-**Affected packages:** `gitstore-api/internal/auth/provider/opa/`, production deployment config
-**Test strategy:** Integration test with OPA running as a Docker Compose sidecar; verify all existing action names resolve correctly; verify deny path on unknown action.
-**Rollback trigger:** Any authz decision returns unexpected outcome vs. rbac-local reference run.
+**Authoritative design:** `022-opa-data-authorization.md`.
+**Deliverable:** An opt-in embedded `OPAProvider` using
+`github.com/open-policy-agent/opa/v1/rego`, a cached prepared decision query, and
+`storage/inmem` for built-in plus namespace IAM projections. Add provider-neutral semantic Decision
+scopes, server-owned GraphQL `@authorize` metadata, and authorized Product/ProductVariant query
+types that select public or management datastore projections before pagination. The provider does
+not call an OPA sidecar and does not send the raw GraphQL query or schema per evaluation.
+**Affected packages:** `gitstore-api/internal/auth/`, `gitstore-api/internal/auth/provider/opa/`,
+GraphQL middleware/schema, IAM datastore implementations, catalog read services, and public
+Product/ProductVariant projections.
+**Test strategy:** Decision parity with `rbac-local` for existing actions; direct/custom-role/group
+IAM expansion; deny precedence and revision freshness; every Product/ProductVariant GraphQL path;
+public versus management Relay correctness on memdb and ScyllaDB; atomic reload, concurrency,
+timeouts, malformed results, and benchmarks proving preparation is not per request.
+**Rollout constraint:** `opa` remains opt-in until a later decision changes production defaults.
+Public ProductVariant reads remain fail closed until GH#314 materializes variant publication
+eligibility.
+**Rollback trigger:** Any existing action diverges unexpectedly from the reference provider, a
+stale/invalid decision does not fail closed, or scoped Relay results expose an ineligible resource.
 
 ---
 

--- a/docs/implementation/021-controller_service_account_auth.md
+++ b/docs/implementation/021-controller_service_account_auth.md
@@ -1,7 +1,10 @@
 # Service-Account Authentication for GitStore Controllers
+**Status**: 🟡️ Proposed (not yet implemented)
 
 > Generated 2026-08-09 via deep-research workflow (102 agents, 20 sources, 21 verified claims) plus direct source inspection of `gitstore-api` and `gitstore-controller-manager`.
 > Extends `020-pluggable_auth_architecture.md` (Phases 1–6 shipped; this document specifies the deferred Phase 7 "OIDC JWT provider" slot as a **GitStore-issued service-account provider** instead, and supersedes spec 040 research.md's "controller = ordinary bearer-JWT admin principal" interim decision).
+> `022-opa-data-authorization.md` extends this document with authoritative read-path enforcement,
+> semantic Product/ProductVariant scopes, and OPA-backed service-account role resolution.
 
 ---
 
@@ -470,10 +473,12 @@ Enumerated from `categorytaxonomy.NewReconciler` wiring in `cmd/controller/main.
 |--------------------------------------------------------|--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Initial list of CategoryTaxonomy                       | `category.list`                                              | **New** — today there is no distinct list/watch action; `rbac-local` only gates mutations via `GraphQLFieldAuthorizer`, so reads currently pass through ungated by any explicit action check. Adding this action is optional hardening, not a blocker — GraphQL read-path authorization is a separate, pre-existing gap this document does not attempt to close in scope, but the action string is reserved here so it composes cleanly if/when read-gating is added. |
 | Watch/subscribe to CategoryTaxonomy changes            | `category.watch`                                             | **New**, same rationale as above                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Supporting product reads (`NewProductCounter(client)`) | `product.list` (or `product.read`, matching existing naming) | **New**, same rationale                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| Supporting product reads (`NewProductCounter(client)`) | `product.list`                                              | **New** — 022 makes this the canonical Product connection action and enforces it through GraphQL read middleware.                                                                                                                                                                                                                                                                                                                                                     |
 | Category status writes                                 | `category.status.write`                                      | **Existing** — already implemented and enforced today (`graphql.go:181-198`)                                                                                                                                                                                                                                                                                                                                                                                          |
 
-**Recommendation:** define `category.list` and `category.watch` now, even though nothing currently enforces them at the read path, so the controller role (below) is forward-compatible with the day read-gating ships, without another round of action-string churn.
+**Recommendation:** define `category.list` and `category.watch` now. This document reserves those
+actions; `022-opa-data-authorization.md` closes the Product/ProductVariant read-path gap and establishes
+the same server-owned SDL/middleware pattern for future Category list/watch enforcement.
 
 ### 10b. Controller role (`rbac-local` `policy.yaml` fragment)
 
@@ -484,6 +489,7 @@ roles:
       - category.list
       - category.watch
       - product.list
+      - product.read.unpublished
       - category.status.write
     deny: []   # least privilege: no admin, no namespace.*, no repository.*
 
@@ -492,9 +498,15 @@ role_bindings:
     - category-taxonomy-controller
 ```
 
+`product.read.unpublished` is required because the controller's product counter reconciles the
+complete admitted catalog, not the storefront/public projection. Under 022, `product.list` supplies
+the base read entitlement and `product.read.unpublished` upgrades that request to the `MANAGEMENT`
+visibility scope. The role receives no ProductVariant management access unless a future reconciler
+demonstrates a need for both `productVariant.list` and `productVariant.read.unpublished`.
+
 ### 10c. Namespacing and future controllers
 
-Service-account identity is **namespaced by convention** (`serviceaccount:<namespace>:<name>`), reusing the exact same `Principal.Subject` string format the codebase already treats as opaque everywhere (`role_bindings` keys, log fields, `OwnerSub` comparisons). GitStore does not need a first-class "namespace" resource for ServiceAccounts distinct from its existing `Namespace` datastore concept — a simple string convention (e.g. `controllers` as the namespace segment for all controller-manager instances, or one namespace per controller class) is sufficient at this scale and matches Kubernetes' own namespace-as-string-segment design without requiring GitStore to build a second namespacing system. Each future controller (e.g. a hypothetical `product-variant-controller`) gets its own `serviceaccount:<ns>:<name>` + its own `role_bindings` entry + its own disjoint role listing only the actions it needs — no code change to the AuthN provider or the `AuthZProvider` interface, only a `policy.yaml` and registry entry, identical in shape to onboarding a new human role today.
+Service-account identity is **namespaced by convention** (`serviceaccount:<namespace>:<name>`), reusing the exact same `Principal.Subject` string format the codebase already treats as opaque everywhere (`role_bindings` keys, log fields, `OwnerSub` comparisons). GitStore does not need a first-class "namespace" resource for ServiceAccounts distinct from its existing `Namespace` datastore concept — a simple string convention (e.g. `controllers` as the namespace segment for all controller-manager instances, or one namespace per controller class) is sufficient at this scale and matches Kubernetes' own namespace-as-string-segment design without requiring GitStore to build a second namespacing system. Each future controller (e.g. a hypothetical `product-variant-controller`) gets its own `serviceaccount:<ns>:<name>` plus a disjoint built-in controller role. In `rbac-local` that subject is connected through `role_bindings`; in the embedded OPA design it resolves through 022's built-in-role and namespace IAM projection. Neither path changes the AuthN provider or the `AuthZProvider` interface, and roles are not embedded in service-account tokens.
 
 ---
 
@@ -505,7 +517,11 @@ Service-account identity is **namespaced by convention** (`serviceaccount:<names
 3. **Phase 2 — installation-time enrollment, not token bootstrap.** Extend `gitctl` with an idempotent controller-identity enrollment command. It generates a private key locally (or accepts a secret-manager-backed signer), uses the administrator's existing installation context to create/update the ServiceAccount and register only the public key, and writes the private key with restrictive permissions or delegates storage to the deployment secret mechanism. Compose/Helm/native installation automation invokes this command as part of provisioning. It never writes a bearer access token to disk. This corresponds to an operator applying a Kubernetes ServiceAccount, RoleBinding, and workload manifest; runtime token delivery remains automatic.
 4. **Phase 3 — controller exchange, renewal, and WebSocket enforcement.** Add `CredentialSource`, signed assertion exchange, access-token caching, proactive renewal, `Websocket.InitFunc`, expiry deadlines, live-connection cancellation, and `resourceVersion` resume. A restart after the access token expires succeeds from the enrolled private key without administrator involvement.
 5. **Phase 4 — flip the default chain, deprecate the static fallback.** `GITSTORE_AUTH__AUTHN__CHAIN` default becomes `["static-admin","serviceaccount-assertion","serviceaccount-jwt","anonymous"]`. `GITSTORE_CONTROLLER__API_TOKEN` is marked deprecated in `docs/configuration.md` and is used only when no ServiceAccount signer is configured—an explicit dev/CI compatibility path, never the production default. Rollback trigger: any existing integration test relying on the static token path regresses.
-6. **Phase 5 — enforce read-path action strings (`category.list`/`.watch`, `product.list`).** Independent of this migration's critical path; can ship separately once the broader read-authorization gap (noted in §10a) is addressed for all resource kinds, not just CategoryTaxonomy.
+6. **Phase 5 — enforce read-path action strings.** Adopt 022's SDL/middleware contract for
+   `product.list` and its semantic visibility scope, then extend the same pattern to
+   `category.list`/`.watch`. The controller role includes `product.read.unpublished` only because its
+   reconciliation count needs the complete admitted Product set. ProductVariant management actions
+   remain absent until a controller requirement justifies them.
 
 At every phase, `static-admin` login and the existing `ChainedAuthN` short-circuit semantics (`registry.go:291-309`) remain intact. The two service-account providers use distinct token `typ` and audience contracts and return `OutcomeChallenge` for credentials they do not recognize. Installation may require an authorized administrative context to enroll identity, just as Kubernetes requires an operator or control plane to create/bind a ServiceAccount, but no administrator-issued bearer token participates in controller startup or renewal.
 
@@ -557,7 +573,11 @@ At every phase, `static-admin` login and the existing `ChainedAuthN` short-circu
 - **Controller private-key protection becomes deployment-critical.** The key is a durable proof-of-possession credential, though it is not a bearer token and never leaves the controller. Native/Compose installs require restrictive filesystem permissions or a secret manager; Kubernetes should use a Secret/CSI-backed mount until the optional cluster-issued-token provider exists. Key rotation must support overlapping `kid` values.
 - **Assertion replay protection is initially process-local.** A short assertion lifetime limits exposure in the single-instance profile. Multi-replica APIs require an atomic shared `jti` store before the feature is enabled across replicas.
 - **Immediate WebSocket revocation is replica-local without broadcast.** Persistent disable/delete state blocks new authentication everywhere, but each replica needs a datastore watch or pub/sub invalidation signal to cancel its existing sockets promptly.
-- **Read-path authorization gap** (§10a) is broader than this document's scope: today `GraphQLFieldAuthorizer` only gates specific mutation fields, not queries/subscriptions in general. Shipping `category.list`/`.watch` action strings without enforcing them anywhere is inert until that gap is closed — tracked as Phase 5 of §11, not blocking the primary migration. The assertion-only principal is nevertheless explicitly operation-restricted in Phase 1 and cannot use this gap.
+- **Read-path authorization migration** (§10a) spans more than controller authentication: today
+  `GraphQLFieldAuthorizer` gates selected mutations, not general queries/subscriptions. 022 defines
+  the Product/ProductVariant enforcement contract; Category list/watch enforcement still requires
+  its own schema annotations and tests. Until those phases ship, assertion-only principals remain
+  explicitly operation-restricted and cannot use the legacy read gap.
 - **Public-key enrollment is an administrative installation operation.** This is not runtime token bootstrap: the administrator never mints or copies a bearer token, and the controller can recover autonomously after enrollment. Automation must make the operation idempotent and auditable.
 
 **Unresolved decisions (deliberately deferred, not blocking)**
@@ -569,7 +589,9 @@ At every phase, `static-admin` login and the existing `ChainedAuthN` short-circu
 - This design does **not** adopt SPIFFE/SPIRE, mTLS, or an external OAuth2 authorization server as the primary mechanism (§5).
 - This design does **not** require Kubernetes for any GitStore deployment profile.
 - This design does **not** embed roles/scopes inside the JWT or ServiceAccount registry (§9) — authorization is resolved from `rbac-local`'s role definitions and subject bindings.
-- This design does **not** attempt to close the general GraphQL read-path authorization gap — only to reserve action-string names so that future work composes cleanly.
+- This design does **not itself implement** the general GraphQL read path. It reserves controller
+  actions and delegates the Product/ProductVariant authorization design to
+  `022-opa-data-authorization.md`; other resource kinds require follow-up specifications.
 
 ---
 

--- a/docs/implementation/022-opa-data-authorization.md
+++ b/docs/implementation/022-opa-data-authorization.md
@@ -1,0 +1,816 @@
+# OPA Data-Aware Authorization for GraphQL Catalog Reads
+**Status**: 🟡 Proposed (architecture only; implementation requires a separate feature specification)
+
+> Extends `020-pluggable_auth_architecture.md` and `021-controller_service_account_auth.md`.
+> This document is authoritative for the embedded OPA provider, GraphQL read authorization,
+> semantic catalog scopes, hybrid IAM data, and authorization-aware Product/ProductVariant reads.
+
+## 1. Executive Decision
+
+GitStore will add an **embedded Open Policy Agent (OPA) AuthZ provider** to the existing
+pluggable authorization plane. The provider compiles and prepares Rego once, evaluates a
+small request-specific input document, and reads shared IAM definitions from an in-memory OPA
+data projection. It does not call an OPA sidecar and does not send the GraphQL schema or raw
+operation to OPA on each request.
+
+The public GraphQL contract will use server-owned SDL metadata to identify the authorization
+action and whether the field requires a binary check or a data scope. gqlgen middleware makes
+the policy decision before catalog access. Resolvers may consume a validated semantic scope
+such as `PUBLIC` or `MANAGEMENT`, but they must not inspect roles, groups, direct grants, or
+permissions. Service and datastore entry points require that validated scope, making an
+unscoped catalog read unavailable by construction.
+
+For Relay connections, authorization changes the physical query plan before pagination. Public
+reads use public Product/ProductVariant projections; management reads use the complete catalog
+projections. GitStore never fetches a page and removes unauthorized nodes afterward, and it
+never relies on CQL `ALLOW FILTERING` for authorization.
+
+OPA remains opt-in. This design does not change the default provider or implement any runtime
+code, GraphQL schema, IAM mutation, or ScyllaDB migration.
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+- Preserve the live `AuthNProvider`, `AuthZProvider`, `Principal`, action-string, and
+  `ResourceContext` contracts from 020.
+- Centralize GraphQL AuthN/AuthZ in gqlgen middleware while carrying policy-produced data scopes
+  to resolvers safely.
+- Enforce consistent Product and ProductVariant visibility across direct lookups, Relay lists,
+  global nodes, relationship fields, counts, and future subscriptions.
+- Support permissions granted directly, through built-in or namespace-defined roles, or through
+  external group membership mapped to namespace roles.
+- Maintain accurate Relay cursors, `totalCount`, and `pageInfo` for every authorization scope.
+- Fail closed when policy, IAM data, scope validation, publication state, or evaluation is unsafe.
+
+### Non-goals
+
+- Designing release tags, schedules, activation windows, or release controllers; that belongs to
+  [GH#314](https://github.com/gitstore-dev/GitStore/issues/314).
+- Treating a client-supplied directive as authority.
+- Translating arbitrary residual Rego expressions into CQL.
+- Loading all user profiles, credentials, sessions, or catalog rows into OPA.
+- Adding nested groups, role inheritance, or a general relationship-authorization graph in v1.
+- Replacing gqlgen's parsing, validation, complexity limiting, or persisted-query handling.
+- Changing current production defaults before a later rollout explicitly approves that change.
+
+## 3. Verified Current-State Constraints
+
+The design extends these existing contracts rather than creating a parallel security path:
+
+- `gitstore-api/internal/auth/types.go` defines `Principal`, `Decision`, `ResourceContext`, and
+  `AuthZProvider.Authorize(ctx, principal, action, resource)`.
+- `gitstore-api/internal/auth/registry.go` exposes exactly one active AuthZ provider through the
+  existing provider registry.
+- `gitstore-api/internal/auth/provider/rbaclocal` resolves principal roles plus subject role
+  bindings, applies explicit deny before allow, and defaults to deny.
+- `gitstore-api/internal/middleware/security/graphql.go` already authenticates GraphQL operations
+  and authorizes selected mutations through gqlgen `AroundOperations` and `AroundFields` hooks.
+- `gitstore-api/internal/app/server.go` installs those hooks on the GraphQL server.
+- Product and ProductVariant reads are currently ungated. They are reachable through root fields,
+  global `node(s)`, and relationship fields such as `Category.products`, `Collection.products`,
+  and `Product.productVariants`.
+- The current datastore exposes unscoped `ListProducts` and `ListProductVariants` methods. ScyllaDB
+  lists by pre-modeled partition/keyset access patterns, while some relationship paths currently
+  filter or paginate in application memory.
+- Product status defines `Published`; ProductVariant status does not currently define an equivalent
+  publication condition. Public ProductVariant rollout therefore depends on GH#314 materializing a
+  variant publication-eligibility signal.
+
+## 4. Trust Boundaries and Request Flow
+
+```mermaid
+flowchart TD
+    A["HTTP or WebSocket request"] --> B["gqlgen AroundOperations: authenticate"]
+    B --> C["Principal in context"]
+    C --> D["SDL @authorize / common field authorizer"]
+    D --> E["Build minimal AuthorizationInput"]
+    E --> F["Verify authoritative IAM revision"]
+    F --> G["Embedded OPA prepared query"]
+    G --> H{"Validated decision"}
+    H -->|deny or invalid| I["FORBIDDEN / fail closed"]
+    H -->|allow + CHECK| J["Resolver executes"]
+    H -->|allow + SCOPE| K["Semantic scope in field context"]
+    K --> L["Authorized catalog query"]
+    L --> M{"Scope"}
+    M -->|PUBLIC| N["Public datastore projection"]
+    M -->|MANAGEMENT| O["Complete datastore projection"]
+```
+
+The boundaries are intentional:
+
+1. **AuthN owns identity.** Credentials are verified before policy evaluation. OPA never parses or
+   verifies passwords, bearer tokens, controller assertions, or JWT signatures.
+2. **GraphQL middleware owns policy invocation.** Resolvers do not call OPA and do not derive
+   permissions from a principal.
+3. **OPA owns entitlement resolution.** Direct grants, role grants, group-derived roles, deny
+   precedence, and scope selection remain policy concerns.
+4. **Resolvers adapt, but do not decide.** A resolver turns a validated decision into an authorized
+   query object because collection scope must influence the datastore query.
+5. **The datastore enforces query shape.** It selects an already-modeled public or management
+   projection; it does not interpret Rego, roles, or GraphQL directives.
+
+## 5. GraphQL Authorization Contract
+
+### 5.1 Server-owned SDL directive
+
+The first implementation adds one reusable directive:
+
+```graphql
+enum AuthzMode {
+  CHECK
+  SCOPE
+}
+
+directive @authorize(
+  action: String!
+  resource: String!
+  mode: AuthzMode! = CHECK
+) on FIELD_DEFINITION
+```
+
+- `CHECK` requires an allow decision and passes no catalog query scope.
+- `SCOPE` requires an allow decision containing exactly one valid scope for the declared resource.
+- `action` uses the existing dot-delimited GitStore vocabulary.
+- `resource` is a stable policy kind, not a Go type or database table name.
+- Directive arguments are schema-authored constants. Clients cannot change or omit them.
+
+gqlgen generates a directive handler that behaves like field middleware and may short-circuit
+before `next(ctx)`. This is the intended use described by gqlgen's
+[schema directive documentation](https://gqlgen.com/reference/directives/). Authentication remains
+in `AroundOperations`; common extraction, logging, decision validation, and dynamic global-node
+handling remain in shared field middleware, following gqlgen's
+[middleware model](https://gqlgen.com/reference/middlewares/).
+
+Representative schema usage:
+
+```graphql
+extend type Query {
+  product(by: ProductBy!): Product
+    @authorize(action: "product.read", resource: "product", mode: SCOPE)
+
+  products(namespace: String!, first: Int, after: String, last: Int, before: String): ProductConnection!
+    @authorize(action: "product.list", resource: "product", mode: SCOPE)
+
+  productVariant(by: ProductVariantBy!): ProductVariant
+    @authorize(action: "productVariant.read", resource: "productVariant", mode: SCOPE)
+
+  productVariants(namespace: String!, first: Int, after: String, last: Int, before: String): ProductVariantConnection!
+    @authorize(action: "productVariant.list", resource: "productVariant", mode: SCOPE)
+}
+
+extend type Category {
+  products(first: Int, after: String, last: Int, before: String): ProductConnection!
+    @authorize(action: "product.list", resource: "product", mode: SCOPE)
+}
+
+extend type Collection {
+  products(first: Int, after: String, last: Int, before: String): ProductConnection!
+    @authorize(action: "product.list", resource: "product", mode: SCOPE)
+}
+
+extend type Product {
+  productVariants(first: Int, after: String, last: Int, before: String): ProductVariantConnection!
+    @authorize(action: "productVariant.list", resource: "productVariant", mode: SCOPE)
+}
+```
+
+### 5.2 Global node fields
+
+`Query.node` and `Query.nodes` are polymorphic and cannot declare a single Product-specific action.
+Their common field authorizer decodes GitStore's opaque global ID before resolving the node:
+
+- Product ID → evaluate `product.read` and attach a Product scope for that ID.
+- ProductVariant ID → evaluate `productVariant.read` and attach a ProductVariant scope for that ID.
+- Other kinds → use that kind's existing or future action without manufacturing a catalog scope.
+- Invalid or unknown IDs retain the current invalid/not-found behavior without disclosing existence.
+
+For `nodes`, decisions are associated with the normalized global ID, not only the resource kind, so
+a mixed batch cannot accidentally reuse one node's decision for another. A later provider extension
+may batch OPA evaluations, but batching must preserve the same per-ID result.
+
+### 5.3 Field-local context
+
+A scoped decision is stored in the context passed to `next(ctx)` and keyed by:
+
+```text
+GraphQL response path + resource kind + normalized resource identifier (when known)
+```
+
+This prevents a decision for one root field, alias, node, or namespace from authorizing another field
+in the same operation. Scope lookup is mandatory and consumes only a decision matching the current
+field path, resource kind, namespace, and identifier. A missing, duplicate, conflicting, or mismatched
+scope fails closed.
+
+### 5.4 Future executable directive
+
+A future feature may add:
+
+```graphql
+enum CatalogView {
+  PUBLIC
+  MANAGEMENT
+}
+
+directive @catalogView(mode: CatalogView!) on FIELD
+```
+
+This directive is **not part of v1**. If implemented, it expresses client intent only. Middleware
+passes the requested view to OPA, and OPA clamps it to the principal's entitlement. Requesting
+`MANAGEMENT` without the unpublished-read entitlement returns the policy-selected `PUBLIC` scope or
+`FORBIDDEN`, according to the field's documented contract; it never grants management access.
+
+## 6. OPA Evaluation Model
+
+### 6.1 Embedded provider
+
+The provider uses the OPA v1 Go packages:
+
+```go
+import (
+    "github.com/open-policy-agent/opa/v1/rego"
+    "github.com/open-policy-agent/opa/v1/storage"
+    "github.com/open-policy-agent/opa/v1/storage/inmem"
+)
+```
+
+At startup it:
+
+1. loads the configured bundle from a local, immutable deployment path;
+2. validates package and decision-path contracts;
+3. creates one `storage/inmem` store containing built-in policy data plus empty namespace IAM data;
+4. compiles and prepares the configured decision query exactly once; and
+5. publishes the engine only after preparation succeeds.
+
+OPA documents that prepared queries can be cached and shared across goroutines, and that preparing
+before evaluation avoids repeated parsing and compilation; see
+[Integrating OPA](https://www.openpolicyagent.org/docs/integration). Namespace IAM changes update the
+same OPA store through write transactions. They do not recompile the policy.
+
+There is no OPA HTTP client, sidecar health dependency, sidecar circuit breaker, or network hop in
+this phase. OPA stays behind the existing `AuthZProvider` interface.
+
+### 6.2 Minimal input
+
+The adapter constructs a typed input rather than serializing request objects wholesale:
+
+```json
+{
+  "principal": {
+    "subject": "user-123",
+    "issuer": "gitstore",
+    "tenant": "",
+    "namespace": "shop-42",
+    "groups": ["merchandising"],
+    "roles": ["staff"],
+    "scopes": [],
+    "auth_method": "oidc-jwt"
+  },
+  "action": "product.list",
+  "resource": {
+    "kind": "product",
+    "name": "",
+    "namespace": "shop-42",
+    "attributes": {}
+  },
+  "graphql": {
+    "operation_type": "query",
+    "operation_name": "Catalog",
+    "parent_type": "Query",
+    "field": "products",
+    "response_path": "publicCatalog"
+  },
+  "request": {
+    "requested_view": "PUBLIC"
+  },
+  "iam": {
+    "namespace": "shop-42",
+    "revision": "184"
+  }
+}
+```
+
+Only allowlisted `ResourceContext.Attrs` keys may enter `resource.attributes`. The adapter rejects an
+unknown attribute instead of silently exposing it to policy. It excludes:
+
+- raw GraphQL source, the complete parsed operation, and the GraphQL schema;
+- request headers, cookies, bearer tokens, passwords, and controller assertions;
+- `Principal.Claims` except values normalized into canonical Principal fields by a trusted provider;
+- unrelated variables, selection sets, catalog rows, and user profiles.
+
+Operation and field names provide audit/policy context but are not authority. The server-owned action
+and resource values remain authoritative.
+
+### 6.3 Decision output and fail-closed rules
+
+The configured Rego decision path returns one object:
+
+```json
+{
+  "allow": true,
+  "reason": "product list allowed with public visibility",
+  "scopes": [
+    {
+      "resource_kind": "product",
+      "name": "catalog.visibility",
+      "value": "PUBLIC"
+    }
+  ],
+  "policy_revision": "sha256:...",
+  "iam_revision": "184"
+}
+```
+
+The Go adapter validates the result before converting it to `auth.Decision`. It denies when:
+
+- evaluation errors, exceeds its deadline, returns undefined, or returns multiple results;
+- the result is not an object or required fields have the wrong type;
+- the returned IAM revision differs from the authoritative revision used for the evaluation;
+- a `CHECK` request returns authority-bearing data the adapter does not understand;
+- a `SCOPE` request is allowed without exactly one matching semantic scope;
+- the scope resource, name, or value is unknown or does not match the field request; or
+- OPA returns `allow=false` or an unknown action is evaluated.
+
+The client receives a stable GraphQL error code, not internal policy or synchronization details.
+
+### 6.4 GraphQL built-ins
+
+OPA's GraphQL built-ins can parse or verify a query against a schema, and custom directive definitions
+must be included in that schema; see OPA's
+[GraphQL built-ins](https://www.openpolicyagent.org/docs/policy-reference/builtins/graphql). GitStore does
+not use those built-ins for v1 field authorization because gqlgen has already parsed and validated the
+operation and exposes the necessary typed field context.
+
+If whole-operation policies are added later, the schema—including GitStore custom directives—is loaded
+with policy configuration and parsed/prepared once. Only the request-specific operation AST or a
+minimized operation summary may vary per evaluation. The full schema is never copied into every input.
+
+## 7. Public Interfaces and Types
+
+### 7.1 Additive authorization decision
+
+`AuthZProvider.Authorize` remains unchanged. `auth.Decision` gains additive, provider-neutral fields:
+
+```go
+type DecisionScope struct {
+    ResourceKind string `json:"resource_kind"`
+    Name         string `json:"name"`
+    Value        string `json:"value"`
+}
+
+type Decision struct {
+    Outcome        Outcome         `json:"outcome"`
+    Reason         string          `json:"reason"`
+    RequestID      string          `json:"request_id"`
+    At             time.Time       `json:"at"`
+    Provider       string          `json:"provider"`
+    Scopes         []DecisionScope `json:"scopes,omitempty"`
+    PolicyRevision string          `json:"policy_revision,omitempty"`
+    IAMRevision    string          `json:"iam_revision,omitempty"`
+}
+```
+
+`DecisionScope` is deliberately different from `Principal.Scopes`: principal scopes are asserted
+identity attributes; decision scopes are short-lived results for one authorization request. Scope
+construction is restricted to provider adapters and validated middleware helpers.
+
+The v1 scope registry is closed:
+
+| Resource kind | Scope name | Allowed values |
+|---|---|---|
+| `product` | `catalog.visibility` | `PUBLIC`, `MANAGEMENT` |
+| `productVariant` | `catalog.visibility` | `PUBLIC`, `MANAGEMENT` |
+
+New scope names or values require an explicit contract change and tests. Arbitrary CQL fragments,
+table names, predicates, field masks, or Rego expressions are forbidden scope values.
+
+### 7.2 Authorized query types
+
+Catalog service/datastore APIs accept typed queries rather than an unscoped namespace plus pagination:
+
+```go
+type CatalogVisibility string
+
+const (
+    CatalogVisibilityPublic     CatalogVisibility = "PUBLIC"
+    CatalogVisibilityManagement CatalogVisibility = "MANAGEMENT"
+)
+
+type AuthorizedProductQuery struct {
+    Namespace  string
+    Visibility CatalogVisibility
+    Page       PageParams
+    By         *ProductSelector
+    Relation   *ProductRelation
+}
+
+type AuthorizedProductVariantQuery struct {
+    Namespace  string
+    Visibility CatalogVisibility
+    Page       PageParams
+    By         *ProductVariantSelector
+    ProductRef *ObjectReference
+}
+```
+
+The exact package placement is an implementation-spec decision, but these invariants are mandatory:
+
+- no exported Product/ProductVariant reader omits `CatalogVisibility`;
+- constructors accept only a matching, validated field decision;
+- `PUBLIC` and `MANAGEMENT` are the only values;
+- selectors and relations are mutually exclusive and validated;
+- relationship reads and counts use the same visibility as their returned connection; and
+- internal controllers use the same authorized path rather than bypassing it through a raw datastore.
+
+The resolver's justified authorization "leak" is therefore limited to:
+
+```go
+scope := authz.RequiredCatalogVisibility(ctx, "product")
+query := catalogquery.NewAuthorizedProductQuery(scope, namespace, page)
+return service.ListProducts(ctx, query)
+```
+
+It never contains `if principal.IsAdmin()`, role names, group names, or permission strings.
+
+## 8. Hybrid IAM Ownership
+
+### 8.1 Sources of authority
+
+GitStore uses a hybrid model:
+
+| Data | Authority | OPA location |
+|---|---|---|
+| Built-in human and controller role definitions | Versioned GitStore OPA bundle | `data.gitstore.builtin_roles` |
+| Namespace custom role definitions | GitStore datastore | `data.gitstore.namespaces[ns].roles` |
+| Direct subject permissions and role assignments | GitStore datastore | `data.gitstore.namespaces[ns].subjects` |
+| Group-to-role bindings | GitStore datastore | `data.gitstore.namespaces[ns].group_role_bindings` |
+| Current principal group membership | Trusted AuthN/UserDir normalization | `input.principal.groups` |
+| Request/resource facts | GraphQL middleware and resource lookup | `input` |
+
+Built-in roles are immutable through IAM APIs. A namespace custom role cannot shadow a built-in role;
+role names are unique across the effective namespace role set. Upstream role/group claims are used only
+after an AuthN/UserDir provider maps them to canonical, allowlisted names. Raw `Principal.Claims` are
+never interpreted by Rego.
+
+There are no persisted group membership lists in v1. GitStore persists only group-to-role mappings;
+the identity provider or UserDir remains authoritative for membership.
+
+### 8.2 Logical persisted entities
+
+The later feature specification must map these logical entities to memdb and ScyllaDB:
+
+```text
+IAMRole
+  namespace, name, allow[], deny[], built_in=false, resource_version
+
+IAMSubjectGrant
+  namespace, subject, roles[], allow[], deny[], resource_version
+
+IAMGroupRoleBinding
+  namespace, group, roles[], resource_version
+
+IAMNamespaceRevision
+  namespace, revision, updated_at
+```
+
+Every mutation of a role, subject grant, or group binding increments the namespace IAM revision in the
+same logical operation. Administrative GraphQL CRUD uses the existing middleware path and requires
+`iam.manage` for that namespace. An actor cannot mutate built-in roles, grant an unknown role, bind a
+group to an unknown role, or create nested group/role references.
+
+Deletion behavior is fail closed: deleting a custom role is rejected while a subject or group binding
+references it, unless a future API defines an atomic cascading mutation.
+
+### 8.3 Permission expansion and precedence
+
+OPA computes effective permissions from:
+
+1. direct subject grants;
+2. roles assigned directly to the subject;
+3. trusted built-in roles normalized onto the Principal;
+4. current Principal groups mapped through namespace group-role bindings; and
+5. built-in or namespace custom role definitions.
+
+Explicit deny overrides every allow, including direct permissions, group-derived roles, wildcards, and
+default allow. No role inherits another role and no group contains another group. An unknown role,
+permission, action, namespace, or binding contributes no allow. The policy default is deny.
+
+### 8.4 Namespace isolation and revision synchronization
+
+Namespace is the customer-defined IAM boundary. Before every evaluation:
+
+1. the provider reads the namespace's authoritative `IAMNamespaceRevision`;
+2. it compares that revision with the namespace snapshot installed in OPA;
+3. when behind, a singleflight refresh reads one complete, internally consistent namespace snapshot;
+4. one OPA write transaction replaces the namespace subtree and its revision atomically; and
+5. evaluation begins only after the installed revision equals the authoritative revision.
+
+Concurrent requests may share the completed refresh. They may not evaluate against a known-stale
+snapshot. If the authoritative revision cannot be read, the snapshot cannot be loaded, or the revision
+changes during refresh, evaluation denies and retries according to the caller's normal retry policy.
+
+Multi-replica API processes maintain independent in-memory OPA stores but converge through the same
+authoritative revision check. No correctness requirement depends on process-local invalidation alone.
+
+## 9. Catalog Actions and Semantic Scopes
+
+The first catalog action vocabulary is:
+
+| Action | Meaning | Base result |
+|---|---|---|
+| `product.read` | Read one Product | `PUBLIC` when allowed |
+| `product.list` | List/count Products | `PUBLIC` when allowed |
+| `product.read.unpublished` | Include non-public Products | upgrades Product scope to `MANAGEMENT` |
+| `productVariant.read` | Read one ProductVariant | `PUBLIC` when allowed |
+| `productVariant.list` | List/count ProductVariants | `PUBLIC` when allowed |
+| `productVariant.read.unpublished` | Include non-public ProductVariants | upgrades ProductVariant scope to `MANAGEMENT` |
+
+The base read/list permission is necessary for either scope. An unpublished-read grant does not grant
+the base action by itself. OPA returns `MANAGEMENT` only when both the requested base action and the
+corresponding unpublished entitlement are effective for the namespace.
+
+The additional entitlement may originate from a direct subject grant, built-in role, custom role, or
+group-derived role. Schema/resolver code does not distinguish those sources.
+
+## 10. Controller Service Accounts
+
+Service-account authentication follows 021. Tokens and ServiceAccount records carry stable identity,
+not authorization roles. OPA resolves `serviceaccount:<namespace>:<name>` through the same built-in role
+and namespace binding model used for humans.
+
+Controller roles are immutable built-ins in the OPA bundle. A controller receives management visibility
+only for resource kinds whose role explicitly grants the matching unpublished-read action. For example,
+the CategoryTaxonomy controller needs `product.list` and `product.read.unpublished` if product counts
+must include admitted-but-unpublished Products. It receives no ProductVariant management scope unless a
+separate reconciler requirement explicitly grants `productVariant.list` and
+`productVariant.read.unpublished`.
+
+Long-lived subscriptions retain the decision made for their authenticated connection only until the
+connection is re-authorized or closed under 021's expiry/revocation rules. A future catalog subscription
+must also re-check IAM/publication authorization when reconnecting and must not replay events outside its
+new scope.
+
+## 11. Publication Eligibility Boundary
+
+Authorization answers **which catalog view the principal may request**. Publication answers **which
+resources belong in the public view**. These decisions must remain separate.
+
+[GH#314](https://github.com/gitstore-dev/GitStore/issues/314) owns the release/publication lifecycle,
+including tags, commit reachability, schedules, selectors, active windows, and materialization strategy.
+OPA does not recreate those rules. It selects `PUBLIC` or `MANAGEMENT`; the datastore/query layer reads
+the corresponding materialized view.
+
+Until GH#314 replaces it, Product public eligibility is:
+
+```text
+status.conditions contains:
+  type == Published
+  status == True
+  observedGeneration == metadata.generation
+```
+
+Missing status, missing `Published`, `False`, `Unknown`, or a condition observed for an older generation
+is non-public. Updating a Product spec increments generation and synchronously removes the Product from
+public projections before the updated full record becomes visible; a later publication reconciliation
+may add it back.
+
+ProductVariant public eligibility requires both:
+
+1. independently materialized publication eligibility for the variant's current generation; and
+2. a publicly eligible parent Product matching the resolved parent reference.
+
+The current ProductVariant GraphQL status enum has no `PUBLISHED` condition. Public ProductVariant reads
+therefore remain fail closed until GH#314 defines and materializes that signal (whether as a condition,
+publication record, or public projection). `READY=True` is not a substitute for publication. GH#314 may
+later require current-generation `Ready=True` and an active effective window in addition to publication
+without changing the `catalog.visibility` authorization scope.
+
+## 12. ScyllaDB and memdb Query Design
+
+### 12.1 Projection rule
+
+Every authorized access pattern has a physical or indexed query path for both scopes:
+
+| GraphQL access | `PUBLIC` | `MANAGEMENT` |
+|---|---|---|
+| Product list by namespace | public Product namespace projection | existing complete Product namespace table |
+| Product by name/UID | public Product name/UID lookup | existing complete name/UID lookup |
+| Category/Collection Products | public relationship projection | complete relationship projection |
+| ProductVariant list by namespace | public variant namespace projection | existing complete variant namespace table |
+| ProductVariant by name/UID/SKU | public variant lookup projections | existing complete lookup projections |
+| Product.productVariants | public variants-by-product projection | complete variants-by-product projection |
+
+Concrete table names and migration ordering belong to the implementation specification. The naming
+convention should make public tables unmistakable, for example `products_public_by_namespace` and
+`product_variants_public_by_product`.
+
+All projections for one catalog write are updated with the consistency mechanism selected by the
+catalog-publication design. The safety invariant is one-way: a resource may temporarily disappear from
+the public view during uncertainty, but an ineligible resource must never remain publicly readable.
+
+### 12.2 Relay invariants
+
+Authorization and publication filtering happen before keyset pagination:
+
+1. select the scope-specific projection;
+2. apply its partition and clustering-key cursor;
+3. read `limit + 1` rows;
+4. build edges and `pageInfo`; and
+5. compute `totalCount` from the same scope-specific dataset or a matching maintained counter.
+
+Public and management projections use identical stable ordering/cursor components wherever the API
+exposes the same connection. A cursor obtained under one visibility is rejected if reused under another;
+the opaque cursor format must bind the resource kind and visibility in its versioned payload.
+
+Fetching a management page and deleting unpublished edges afterward is prohibited because it creates
+short pages, misleading `hasNextPage`, inconsistent counts, and data-dependent over-fetching. CQL
+`ALLOW FILTERING` is also prohibited: ScyllaDB documents that such queries can have performance tied to
+the total stored data rather than returned rows; see the
+[ScyllaDB SELECT guidance](https://docs.scylladb.com/manual/stable/cql/dml/select.html#allowing-filtering).
+
+memdb implements the same externally observable contracts with visibility-specific indexes or
+pre-pagination selection. It may not post-filter an already-paginated result.
+
+## 13. GraphQL Error and Enumeration Semantics
+
+| Condition | GraphQL behavior |
+|---|---|
+| Missing base action | `FORBIDDEN`; resolver is not called |
+| OPA unavailable/invalid/timeout/stale IAM | stable authorization error with `FORBIDDEN`; details only in logs |
+| Public direct lookup of unpublished Product/ProductVariant | `null` or existing `NOT_FOUND` shape, identical to absent resource |
+| Public list | ineligible resources absent; no per-edge errors |
+| Invalid/mismatched semantic scope | `FORBIDDEN`; no fallback to management query |
+| Management lookup of existing unpublished resource | returned normally when base + unpublished entitlements allow it |
+
+Direct lookup behavior prevents resource enumeration. The API must not reveal whether a Product or
+ProductVariant exists but is outside the caller's view through messages, timing classes, counts, or
+global-node behavior.
+
+## 14. Configuration, Lifecycle, and Failure Handling
+
+Proposed additive Viper keys:
+
+```toml
+[auth.authz]
+provider = "opa"
+
+[auth.opa]
+bundle_path = "./policy/opa/gitstore-bundle.tar.gz"
+decision_path = "data.gitstore.authz.decision"
+evaluation_timeout = "25ms"
+```
+
+Environment variables follow existing Viper conventions:
+
+```text
+GITSTORE_AUTH__AUTHZ__PROVIDER=opa
+GITSTORE_AUTH__OPA__BUNDLE_PATH=...
+GITSTORE_AUTH__OPA__DECISION_PATH=data.gitstore.authz.decision
+GITSTORE_AUTH__OPA__EVALUATION_TIMEOUT=25ms
+```
+
+Rules:
+
+- `opa` is opt-in; existing defaults remain unchanged.
+- Missing bundle, compile error, invalid decision path, or invalid built-in data prevents readiness
+  and startup of the GraphQL serving path.
+- Bundle reload uses read → verify/compile/prepare → atomic engine swap. Requests see either the old
+  complete engine or the new complete engine.
+- Runtime reload failure retains the last valid engine, marks reload health/metrics, and logs the
+  failure. It never installs a partial bundle.
+- Keeping the old policy does not permit known-stale namespace IAM data: the per-evaluation revision
+  contract still denies until the current IAM snapshot is installed.
+- Evaluation uses a child context with the configured deadline. Cancellation and timeout deny.
+- A bundle rollback is the same atomic swap mechanism and must preserve decision-output compatibility.
+
+## 15. Observability and Audit Contract
+
+Extend `DecisionLogger` fields with:
+
+```text
+scope_resource_kind, scope_name, scope_value,
+policy_revision, iam_revision, evaluation_latency_ms,
+iam_sync_lag_revisions, graphql_parent_type, graphql_field
+```
+
+Continue logging `provider`, `subject`, `action`, resource identity, outcome, reason, request ID, and
+total latency. Never log credentials, JWT/assertion contents, raw claims, raw GraphQL source, arbitrary
+variables, OPA data snapshots, or full catalog resources.
+
+Minimum metrics:
+
+```text
+gitstore_api_authz_decisions_total{provider,action,outcome,scope}
+gitstore_api_authz_evaluation_seconds{provider}
+gitstore_api_authz_policy_reload_total{outcome}
+gitstore_api_authz_policy_revision_info{revision}
+gitstore_api_authz_iam_refresh_total{outcome}
+gitstore_api_authz_iam_sync_lag{namespace_hash}
+```
+
+Namespace labels must be bounded or hashed to avoid unbounded Prometheus cardinality. Policy and IAM
+revisions are useful in structured logs; exposing raw revisions as metric labels requires an explicit
+cardinality review.
+
+## 16. Validation and Acceptance Matrix
+
+### Policy and IAM
+
+- Direct allow and direct deny for each catalog action.
+- Built-in role and namespace custom-role permission expansion.
+- Principal group → namespace group binding → built-in/custom role → permission.
+- Subject-to-role assignment and combination with trusted Principal built-in roles.
+- Explicit deny precedence across direct, role, group, wildcard, and default-allow sources.
+- Unknown role/action/scope/namespace and cross-namespace binding isolation.
+- Built-in role immutability, referenced-role deletion rejection, and `iam.manage` enforcement.
+- Decision parity with `rbac-local` for every pre-existing non-catalog action.
+
+### GraphQL coverage
+
+- `product`, `products`, `productVariant`, and `productVariants`.
+- Product/ProductVariant IDs through `node` and mixed `nodes` batches.
+- `Category.products`, `Collection.products`, and `Product.productVariants`.
+- Scope-correct `totalCount`, cursors, aliases, fragments, and multiple root fields.
+- Future Product/ProductVariant subscription entry, reconnect, and replay boundaries.
+- Missing base permission is `FORBIDDEN`; unpublished public lookup is indistinguishable from absent.
+
+### Publication and storage
+
+- Current-generation Product publication enters the public projection.
+- Missing/false/unknown/stale publication stays out; a generation change removes public visibility
+  synchronously.
+- Variant eligibility is fail closed before GH#314 materializes it.
+- Variant public visibility requires both variant and current parent eligibility.
+- Scheduled activation/expiry integration tests are added with GH#314 without changing AuthZ scopes.
+- memdb and ScyllaDB produce identical public/management results and Relay metadata.
+- Cursor visibility binding rejects cross-scope reuse.
+- No `ALLOW FILTERING` and no post-pagination authorization filtering in query implementations.
+
+### OPA engine and operations
+
+- Startup rejects missing, malformed, or contract-incompatible bundles.
+- Atomic reload exposes no partial policy; failed reload retains the last valid engine.
+- IAM revision refresh is atomic, singleflight, namespace-isolated, and denies on uncertainty.
+- Concurrent evaluation is race-free and observes complete store transactions.
+- Undefined, multiple, malformed, mismatched-revision, invalid-scope, error, cancellation, and timeout
+  results all fail closed.
+- Decision logs/metrics contain revisions and scope but no secrets or raw input.
+- Benchmarks prove policy preparation occurs at startup/reload, never per authorization request, and
+  establish p50/p95/p99 evaluation plus IAM-refresh overhead budgets before rollout.
+
+## 17. Rollout and Compatibility
+
+1. **Feature specification:** define concrete Go packages, GraphQL annotations, IAM schemas/mutations,
+   datastore projections/migrations, and GH#314 dependencies.
+2. **Provider foundation:** implement additive Decision scopes, OPA bundle preparation, strict result
+   validation, and parity tests while keeping `opa` disabled by default.
+3. **IAM projection:** add persistent namespace IAM entities, revision synchronization, and protected
+   administration APIs.
+4. **Scoped readers:** replace unscoped Product/ProductVariant read interfaces and cover all GraphQL
+   paths. Public ProductVariant exposure stays gated on publication eligibility.
+5. **Public projections:** build/backfill scope-specific memdb and ScyllaDB query paths, then enable
+   public visibility behind a deployment feature flag.
+6. **Production opt-in:** enable `GITSTORE_AUTH__AUTHZ__PROVIDER=opa` only after parity, load,
+   publication, and rollback tests pass. Changing the default is a separate decision.
+
+Compatibility guarantees:
+
+- `AuthZProvider.Authorize` and existing action strings do not change.
+- Existing providers may leave new Decision fields empty; `CHECK` calls continue to work.
+- A `SCOPE` field fails closed when the active provider cannot produce the required semantic scope.
+- `rbac-local` remains usable for existing checks; it must be extended or wrapped before it can serve
+  scoped catalog reads.
+- Existing admin and controller tokens do not gain permissions from token claims; IAM policy remains
+  authoritative.
+
+## 18. Assumptions and Resolved Decisions
+
+- Namespace is the tenant/customer boundary for custom IAM.
+- Built-in roles and controller roles ship in the OPA bundle and are immutable at runtime.
+- External group membership is trusted only after AuthN/UserDir normalization.
+- Custom roles, subject grants, and group-role bindings are GitStore datastore state.
+- v1 has no nested groups or role inheritance.
+- OPA is embedded with `rego` and `storage/inmem`; no sidecar is used.
+- The GraphQL schema and raw query are not OPA input for field authorization.
+- `@authorize` is server-owned v1 SDL; executable `@catalogView` is deferred.
+- Public visibility derives from materialized publication eligibility owned by GH#314.
+- ProductVariant public reads remain fail closed until variant eligibility is materialized.
+- OPA remains opt-in until an explicit later rollout changes defaults.
+
+## 19. References
+
+- GitStore core architecture: `docs/implementation/020-pluggable_auth_architecture.md`
+- GitStore controller identities: `docs/implementation/021-controller_service_account_auth.md`
+- Live auth contracts: `gitstore-api/internal/auth/types.go`
+- Live GraphQL middleware: `gitstore-api/internal/middleware/security/graphql.go`
+- Live GraphQL server wiring: `gitstore-api/internal/app/server.go`
+- Product schema: `shared/schemas/product.graphqls`
+- ProductVariant schema: `shared/schemas/product_variant.graphqls`
+- Publication design dependency: [GitStore GH#314](https://github.com/gitstore-dev/GitStore/issues/314)
+- OPA Go embedding and prepared queries: [Integrating OPA](https://www.openpolicyagent.org/docs/integration)
+- OPA GraphQL built-ins and custom directives:
+  [GraphQL built-ins](https://www.openpolicyagent.org/docs/policy-reference/builtins/graphql)
+- gqlgen permission directives: [Schema Directives](https://gqlgen.com/reference/directives/)
+- gqlgen cross-cutting hooks: [Middlewares and Interceptors](https://gqlgen.com/reference/middlewares/)
+- ScyllaDB filtering behavior:
+  [CQL SELECT — Allowing filtering](https://docs.scylladb.com/manual/stable/cql/dml/select.html#allowing-filtering)

--- a/docs/implementation/032-phased-implementation.md
+++ b/docs/implementation/032-phased-implementation.md
@@ -1,4 +1,5 @@
 # GitStore Implementation Roadmap
+**Status**: ⚠️ In Progress
 
 ## Executive summary
 

--- a/docs/implementation/033-phase-1-control-plane-implementation-plan.md
+++ b/docs/implementation/033-phase-1-control-plane-implementation-plan.md
@@ -1,6 +1,6 @@
 # Phase 1 Control-Plane Implementation Plan
 
-**Status**: Partially implemented — Wave 1 auth/admission closed; Wave 1 control-plane contracts open; Wave 2 partially closed
+**Status**: ⚠️Partially implemented — Wave 1 auth/admission closed; Wave 1 control-plane contracts open; Wave 2 partially closed
 
 **Date**: 2026-06-26
 

--- a/docs/implementation/034-file-media-lifecycle-architecture.md
+++ b/docs/implementation/034-file-media-lifecycle-architecture.md
@@ -1,6 +1,6 @@
 # File and Media Resource Lifecycle: Architecture Decision Document
 
-**Status**: Research / Proposed (pre-ADR)
+**Status**: 🟡️ Proposed (not yet implemented)
 **Date**: 2026-08-09
 **Audience**: GitStore API, controller-manager, and catalog authors.
 **Feeds**: ADR-0008 (finalize), GH#79, GH#127, GH#192, GH#194, GH#195, GH#244, GH#283, GH#304, GH#316.
@@ -266,33 +266,67 @@ Category/Collection.
 
 ### 7a. Manifest-first creation + out-of-band upload (Phase 1, matches ADR-0008 today)
 
-```
-Author → git push files/hero.md (kind: File, source.uri: s3://.../hero.jpg not yet present)
-       → pre-receive: envelope/contentType/source.type/source.uri non-empty ✓
-       → post-receive admission: AdmissionAccepted=True, ownerReferences→Repository
-       → File controller enqueued
-       → controller GETs source.uri → 404 (object not uploaded yet)
-       → SourceResolved=False, reason=SourceNotFound (transient retry class)
-Author → uploads binary out-of-band to s3://.../hero.jpg (existing credentials)
-       → controller's next retry (backoff) or a watch-triggered re-check succeeds
-       → checksum verified → SourceResolved=True
-       → processing pipeline runs (image variants) → ProcessingComplete=True
-       → Ready=True
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Author
+    participant Git as Git service
+    participant Admission as Admission pipeline
+    participant FileController as File controller
+    participant StatusAPI as File status API
+    participant Storage as Object storage
+    participant Processor as Processing pipeline
+
+    Author->>Git: Push files/hero.md<br/>(kind: File, source URI not present yet)
+    Git->>Admission: Run pre-receive validation
+    Admission->>Admission: Validate envelope, content type,<br/>source type, and non-empty source URI
+    Admission-->>Git: Accepted
+    Git->>Admission: Run post-receive admission
+    Admission->>Admission: Set AdmissionAccepted=True<br/>and owner reference to Repository
+    Admission->>FileController: Enqueue File
+    FileController->>Storage: GET s3://.../hero.jpg
+    Storage-->>FileController: 404 Not Found
+    FileController->>StatusAPI: Write SourceResolved=False<br/>reason=SourceNotFound (transient)
+
+    Author->>Storage: Upload binary out of band<br/>using existing credentials
+    Note over FileController,Storage: Next backoff retry or watch-triggered recheck
+    FileController->>Storage: GET s3://.../hero.jpg
+    Storage-->>FileController: Binary payload
+    FileController->>FileController: Verify checksum<br/>Set SourceResolved=True
+    FileController->>Processor: Generate image variants
+    Processor-->>FileController: Processing complete
+    FileController->>StatusAPI: Write SourceResolved=True,<br/>ProcessingComplete=True, and Ready=True
 ```
 
 ### 7b. Signed-URL upload (Phase 2, `requestFileUpload`/`completeFileUpload`)
 
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Client
+    participant API as gitstore-api
+    participant Storage as Object storage
+    participant Git as Git service
+    participant Admission as Admission pipeline
+
+    Client->>API: requestFileUpload(name, namespace,<br/>contentType, sizeHint)
+    API->>API: Authorize caller and validate namespace
+    API->>Storage: Create presigned PUT or multipart upload<br/>for one object key, short TTL, one action
+    Storage-->>API: Upload target and optional upload ID
+    API-->>Client: uploadURL, uploadId?, expiresAt
+
+    Client->>Storage: PUT binary or upload multipart sequence
+    Storage-->>Client: Upload accepted
+    Client->>API: completeFileUpload(name, namespace, uploadId?)
+    API->>Storage: Verify object exists and read payload metadata
+    Storage-->>API: Object metadata and checksum input
+    API->>API: Compute or verify checksum server-side
+    API->>Git: Auto-commit files/{name}.md
+    Git->>Admission: Run File admission
+    Admission-->>API: Continue from SourceResolved lifecycle in 7a
+    API-->>Client: File upload completed
 ```
-Client → mutation requestFileUpload(name, namespace, contentType, sizeHint)
-       → API validates auth/namespace, generates presigned PUT (or multipart
-         Create) scoped to ONE object key, short TTL, single action
-       ← {uploadURL, uploadId?, expiresAt}
-Client → PUT binary directly to object storage (or multipart PUT sequence)
-Client → mutation completeFileUpload(name, namespace, uploadId?)
-       → API verifies object exists + computes/verifies checksum server-side
-       → API commits files/<name>.md to git (auto-commit, per ADR-0008 Phase 2 note)
-       → admission proceeds as in 7a from SourceResolved onward
-```
+
 Multipart switch-over at ~100MB (AWS threshold, verified) — below that,
 single presigned PUT; above, presigned multipart (Create/UploadPart/Complete).
 `tus` is a viable alternative for **self-hosted, S3-independent** local dev

--- a/docs/implementation/035-collection-membership-materialization.md
+++ b/docs/implementation/035-collection-membership-materialization.md
@@ -96,7 +96,7 @@ See §7 for the full side-by-side comparison; the summary judgment is that **B a
 | Query count / read amplification | Good — 1 query/page | Good — 1 query/page (once populated) | Fair — N+ queries, still materializes full intersection for multi-term/negative selectors | Fair — 1+ queries/round, multiple rounds under low authz density |
 | Partition/hotspot risk | Poor — unbounded partition per broad collection, no mitigation | Poor — same, `collection_uid` partition | Poor — value-partitioned, popular label values hot | Poor — same `collection_uid` partition, explicitly flagged unmitigated |
 | Pagination correctness | Good — standard keyset, no offset (see §11 for a bulk-rewrite caveat) | Good — keyset, but membership-not-current | Fair — intersection breaks true cursor semantics for multi-term | Good for membership; short-page risk under authz filtering |
-| Cursor stability | Good — reuses `EncodeKeysetCursor`/`DecodeKeysetCursor` unchanged | Good — same | Good | Good |
+| Cursor stability | Good — versioned cursor binds kind, scope, namespace, collection, and keyset position | Good — same | Fair — intersection still needs a bound cursor contract | Fair — same plus bounded over-read state |
 | Write amplification | Fair — bounded by collections/products per namespace | Fair — similar, but async so latency hidden from writer | Poor — 2K writes per product, diff-on-write required | Poor — same as A plus authz has no write cost but membership same |
 | Staleness behavior | Good — synchronous, single-request window (but see §13 for a backfill-window caveat) | Poor — queue/backoff-dependent, unbounded in principle | Fair — synchronous but no controller to host diffing, so inline too | Poor — controller-reconcile-dependent |
 | Rebuild/backfill complexity | Fair — derivable, needs one-shot job, no drift detection built in | Poor — no rebuild precedent, no drift detection | Fair — full scan re-derivation, same gap | Fair — `resource_version` per row aids diffing, but still needs new job |
@@ -113,13 +113,18 @@ See §7 for the full side-by-side comparison; the summary judgment is that **B a
 
 B and D are rejected outright: both require standing up controllers this codebase deliberately does not have. Spec 042 is direct precedent — it added a Product *cache* but explicitly declined to register a Product *reconciler* (`cmd/controller/main.go:191-196`), and a Collection controller has even less precedent (no `internal/collection` package exists at all, no many-to-many derived index has ever been built here). C is rejected because it does not eliminate full-namespace scans for negative-only selectors, which the schema explicitly permits, and its write cost (2K writes per product) with no controller to host the diff is strictly worse than A under the same "no controller" constraint.
 
-A wins because it needs zero new controller-manager work, reuses every existing convention (`(CreationTimestamp DESC, UID DESC)` clustering, `EncodeKeysetCursor`, `PageResult[T]`), and turns an O(namespace) scan-per-request into O(1) partition reads at the one-time cost of write-path hooks in code that already computes derived fields (spec 034's admission functions).
+A wins because it needs zero new controller-manager work, reuses the existing clustering and `PageResult[T]` conventions, and turns an O(namespace) scan-per-request into O(1) partition reads at the one-time cost of write-path hooks in code that already computes derived fields (spec 034's admission functions).
 
-This recommendation is adopted **with amendments** relative to the original Candidate A writeup, required by the three adversarial verification passes:
+This recommendation is adopted **with amendments** relative to the original Candidate A writeup, required by the adversarial verification and Codex review:
 
 - **§11** amends the bulk `ReplaceCollectionMembership` contract to fix a real cursor-instability bug found in verification.
 - **§12** amends `memberCount` and the migration-fallback path to close a real information-leak the auth-leak verifier constructed concretely.
 - **§13** amends the backfill/bootstrap story to name and bound (rather than silently absorb) the under-count window the staleness verifier found.
+- **§12** makes the validated, field-local OPA `DecisionScope` the source of visibility rather than deriving visibility from the principal.
+- **§9/§10/§16** define a complete Product read projection in membership rows, avoiding an N+1 hydration path.
+- **§13** replaces the mutable Collection status condition as the authoritative backfill gate with a durable projection-state record.
+- **§16** carries immutable Product creation timestamps through retry-safe removal operations.
+- **§11/§16** replace the generic cursor with a versioned cursor bound to resource kind, visibility, namespace, and collection.
 
 None of these amendments changes the overall recommendation; they close gaps in how it must be built.
 
@@ -132,7 +137,12 @@ CREATE TABLE IF NOT EXISTS collection_membership_by_collection (
     product_created_at   timestamp,   -- the PRODUCT's own immutable CreationTimestamp, NOT a rewrite/index timestamp
     product_uid           uuid,
     product_name          text,
-    resource_version       text,       -- product's resource_version at last evaluation, for staleness detection
+    repository_id         uuid,
+    product_metadata      text,       -- serialized Product fields required by the GraphQL node
+    product_spec          text,
+    product_status        text,
+    resource_version      text,       -- product's resource_version at last evaluation, for staleness detection
+    projection_version    text,
     PRIMARY KEY ((namespace, collection_uid), product_created_at, product_uid)
 ) WITH CLUSTERING ORDER BY (product_created_at DESC, product_uid DESC);
 
@@ -140,7 +150,19 @@ CREATE TABLE IF NOT EXISTS collection_membership_by_product (
     namespace       text,
     product_uid     uuid,
     collection_uid   uuid,
+    product_created_at timestamp,     -- retained so removal is possible after Product deletion
     PRIMARY KEY ((namespace, product_uid), collection_uid)
+);
+
+CREATE TABLE IF NOT EXISTS collection_membership_state (
+    namespace             text,
+    collection_uid        uuid,
+    collection_generation bigint,
+    state                 text,       -- UNINITIALIZED, BACKFILLING, READY, FAILED
+    projection_version    text,
+    completed_at           timestamp,
+    last_error             text,
+    PRIMARY KEY ((namespace), collection_uid)
 );
 ```
 
@@ -149,13 +171,17 @@ Design notes:
 - Partition key includes `namespace` on both tables (unlike the original candidate writeups' UID-only reverse-index shape), giving the same structural namespace isolation every other table in `001_initial_schema.cql` has, and giving `HasCollectionMembership` and any future public-scope variant a namespace-scoped partition to query.
 - `product_created_at` **must** be the product's own `CreationTimestamp`, never a write-time/rewrite timestamp — this is the fix for the pagination bug in §11. It is denormalized from the product row at every write (initial insert, incremental upsert, and bulk rewrite alike) rather than being generated fresh.
 - `resource_version` on the membership row is the product's `resource_version` at the time this membership row was last written — the basis for backfill-completeness / drift detection, not a version of the membership row itself.
-- A visibility-scoped twin table, `collection_membership_public_by_collection` (same shape, populated only for publicly visible products), is a **named, reserved-but-not-yet-built** part of this schema — see §12 for why it must exist before 022 ships, not after.
+- A visibility-scoped twin table, `collection_membership_public_by_collection`, has the same complete Product projection shape and is populated only for publicly visible products. Its reverse table is `collection_membership_public_by_product`. These tables must exist before 022 enforcement ships.
+- The membership state table is authoritative for read readiness. `Collection.status.conditions` may mirror the state for observability, but Collection admission must not be able to erase the durable gate.
+- The embedded Product fields are a rebuildable read projection, not a second Product authority. Product admission, update, and publication transitions must update them.
 
 ## 10. Example CQL queries
 
 Forward page (`first`/`after`):
 ```cql
-SELECT product_uid, product_name, product_created_at, resource_version
+SELECT product_uid, product_name, product_created_at, repository_id,
+       product_metadata, product_spec, product_status,
+       resource_version, projection_version
 FROM collection_membership_by_collection
 WHERE namespace = ? AND collection_uid = ?
   AND (product_created_at, product_uid) < (?, ?)
@@ -165,7 +191,9 @@ LIMIT 21;  -- first + 1, to compute hasNextPage
 
 Backward page (`last`/`before`), reversing the inequality and re-reversing the result in application code, per `buildPaginatedSelect`'s existing convention (`scylla/pagination.go:92-104`):
 ```cql
-SELECT product_uid, product_name, product_created_at, resource_version
+SELECT product_uid, product_name, product_created_at, repository_id,
+       product_metadata, product_spec, product_status,
+       resource_version, projection_version
 FROM collection_membership_by_collection
 WHERE namespace = ? AND collection_uid = ?
   AND (product_created_at, product_uid) > (?, ?)
@@ -189,11 +217,14 @@ WHERE namespace = ? AND product_uid = ?;
 Incremental write (single product, single collection, on label-driven match-state flip):
 ```cql
 INSERT INTO collection_membership_by_collection
-  (namespace, collection_uid, product_created_at, product_uid, product_name, resource_version)
-VALUES (?, ?, ?, ?, ?, ?);
+  (namespace, collection_uid, product_created_at, product_uid, product_name,
+   repository_id, product_metadata, product_spec, product_status,
+   resource_version, projection_version)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
-INSERT INTO collection_membership_by_product (namespace, product_uid, collection_uid)
-VALUES (?, ?, ?);
+INSERT INTO collection_membership_by_product
+  (namespace, product_uid, collection_uid, product_created_at)
+VALUES (?, ?, ?, ?);
 ```
 (and the corresponding `DELETE ... WHERE namespace = ? AND collection_uid = ? AND product_created_at = ? AND product_uid = ?` / reverse-table delete for products that no longer match.)
 
@@ -201,7 +232,9 @@ Bulk rewrite (Collection selector change) is deliberately **not** expressed as a
 
 ## 11. Pagination and cursor semantics
 
-Cursor format, ordering, and windowing are unchanged from every other Relay connection in this codebase: `EncodeKeysetCursor(product_created_at, product_uid)` / `DecodeKeysetCursor` (`keyset_cursor.go:23-51`), `(CreationTimestamp DESC, UID DESC)` ordering, `limit+1` read to compute `hasNextPage`, fed into the existing generic `PageResult[T]`-based connection builder (the one `Category`/`Namespace` already use) rather than `BuildProductConnectionFromSlice`, which is retired for this path.
+Ordering and windowing retain the repository convention `(CreationTimestamp DESC, UID DESC)`, with a `limit+1` read to compute `hasNextPage`, fed into the existing generic `PageResult[T]`-based connection builder. The cursor itself is a versioned, scope-bound payload rather than the current generic `EncodeKeysetCursor` format.
+
+The collection-product cursor payload contains `version`, resource kind (`Product`), visibility (`PUBLIC` or `MANAGEMENT`), namespace, collection UID, product creation timestamp, and product UID. The resolver validates every bound value against the current field-local `DecisionScope` and request before issuing the CQL query. Cursors from another scope, collection, namespace, or resource kind are rejected; legacy unbound cursors are rejected once scoped reads are enabled. Base64 is only transport encoding; the implementation must use the application cursor-signing mechanism, or explicitly document authenticated opaque-cursor validation, so callers cannot forge scope fields.
 
 ### 11.1 The bulk-rewrite cursor-instability bug (confirmed by adversarial review) and its fix
 
@@ -228,7 +261,13 @@ This closes the bug at the contract level; §16 reflects the corrected method si
 
 ### 12.1 Where authorization is enforced (query-time projection selection, never post-hoc)
 
-`ListCollectionMembers(ctx, namespace, collectionUID, visibility, page)` resolves `visibility` from `auth.PrincipalFromContext(ctx)` (`auth/context.go:18-21`) and selects between `collection_membership_by_collection` (management scope) and `collection_membership_public_by_collection` (public scope) **before** building the paginated CQL query — exactly 022 §12.1-12.2's mandate, and exactly what rules out post-fetch filtering or the over-read/fill approach evaluated (and rejected) as Candidate D.
+`ListCollectionMembers(ctx, scope, page)` receives the field-local, middleware-validated `auth.DecisionScope`; it never derives visibility from `auth.PrincipalFromContext`. The API validates that the scope matches Product, the namespace, collection UID, and current GraphQL field path, then passes only the validated `PUBLIC` or `MANAGEMENT` visibility to the datastore. The datastore selects between `collection_membership_by_collection` and `collection_membership_public_by_collection` **before** building the paginated CQL query. Missing, duplicate, stale, or mismatched scopes fail closed with `FORBIDDEN`. This is exactly 022 §12.1-12.2's mandate and rules out post-fetch filtering or the over-read/fill approach evaluated as Candidate D.
+
+### 12.1.1 Complete Product page projection
+
+Membership rows contain the complete Product read projection needed by `BuildProductConnection`, rather than only a Product UID. A page therefore requires one bounded partition query and no per-edge Product lookup. The management projection contains the fields allowed for management visibility; the public projection contains only the fields allowed for public visibility.
+
+Product admission, Product updates, Product deletion, and future publication-state transitions update the affected projection rows. Each row carries the Product `resource_version` and a membership `projection_version`. A missing or stale row is not removed by a read-time filter, because that would reintroduce short pages and count mismatches. Instead, the affected collection remains non-`READY` until the projection is rebuilt, or a repair/backfill operation restores the row.
 
 ### 12.2 Finding 1 (confirmed): unscoped `memberCount` is a label-predicate oracle — closed by design amendment
 
@@ -248,7 +287,7 @@ This is **not fully resolved by this design** — it is listed as an explicit un
 
 ### 12.5 Axes checked and found sound
 
-- **Cursor forgery/replay**: `DecodeKeysetCursor` validates only the `"keyset"` tag, timestamp parseability, and id — it does not check row existence, so a forged cursor for a real-but-hidden product's `(timestamp, uid)` is indistinguishable from one for a non-existent tuple; no observable leak beyond Findings 1/3 above. (The cursor format not being visibility-bound, per 022 §12.2's stricter requirement, is a spec-compliance gap worth closing defensively but was not turned into an independent exploit.)
+- **Cursor forgery/replay**: the collection-product cursor is versioned and binds resource kind, visibility, namespace, collection UID, timestamp, and product UID. The resolver rejects malformed, legacy, cross-scope, cross-collection, and cross-kind cursors before querying. Base64 is not treated as authentication; the cursor uses the application's signing mechanism or an equivalent authenticated opaque-cursor mechanism.
 - **`hasNextPage`/short pages on the primary connection**: safe, provided the twin scope-specific tables are implemented and kept in sync as required by §16/§12.4 — pagination runs entirely inside one consistent, correctly-scoped table with no post-hoc filtering.
 - **Error messages**: `ErrNotFound` is reused undifferentiated for missing collection/product, matching 022 §13's mandate; no new differentiation introduced.
 - **Ordering**: uniform `(CreationTimestamp DESC, UID DESC)` regardless of which table is queried; no additional leakage beyond the inherent, unavoidable property of any filtered keyset list.
@@ -257,24 +296,24 @@ This is **not fully resolved by this design** — it is listed as an explicit un
 
 ### 13.1 Authoritative vs. derived data
 
-`Product.Labels` and `Collection.Spec.Selector` remain authoritative — unchanged, still the source data. `collection_membership_by_collection`/`collection_membership_by_product` (and their future public-scoped twins) are a fully rebuildable derived index: any drift can be repaired by re-running `catalog.MatchesLabels` (`catalog/selector.go:8-46`) against the authoritative tables. `Collection.status.resolved.memberCount`'s doc comment — "a cached hint; collection.products is authoritative" — is preserved, except "authoritative" now means "authoritative derived index," not "recomputed live every request," and (per §12.2) is scope-specific rather than a single value.
+`Product.Labels` and `Collection.Spec.Selector` remain authoritative — unchanged, still the source data. `collection_membership_by_collection`/`collection_membership_by_product` and their public-scoped counterparts are fully rebuildable derived indexes: any drift can be repaired by re-running `catalog.MatchesLabels` (`catalog/selector.go:8-46`) against the authoritative tables. `Collection.status.resolved.memberCount`'s doc comment — "a cached hint; collection.products is authoritative" — is preserved, except "authoritative" now means "authoritative derived index," not "recomputed live every request," and (per §12.2) is scope-specific rather than a single value.
 
 ### 13.2 Steady-state consistency
 
 Writes are synchronous, inside the same request as the triggering `CreateProduct`/`UpdateProduct`/`DeleteProduct`/`CreateCollection`/`UpdateCollection` call. No cross-partition transaction exists between the forward and reverse tables (ScyllaDB gives no such primitive), so a crash mid-write can desync them; this is an accepted, bounded risk (repaired by the same rebuild mechanism as backfill, §13.4), not eliminated.
 
-### 13.3 The backfill/bootstrap gap (confirmed by adversarial review) — named and bounded, not hand-waved
+### 13.3 The backfill/bootstrap gap — durable readiness state
 
-Adversarial review traced a concrete, previously-unnamed failure mode. On the day this design ships, every Collection/Product row that existed **before** deploy has zero membership rows, because admission hooks only fire on new writes. `HasCollectionMembership(collectionUID)` returning `false` correctly triggers a fallback to the live `ListProductsByLabelSelector` scan — this holds and is correct on literal deploy day, before any backfill job runs.
+On the day this design ships, every Collection/Product row that existed **before** deploy has zero membership rows because admission hooks only fire on new writes. The resolver therefore starts in the live-scan fallback until the durable membership state reaches `READY` for the current Collection generation.
 
-The gap is in the backfill job's transition window, not its absence. Since ScyllaDB gives no cross-partition, arbitrary-size atomic transaction (confirmed: no materialized view, no aggregate column anywhere in `001_initial_schema.cql`), a backfill job populating a collection with, say, 500 members necessarily writes those rows incrementally. Mid-backfill, for a collection currently at 1-of-500 written rows: `HasCollectionMembership(X)` returns **true** (a `LIMIT 1` existence check needs only one row), so the resolver switches off the live-scan fallback and reads the partially-populated table directly — returning a fully-formed, error-free 1-edge connection with `hasNextPage: false`. This is a **silent under-count, structurally indistinguishable from a genuine 1-member collection**, and it reproduces — inside Candidate A's own migration mechanism, narrowed from "permanent" to "a race window" — exactly the failure mode this design's own decision matrix used to reject Candidate B ("empty-vs-unmaterialized ambiguity"). `HasCollectionMembership`/`HasRepositories`/`HasCatalogResources`'s `LIMIT 1` semantics (designed for spec 041's precondition-check use case) cannot express "fully populated" vs. "partially populated" — repurposing an existence check as a migration-completeness signal is a category error, not a minor gap.
+Since ScyllaDB gives no cross-partition, arbitrary-size atomic transaction, a backfill populating a large collection necessarily writes rows incrementally. A partial projection must never be served: `HasCollectionMembership` remains a `LIMIT 1` existence check only, while `collection_membership_state.state` is the sole readiness signal. This closes the silent under-count window without treating row existence as proof of completeness.
 
-**Design amendments, adopted, to bound this window instead of leaving it open-ended:**
+**Design amendments, adopted, to make readiness durable and generation-safe:**
 
-1. **A per-collection backfill-completion marker is required**, not just a job that "populates all existing collections." Concretely: reuse the existing `CollectionStatus.observedGeneration`/`conditions` fields already present on the schema (`shared/schemas/collection.graphqls:215-235`, same shape as `CategoryTaxonomyStatus`) to record a condition such as `MembershipBackfilled: true` written atomically as the *last* step of that collection's backfill (after all rows are written), analogous to how `categorytaxonomy.Reconciler` only reports `Resolved` once its computation is complete. `HasCollectionMembership` continues to answer "is there at least one row" for the cheap common case, but the resolver's decision to trust the materialized table for a *given* collection is gated on this condition being present, not merely on row existence.
-2. Until that condition is set for a collection, `ListCollectionMembers` **must** continue to use the live-scan fallback for that specific collection, even if `HasCollectionMembership` would return `true` — closing the exact race window traced above.
-3. The backfill job itself (new, does not exist today, and this document does not claim otherwise) is scoped as: for each Collection lacking `MembershipBackfilled`, diff-write its full membership set (using the same diff discipline as §11's bulk-rewrite fix, not a blind delete+reinsert), then set the condition. This gives an automatable, testable completion signal instead of relying on operator judgment to know when the fallback branch can be safely deleted.
-4. `Collection.status.resolved.memberCount` during the backfill window reports whatever the (possibly partial) materialized table currently holds **only if** the fallback-gating condition from (2) is respected — i.e., during backfill, `memberCount` is sourced from the live scan just like `products` is, so the two never visibly disagree mid-migration. This directly addresses the adversarial finding that the original design's `memberCount` would "corroborate rather than flag the wrong answer" during the race.
+1. The authoritative gate is the durable `collection_membership_state` record, not `HasCollectionMembership` and not mutable Collection status. It records Collection generation, projection version, `UNINITIALIZED`/`BACKFILLING`/`READY`/`FAILED` state, completion time, and last error.
+2. The backfill job performs a diff-based rewrite using immutable Product timestamps and complete Product projections, then writes `READY` only after forward, reverse, and Product projection rows for the current Collection generation are complete.
+3. Until the current generation is `READY`, both products and counts use the existing live selector scan. Partial rows are never exposed as a complete connection. A selector update transitions the state to `BACKFILLING`; an interrupted or failed rewrite leaves the fallback active.
+4. Collection status may mirror the state for observability, but normal Collection admission must preserve or invalidate the durable state rather than erase it. 022 enforcement, visibility-specific projections, publication-transition triggers, scoped cursors, and removal of the fallback are one rollout gate.
 
 ### 13.4 Rebuild and drift detection going forward
 
@@ -294,62 +333,90 @@ Both tables mirror straightforwardly onto `go-memdb`: `map[uuid.UUID][]membershi
 
 New `Datastore` interface methods (`gitstore-api/internal/datastore/datastore.go`), alongside existing Product/Collection methods:
 
-- `ListCollectionMembers(ctx context.Context, namespace string, collectionUID uuid.UUID, visibility Visibility, page PageParams) (PageResult[*Product], error)` — primary read; replaces `ListProductsByLabelSelector` as the `Collection.Products` data source. `visibility` selects between the management and public-scoped tables (§12.1); required from day one, not deferred.
-- `CollectionMemberCount(ctx context.Context, namespace string, collectionUID uuid.UUID, visibility Visibility) (int, error)` — **new relative to the original recommendation**, added directly in response to §12.2's Finding 1: a scope-aware count, so `memberCount` can never be sourced from an unscoped table.
-- `ReplaceCollectionMembership(ctx context.Context, namespace string, collectionUID uuid.UUID, products []ProductRef) error` — Collection-selector-change trigger. **Signature changed from the original `productUIDs []uuid.UUID`** to carry each product's real `CreationTimestamp` (`ProductRef{UID, CreationTimestamp}`) and is specified as a diff against current partition contents, not a blind delete+reinsert — the §11.1 fix.
-- `UpsertCollectionMembership` / `RemoveCollectionMembership(ctx, namespace, collectionUID, productUID uuid.UUID) error` — incremental, Product-label-change trigger, diffed against `collection_membership_by_product`.
-- `HasCollectionMembership(ctx context.Context, namespace string, collectionUID uuid.UUID) (bool, error)` — cheap existence check, same "LIMIT 1, not a count" convention as `HasRepositories`/`HasCatalogResources`. Per §13.3, this is **not** sufficient on its own to gate the fallback-to-live-scan decision; it must be combined with the `MembershipBackfilled` condition check.
+- `ListCollectionMembers(ctx context.Context, scope CollectionProductReadScope, page PageParams) (PageResult[*Product], error)` — primary read; replaces `ListProductsByLabelSelector` as the `Collection.Products` data source. The scope contains the validated field-local `auth.DecisionScope`, namespace, and collection UID; only its validated visibility selects the physical projection (§12.1).
+- `CollectionMemberCount(ctx context.Context, scope CollectionProductReadScope) (int, error)` — **new relative to the original recommendation**, added directly in response to §12.2's Finding 1: a scope-aware count, so `memberCount` can never be sourced from an unscoped table.
+- `ReplaceCollectionMembership(ctx context.Context, namespace string, collectionUID uuid.UUID, products []ProductRef) error` — Collection-selector-change trigger. The diff carries each Product's immutable `CreationTimestamp`, and updates the complete Product projection without rewriting unaffected clustering keys.
+- `UpsertCollectionMembership` / `RemoveCollectionMembership(ctx context.Context, namespace string, collectionUID uuid.UUID, product ProductRef) error` — incremental Product-label/publication trigger. The same `ProductRef` is used for forward and reverse cleanup, including retries after canonical Product deletion.
+- `GetCollectionMembershipState(ctx context.Context, namespace string, collectionUID uuid.UUID) (CollectionMembershipState, error)` / `SetCollectionMembershipState(...) error` — durable generation-aware readiness state. Row existence is not a readiness signal.
+- `HasCollectionMembership(ctx context.Context, namespace string, collectionUID uuid.UUID) (bool, error)` — cheap existence check only; it must not gate the fallback.
 
-**Types:** reuse existing `PageParams`/`PageResult[T]`, `EncodeKeysetCursor`/`DecodeKeysetCursor` unchanged — no new cursor format.
+**Types:** reuse existing `PageParams`/`PageResult[T]`; add `ProductRef`, `CollectionProductReadScope`, `CollectionMembershipState`, and a versioned scope-bound collection-product cursor. The generic cursor remains valid for unrelated connections, but is not used for this scoped path.
+
+```go
+type ProductRef struct {
+    UID               uuid.UUID
+    CreationTimestamp time.Time
+}
+
+type CollectionProductReadScope struct {
+    DecisionScope auth.DecisionScope
+    Namespace     string
+    CollectionUID uuid.UUID
+}
+
+type CollectionMembershipState struct {
+    CollectionGeneration int64
+    ProjectionVersion    string
+    State                string // UNINITIALIZED, BACKFILLING, READY, FAILED
+    CompletedAt          *time.Time
+    LastError            string
+}
+```
 
 **Ordering guarantee:** `(CreationTimestamp DESC, UID DESC)`, enforced by both backends, fixing memdb's currently-unenforced sort (§2.1, §14).
 
-**Error behavior:** `ErrNotFound` for missing collection/product, `ErrConflict` for optimistic-concurrency membership writes (mirroring `ApplyCategoryTaxonomyStatusPatch`'s `ResourceVersion` check pattern, `datastore.go:83-115`).
+**Error behavior:** `ErrNotFound` for missing collection/product, `ErrConflict` for optimistic-concurrency membership writes, and `FORBIDDEN` for missing or mismatched field-local authorization scope. Cursor validation errors are returned before any datastore query.
 
 **Resolver change:** `collectionResolver.Products` (`collection.resolvers.go:20-55`) drops the `spec.Selector`/`ListProductsByLabelSelector` call and calls `r.service.ListCollectionMembers`, feeding the returned `PageResult[*Product]` into the existing generic connection builder Category/Namespace already use, retiring `BuildProductConnectionFromSlice` for this path. `Collection.status.resolved.memberCount` resolves via `CollectionMemberCount`, scope-aware and backfill-window-aware per §13.3(4).
 
 ## 17. Migration and rollout plan
 
 1. Ship the two Scylla tables (`collection_membership_by_collection`, `collection_membership_by_product`) plus the memdb equivalents, and the admission-path write hooks (incremental first, since it's the lower-risk path — bulk rewrite ships with the §11.1 diff logic from the start, never as a naive delete+reinsert).
-2. Ship `ListCollectionMembers`/`CollectionMemberCount` behind the `HasCollectionMembership` + `MembershipBackfilled`-condition gate described in §13.3; until a given collection's condition is set, both continue to use today's live scan, so behavior is unchanged for every not-yet-backfilled collection.
-3. Build and run the backfill job (diff-based per-collection rewrite, condition set only on completion, per §13.3(3)) as a one-shot operational task; monitor `MembershipBackfilled` coverage across all namespaces before proceeding.
-4. Once all collections report `MembershipBackfilled`, delete the fallback branch from the resolver — do not keep it as a permanent dual-source-of-truth.
-5. **Do not enable 022 enforcement for this path** (i.e., do not wire the `visibility` parameter to a real authz decision, and do not populate the public-scoped twin tables) until both (a) 022 itself ships, and (b) the visibility-transition trigger required by §12.4 is implemented — these are sequenced, not independent, per §12.3.
+2. Ship the durable membership-state table, complete Product projections, versioned scope-bound cursors, and `ListCollectionMembers`/`CollectionMemberCount` behind the generation-aware `READY` gate described in §13.3. Until a Collection generation is `READY`, both products and counts continue to use today's live scan.
+3. Build and run the backfill job (diff-based per-collection rewrite, complete projection hydration, state set to `READY` only on completion); monitor state coverage and failures across all namespaces.
+4. Ensure Collection selector updates invalidate readiness and that Product label, deletion, and publication transitions update both the forward and reverse projections with retry-safe `ProductRef` values.
+5. **Do not enable 022 enforcement for this path** until scope-aware reads consume validated `DecisionScope`, visibility-specific projections are complete, publication-transition triggers are implemented, scoped cursors are deployed, and durable readiness is observable. Only then may the fallback branch be removed.
 
 ## 18. Test strategy
 
 - **Unit**: `catalog.MatchesLabels` is already covered (`selector_test.go:16-107`); extend coverage to the diff functions (label-change diff, selector-change diff) with property-style tests asserting that unaffected members' `CreationTimestamp` is never rewritten across a bulk `ReplaceCollectionMembership` call (direct regression test for §11.1).
 - **Pagination correctness**: a test that pages a collection, performs a membership-preserving Collection selector edit mid-pagination (adding a redundant matchExpression that changes nothing), and asserts the next page still returns all originally-untouched members — this is the exact regression the adversarial pagination-correctness finding demonstrated as broken under the original signature.
 - **Leak regression**: a test asserting `CollectionMemberCount` under PUBLIC scope never exceeds the count of edges a PUBLIC-scoped `products` query would return for the same collection and selector, across `matchLabels`/`In`/`NotIn`/`Exists`/`DoesNotExist` selector shapes — direct regression for §12.2's Finding 1.
-- **Backfill-window regression**: a test that starts a fake partial backfill (writes 1-of-N rows, does not set `MembershipBackfilled`), and asserts `ListCollectionMembers`/`CollectionMemberCount` still return the live-scan result, not the partial materialized result — direct regression for §13.3.
+- **Backfill-window regression**: a test that starts a fake partial backfill (writes 1-of-N rows, leaves state `BACKFILLING`), and asserts `ListCollectionMembers`/`CollectionMemberCount` still return the live-scan result, not the partial materialized result — direct regression for §13.3.
 - **Dual-backend parity**: run the full `Collection.products` connection test suite against both memdb and Scylla backends, asserting identical ordering, cursor behavior, and count semantics — extending the existing pattern implied by the dual-implementation maintenance burden noted throughout the investigation.
 - **Cross-table consistency**: a test/tool that walks `collection_membership_by_collection` and `collection_membership_by_product` for a namespace and asserts they agree (every forward row has a matching reverse row and vice versa) — a minimal drift detector, given none exists elsewhere in the repo to reuse (§13.4).
+- **Decision scope**: a test where OPA grants or denies namespace visibility differently from identity-derived assumptions, plus missing, duplicate, stale, wrong-kind, wrong-namespace, and wrong-field-path scopes; all fail closed.
+- **Projection hydration**: a page returns complete Product nodes from one bounded membership query with no per-edge lookup; Product resource-version/projection-version changes are reflected after an update and stale rows trigger rebuild rather than read-time filtering.
+- **Durable readiness**: Collection admission cannot erase the membership state; selector updates invalidate the generation; `BACKFILLING` and `FAILED` use the live fallback; only `READY` serves materialized rows.
+- **Retry-safe removal**: Product deletion after the canonical Product row is gone still removes forward and reverse rows using the persisted creation timestamp and is idempotent.
+- **Scoped cursors**: reject legacy, malformed, cross-visibility, cross-collection, cross-namespace, and cross-kind cursors, while accepting valid forward and backward cursors for the same scope.
 
 ## 19. Risks and unresolved questions
 
 1. **Wide-partition/hotspot risk is unmitigated.** A single collection with a very broad selector (e.g., `Exists` on a common label) accumulates an unbounded number of clustering rows in one `(namespace, collection_uid)` partition. No sharding/bucketing scheme is designed here; mitigating this would require a synthetic bucket suffix on the partition key, which complicates cursor encoding and is deferred as a follow-up if any collection is observed approaching Scylla's practical per-partition row-count guidance.
 2. **Cross-table atomicity is not guaranteed.** `collection_membership_by_collection` and `collection_membership_by_product` are updated in the same logical operation but not atomically (no Scylla multi-partition transaction); a crash mid-write can desync them, recoverable only via the (not-yet-built) drift-detection/repair job in §13.4.
 3. **Visibility-transition trigger is a named gap, not a closed one (§12.4).** This document specifies that a Product's visibility/publish-state change must become a third membership-write trigger before 022 enforcement is turned on, but the concrete field and mechanics depend on 022's own not-yet-finalized design. Shipping this design's write-time hooks without that third trigger, then later enabling 022 without adding it, will reproduce Finding 3's leak exactly as described.
-4. **The backfill job and its completion signal do not exist yet.** §13.3 specifies the shape they must take (diff-based rewrite, `MembershipBackfilled` condition gating) but this document does not claim they are built; rollout (§17) is explicitly sequenced to prevent the ambiguity window from being silently absorbed.
-5. **Cursor format is not visibility-bound**, contrary to 022 §12.2's stricter requirement that a cursor encode enough scope information to prevent replay-across-scope probing. This was checked by adversarial review and not turned into an independent exploit given the other mitigations in §12, but it remains a spec-compliance gap relative to 022's letter, not just its spirit, and should be revisited when 022's cursor requirements are finalized.
-6. **`resource_version`-based drift detection (§13.4) is specified but not implemented.** No automated job exists today to detect or repair post-backfill drift; this is accepted as follow-up work, not a blocking gap for initial rollout, but should not be indefinitely deferred given the cross-table atomicity risk in item 2.
-7. **Scope of `CollectionMemberCount` beyond PUBLIC/MANAGEMENT.** If 022 eventually introduces finer-grained scopes than a binary PUBLIC/MANAGEMENT split, the two-table (management + public) design in §9/§12.1 would need to generalize; this document does not attempt to anticipate that and treats it as an explicit non-goal for this iteration.
+4. **The backfill job and its completion signal do not exist yet.** §13.3 specifies a durable generation-aware state record, diff-based rewrite, complete Product hydration, and `READY` only after full completion; rollout (§17) must prevent partial projections from being served.
+5. **Product projection maintenance adds write amplification.** Complete Product fields are duplicated in membership projections to avoid N+1 hydration. Product updates and publication transitions must update every affected projection row; projection versions and repair/backfill tooling are required to recover from partial writes.
+6. **Scoped cursor signing and DecisionScope plumbing do not exist yet.** The implementation must add them before 022 enforcement; the generic cursor and principal-derived visibility path are not valid substitutes.
+7. **`resource_version`-based drift detection (§13.4) is specified but not implemented.** No automated job exists today to detect or repair post-backfill drift; this is accepted as follow-up work, not a blocking gap for initial rollout, but should not be indefinitely deferred given the cross-table atomicity risk in item 2.
+8. **Scope of `CollectionMemberCount` beyond PUBLIC/MANAGEMENT.** If 022 eventually introduces finer-grained scopes than a binary PUBLIC/MANAGEMENT split, the two-table (management + public) design in §9/§12.1 would need to generalize; this document does not attempt to anticipate that and treats it as an explicit non-goal for this iteration.
 
 ## 20. Phased implementation plan
 
 **Phase 1 — Datastore foundation (no behavior change).**
-Add the two Scylla tables and memdb equivalents; add `Datastore` interface methods (`ListCollectionMembers`, `CollectionMemberCount`, `ReplaceCollectionMembership` with the §11.1 diff contract, `UpsertCollectionMembership`, `RemoveCollectionMembership`, `HasCollectionMembership`); implement admission-path write hooks for both backends. `Collection.products` and `status.resolved.memberCount` continue to use today's live-scan path — nothing reads the new tables yet.
+Add the Scylla tables and memdb equivalents; add `Datastore` interface methods (`ListCollectionMembers`, `CollectionMemberCount`, `ReplaceCollectionMembership` with the §11.1 diff contract, `UpsertCollectionMembership`, `RemoveCollectionMembership`, `GetCollectionMembershipState`, `SetCollectionMembershipState`, and `HasCollectionMembership`); implement admission-path write hooks for both backends. `Collection.products` and `status.resolved.memberCount` continue to use today's live-scan path — nothing reads the new tables yet.
 
-**Phase 2 — Read path cutover, gated by backfill condition.**
-Change `collectionResolver.Products` to call `ListCollectionMembers` and `CollectionMemberCount`, both gated per collection on the `MembershipBackfilled` condition (§13.3). Add the fallback-branch test (§18) proving live-scan behavior is unchanged for any not-yet-gated collection. No visibility/authz parameter is wired to a real decision yet — `visibility` defaults to "management" (today's ungated behavior) for every caller, matching current production behavior exactly.
+**Phase 2 — Read path cutover, gated by durable readiness.**
+Change `collectionResolver.Products` to consume the middleware-validated field-local `DecisionScope`, validate the versioned scope-bound cursor, and call `ListCollectionMembers` and `CollectionMemberCount`. Gate both reads on the generation-aware `collection_membership_state`; non-`READY` collections use the existing live scan. Add the fallback, scope-mismatch, hydration, and cursor-binding tests from §18.
 
 **Phase 3 — Backfill.**
-Build and run the one-shot backfill job (diff-based per-collection rewrite, condition set only on full completion). Monitor coverage; do not delete the fallback branch until 100% of collections across all namespaces report `MembershipBackfilled`.
+Build and run the one-shot backfill job with complete Product projection hydration and diff-based writes. Set durable state to `READY` only after the current Collection generation is complete; monitor coverage and failures.
 
 **Phase 4 — Fallback removal.**
 Delete the live-scan fallback branch and `BuildProductConnectionFromSlice`'s usage for this path entirely. `ListCollectionMembers`/`CollectionMemberCount` become the sole source of truth for `Collection.products`/`memberCount`.
 
 **Phase 5 — 022 integration (sequenced with 022's own rollout, not before).**
-Implement the public-scoped twin tables (`collection_membership_public_by_collection`, `collection_membership_public_by_product`), wire the visibility-transition trigger (§12.4/item 3 in §19), wire `visibility` to a real authz decision derived from `auth.PrincipalFromContext`, and only then enable enforcement — per §12.3's explicit sequencing requirement that this phase must not ship ahead of both 022 itself and the visibility-transition trigger.
+Implement the public-scoped twin tables (`collection_membership_public_by_collection`, `collection_membership_public_by_product`), wire publication-state transitions, consume the validated `DecisionScope` rather than deriving visibility from `PrincipalFromContext`, deploy authenticated scope-bound cursors, and only then enable enforcement.
 
 Relevant files referenced throughout: `gitstore-api/internal/graph/resolver/collection.resolvers.go:20-55`, `gitstore-api/internal/graph/resolver/pagination.go:14-266`, `gitstore-api/internal/datastore/memdb/backend.go:18-33,114-127,592-607,686,771`, `gitstore-api/internal/datastore/scylla/backend.go:793-816,1140-1159`, `gitstore-api/internal/datastore/scylla/migrations/001_initial_schema.cql`, `gitstore-api/internal/datastore/scylla/pagination.go:72-121`, `gitstore-api/internal/catalog/collection.go:16-36`, `gitstore-api/internal/catalog/selector.go:8-46`, `gitstore-api/internal/catalog/selector_test.go:16-107`, `gitstore-api/internal/datastore/datastore.go:83-127,134-212`, `gitstore-api/internal/middleware/security/graphql.go:39-42,46-122`, `gitstore-api/internal/auth/provider/rbaclocal/provider.go:52-92`, `gitstore-api/internal/eventbus/eventbus.go`, `gitstore-controller-manager/internal/categorytaxonomy/reconciler.go:87-190`, `gitstore-controller-manager/internal/categorytaxonomy/products.go:44-116`, `gitstore-controller-manager/cmd/controller/main.go:130-139,170-212`, `gitstore-controller-manager/internal/status/patch.go`, `shared/schemas/collection.graphqls:156-256`, `shared/schemas/category.graphqls:161-224`, `docs/implementation/022-opa-data-authorization.md` (§2-3, §7, §12-13).

--- a/docs/implementation/035-collection-membership-materialization.md
+++ b/docs/implementation/035-collection-membership-materialization.md
@@ -1,0 +1,355 @@
+# Collection Membership Materialization for Paginated Product Access
+
+**Status**: 🟡 Proposed
+
+## 1. Problem statement
+
+`Collection.products` is a Relay connection over a many-to-many, label-selector-defined relationship between `Collection` and `Product`. Today it is resolved by loading the *entire* matching set into memory on every request and then windowing it in application code (`gitstore-api/internal/graph/resolver/collection.resolvers.go:20-55`), rather than pushing the cursor/limit down to the datastore the way `Category.products` and `Namespace.repositories` already do (`category.resolvers.go:22-34`, `repository.resolvers.go:151-165`). This is the last major Relay connection in the catalog surface that still does "materialize the full match set, then paginate" instead of "paginate the datastore directly," and it is also the read path that authorization (spec 022) explicitly forbids implementing naively — 022 requires the *query itself* to be scope-specific, not a page-then-filter operation.
+
+This document designs a replacement access pattern: how `Collection.products` should be stored, queried, paginated, and eventually authorized, given (a) the existing keyset-cursor pagination conventions used everywhere else in the catalog, (b) the ScyllaDB/memdb dual-backend datastore, (c) the absence of any Collection or Product reconciler in `gitstore-controller-manager` today, and (d) the not-yet-implemented but architecturally binding constraints of spec 022 (OPA data authorization).
+
+## 2. Existing implementation and evidence
+
+### 2.1 Read path: materialize-then-paginate
+
+`collectionResolver.Products` (`gitstore-api/internal/graph/resolver/collection.resolvers.go:20-55`) unmarshals `Collection.Spec.Selector` and calls `r.service.ListProductsByLabelSelector(ctx, c.Namespace, selector)` (`service.go:184-186`). Both backends materialize the *entire* matching set before any windowing happens:
+
+- memdb (`gitstore-api/internal/datastore/memdb/backend.go:592-607`): a raw index scan over every product row in the namespace, appending label matches into one slice, **with no sort applied**.
+- Scylla (`gitstore-api/internal/datastore/scylla/backend.go:793-816`): pages through `ListProducts` in 500-row batches, evaluating `catalog.MatchesLabels` client-side and appending into one `matched` slice until exhaustion.
+
+`BuildProductConnectionFromSlice` (`gitstore-api/internal/graph/resolver/pagination.go:49-108`) then does the Relay windowing over that already-fully-loaded slice by linear-scanning for the cursor position. Its own doc comment (`pagination.go:48`) states "Products must be pre-sorted by (CreationTimestamp DESC, UID DESC)" — an invariant the memdb caller never actually establishes, since `ListProductsByLabelSelector` there does not sort (finding confirmed directly against `memdb/backend.go:592-607`).
+
+By contrast, `Category.products` (`category.resolvers.go:22-34`) and `Namespace.repositories` (`repository.resolvers.go:151-165`) already push pagination to the datastore via `PageResult[T]`-returning methods (`GetProducts`, `ListRepositoriesByNamespace`). Collection is the outlier.
+
+### 2.2 Cursor mechanics (repo-wide convention, to be reused unchanged)
+
+`keyset_cursor.go`: `EncodeKeysetCursor(createdAt, id)` (lines 23-27) builds `"keyset|<RFC3339Nano>|<id>"`, base64-standard-encoded; `DecodeKeysetCursor` (lines 31-51) reverses this and validates the `"keyset"` tag. The cursor encodes `(CreationTimestamp, UID/ID)`, not an offset. Ordering convention repo-wide is **`CreationTimestamp DESC, UID/ID DESC`** (`memdb/backend.go:18-33` `paginateSlice`, `memdb/backend.go:114-127` `compareKeyset`; ScyllaDB clustering columns in `001_initial_schema.cql`).
+
+### 2.3 Selector shape and evaluation
+
+`catalog.LabelSelector` (`gitstore-api/internal/catalog/collection.go:16-36`) is a full Kubernetes-style selector: `MatchLabels map[string]string` plus `MatchExpressions []LabelSelectorRequirement{Key, Operator ∈ {In,NotIn,Exists,DoesNotExist}, Values}`, AND'd together; an empty/absent selector matches nothing. `catalog.MatchesLabels` (`gitstore-api/internal/catalog/selector.go:8-46`) is the single, unit-tested (`selector_test.go:16-107`) evaluator used by both backends. Product `Labels` is a flat `map[string]string` (`catalog/product.go:25-30`, Scylla column `labels map<text,text>`), scoped by `namespace` in the query, not by key-prefixing.
+
+### 2.4 ScyllaDB schema conventions
+
+`products_by_namespace`, `collection`, and `category_taxonomy` all share `PRIMARY KEY ((namespace), creation_timestamp, uid)` with `CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC)` (`001_initial_schema.cql` lines 1, 39, 112), plus `_by_name`/`_by_uid` lookup tables. No table has a count/aggregate column; no materialized view exists anywhere in the migrations. No secondary index exists for Product/Collection/CategoryTaxonomy (`002_add_initial_indices.cql:1-7` covers only namespaces/repositories/namespace_mappings). All list queries use pure keyset pagination — no `PageState`/`PagingState` usage anywhere in `gitstore-api/internal/` — via `buildPaginatedSelect`'s tuple-inequality WHERE clauses (`scylla/pagination.go:72-121`).
+
+### 2.5 Existing status/resolved precedent
+
+`Collection.status.resolved: ResolvedCollectionDefinition { memberCount: Int! }` is documented as "a cached hint; collection.products is authoritative" (`shared/schemas/collection.graphqls:230,234,251-256`). `CategoryTaxonomy.status.resolved` is the controller-computed analog, with the same nullable-until-first-reconcile semantics (`categorytaxonomy/reconciler.go:182-190`). Both `CollectionStatus` and `CategoryTaxonomyStatus` carry the same `observedGeneration`/`conditions`/`resolved` shape (`shared/schemas/collection.graphqls:215-235`, `shared/schemas/category.graphqls:188-224`) — this machinery already exists on `Collection` and is available for staleness signaling even though nothing currently populates it.
+
+### 2.6 Existence-check convention (spec 041)
+
+`HasRepositories(namespaceID) (bool, error)` and `HasCatalogResources(repoID) (bool, error)` (`datastore.go:187,200`) are explicitly documented as "must be an existence check (LIMIT 1 / equivalent), not a full count." This is the pattern this design reuses for migration-fallback detection (§13), and — per adversarial review — the pattern's limits (it cannot express "fully populated" vs. "partially populated") are a real constraint on how far it can be stretched (§13, §19).
+
+## 3. Relevant authorization constraints from docs/implementation/022-*
+
+022 (`Status: 🟡 Proposed (architecture only)`) is not implemented — the only live `AuthZProvider` is `rbac-local` (`gitstore-api/internal/auth/provider/rbaclocal/provider.go:52-92`), a pure action-string check that explicitly discards the resource argument and has no per-item data scoping. Today, `Query.products`, `Query.product`, `Category.products`, and `Collection.products` all call the datastore directly with **zero** authorization check and no per-item filtering (`product.resolvers.go:21-52`, `category.resolvers.go:22-35`, `collection.resolvers.go:20-49`) — matching 022 §3's own description of the gap verbatim.
+
+022's binding requirements for any future connection design:
+
+1. **No post-hoc filtering, ever.** "For Relay connections, authorization changes the physical query plan before pagination... GitStore never fetches a page and removes unauthorized nodes afterward, and it never relies on CQL `ALLOW FILTERING` for authorization" (022 lines 22-26). §12.2 restates this as a prohibition: fetching a page and deleting unpublished edges afterward "creates short pages, misleading `hasNextPage`, inconsistent counts, and data-dependent over-fetching" (022 lines 625-632).
+2. **Scope-specific projections, not per-item authz calls.** Filtering is by visibility *class* (PUBLIC vs MANAGEMENT), selected as a whole pre-materialized projection before pagination (022 §7.1-7.2, §12.1 lines 592-605) — not a residual per-row "can this user see item N" filter.
+3. **Ordered pipeline** (022 §12.2 lines 613-618): select the scope-specific projection → apply its cursor → read `limit+1` rows → build edges/pageInfo → compute `totalCount` from the same scope-specific dataset or a matching maintained counter.
+4. **No enumeration via any channel.** §13 (lines 634-647): direct lookup of an unpublished resource returns `NOT_FOUND`, identical to absent; list results show ineligible resources as simply absent, no per-edge errors; "the API must not reveal whether a Product or ProductVariant exists but is outside the caller's view through messages, timing classes, **counts**, or global-node behavior" (emphasis load-bearing for §12 of this document). Cursors must bind visibility so a cursor can't be replayed under a different scope to probe existence (§12.2 lines 621-623).
+
+There is no existing "visible namespace/authorized-ID set" precomputation to build on (`AuthorizedNamespaceForDeletion`, `middleware/security/graphql.go:39-42`, is a single-resource cache for one mutation flow, not reusable for a WHERE-clause push-down).
+
+## 4. Control-plane and asynchronous reconciliation model
+
+`gitstore-controller-manager` has exactly one reconciled kind today: `CategoryTaxonomy`, wired via `internal/categorytaxonomy/reconciler.go:87-180` and registered in `cmd/controller/main.go:130-139`. Its `Reconcile` computes `ResolvedCategoryTaxonomy{Depth, Path, ChildCount, ProductCount}`, marshals it into `status.StatusPatch.Resolved json.RawMessage` (`status/patch.go:41-54`), skips no-op writes (`patch.IsNoOp`, lines 59-80), and calls `StatusClient.Apply` treating conflicts as retryable (lines 171-173).
+
+Spec 042 added a **cache without a reconciler** for Product: `internal/categorytaxonomy/products.go:44-116` defines a Product cache entity and an `EventHandler[Product]` whose only effect is to re-enqueue **CategoryTaxonomy** work items — never a Product work item. `cmd/controller/main.go:170-212`'s `registerProductWatch` deliberately never calls `mgr.Register(manager.ReconcilerRegistration{Kind: "Product", ...})` (contrast with `registerCategoryTaxonomy` at line 130-139, which does). The comment at lines 191-196 states outright that "Product has no registered Reconciler/work queue of its own."
+
+There is **no Collection reconciler, no `internal/collection` package, and no precedent anywhere in this codebase for a controller-maintained many-to-many derived index** (the only cross-kind linkage, CategoryTaxonomy↔Product, is one-to-many and computed by client-side pagination-and-filter, not a stored index). The eventbus itself is kind-agnostic (`eventbus.go` keys everything by an arbitrary string `Kind`, no enum) — `Kind: "Product"` already flows end-to-end (spec 042 shipped it) and `Kind: "Collection"` would work with zero eventbus/schema changes if a future controller needed it — but no controller consumes it today.
+
+This matters directly for the design decision in §8: any candidate requiring a new controller is asking this codebase to cross a line it has so far deliberately avoided (spec 042 added the cache half of the CategoryTaxonomy pattern for Product and explicitly stopped short of the reconciler half).
+
+## 5. Access-pattern inventory
+
+| Access pattern | Current implementation | Cursor/order |
+|---|---|---|
+| `Collection.products` (forward/backward page) | Full namespace scan + in-memory selector match + linear-scan windowing (`collection.resolvers.go:20-55`) | `(CreationTimestamp DESC, UID DESC)`, unenforced on memdb |
+| `Collection.status.resolved.memberCount` | Not populated anywhere today; doc-commented as a "cached hint" | N/A |
+| `Category.products` | Datastore-paginated `GetProducts` (`category.resolvers.go:22-34`) | Same convention, correctly pushed down |
+| `Namespace.repositories` | Datastore-paginated `ListRepositoriesByNamespace` (`repository.resolvers.go:151-165`) | Same convention |
+| Reverse lookup: "which collections contain product X" | Does not exist | — |
+| Existence check: "has this collection been indexed yet" | Does not exist (needed for migration, §13) | — |
+
+## 6. Candidate designs
+
+Four candidates were evaluated; the full decision matrix is in §7.
+
+**A — Materialized `collection_membership` table, populated synchronously in the admission path.** A `(namespace, collection_uid)`-partitioned forward table plus a `(namespace, product_uid)`-partitioned reverse table, both clustered `(creation_timestamp DESC, uid DESC)` exactly like `products_by_namespace`. Populated inline inside `CreateProduct`/`UpdateProduct`/`DeleteProduct` (diff old vs. new label match against all Collections in the namespace via the reverse table) and `CreateCollection`/`UpdateCollection` (full re-scan and partition replace). Strengths: one query per page at read time, zero controller involvement, reuses every existing cursor/ordering convention, bounded staleness window (one write). Weaknesses: unbounded single-partition growth for a broad-selector collection with no mitigation designed; cross-table (forward/reverse) writes are not atomic, so a crash mid-write can desync them; needs a second, visibility-scoped table to satisfy 022 once it ships; a full-partition-replace on Collection selector edit is not atomic at Scylla batch-size scale.
+
+**B — Collection-membership projection derived asynchronously by future Product and Collection controllers.** Follows the CategoryTaxonomy reconciler pattern exactly, but requires **two new reconcilers that do not exist today**, one of which (Product) directly contradicts the deliberate no-reconciler decision spec 042 just shipped (§4). It also escalates `status.resolved` from a documented "cached hint" to a load-bearing pagination source (or else creates a visible count/list disagreement if it doesn't), has no rebuild/drift-detection mechanism and none to borrow from elsewhere in the repo, doesn't satisfy 022 without duplicating every table per visibility scope, and has the same unmitigated wide-partition risk as A. Its pre-controller behavior is worse than A's: an empty projection is indistinguishable from an unmaterialized one, requiring yet another marker field to disambiguate.
+
+**C — Inverted label-index tables queried at read time.** Per-`(namespace, label_key, label_value)` and per-`(namespace, label_key)` tables enabling equality/`In`/`Exists` lookups without a full scan. Rejected primarily because `NotIn`/`DoesNotExist`-only selectors (permitted by `catalog.LabelSelectorRequirement.Operator` today, `catalog/collection.go:26-36`) have no anchor set and degrade to exactly today's full scan — the design's core promise ("avoid full scans") doesn't hold for a selector shape the schema explicitly allows. Multi-term intersection still requires materializing the full candidate set before Relay windowing — the same anti-pattern being fixed, just over a smaller candidate universe. Write amplification is up to 2K writes per K-labeled product with no controller to host the diffing, and popular label values create the same wide-partition risk as A/B, worse because it fragments by value while still concentrating popular ones.
+
+**D — Hybrid: materialized membership plus authorization filtering at read time (over-read-and-fill).** Keeps one shared (non-visibility-scoped) `collection_membership` table and defers authorization to a bounded-rounds over-read-and-fill loop at query time, explicitly documented as unable to fully honor 022's "never short pages" guarantee (a page can hit `maxRounds` and return short-but-not-exhausted, itself a soft leak signal). Requires a Collection controller that does not exist (same gap as B for the write side), cannot ship before that controller exists (no dual-source migration story is given), and has the highest write cost of all four candidates combined with a deliberately weaker authorization guarantee than A or B's "true" scope-specific-table approach.
+
+See §7 for the full side-by-side comparison; the summary judgment is that **B and D require new controllers this codebase has deliberately avoided building, and C fails to eliminate the scan it exists to eliminate for a selector shape the schema already permits** — leaving A as the only candidate that is both a genuine improvement over the status quo and buildable without new control-plane scope.
+
+## 7. Decision matrix
+
+| Criterion | A: Materialized (write-time) | B: Controller-derived (async) | C: Inverted label index | D: Hybrid materialized + runtime authz |
+|---|---|---|---|---|
+| Query count / read amplification | Good — 1 query/page | Good — 1 query/page (once populated) | Fair — N+ queries, still materializes full intersection for multi-term/negative selectors | Fair — 1+ queries/round, multiple rounds under low authz density |
+| Partition/hotspot risk | Poor — unbounded partition per broad collection, no mitigation | Poor — same, `collection_uid` partition | Poor — value-partitioned, popular label values hot | Poor — same `collection_uid` partition, explicitly flagged unmitigated |
+| Pagination correctness | Good — standard keyset, no offset (see §11 for a bulk-rewrite caveat) | Good — keyset, but membership-not-current | Fair — intersection breaks true cursor semantics for multi-term | Good for membership; short-page risk under authz filtering |
+| Cursor stability | Good — reuses `EncodeKeysetCursor`/`DecodeKeysetCursor` unchanged | Good — same | Good | Good |
+| Write amplification | Fair — bounded by collections/products per namespace | Fair — similar, but async so latency hidden from writer | Poor — 2K writes per product, diff-on-write required | Poor — same as A plus authz has no write cost but membership same |
+| Staleness behavior | Good — synchronous, single-request window (but see §13 for a backfill-window caveat) | Poor — queue/backoff-dependent, unbounded in principle | Fair — synchronous but no controller to host diffing, so inline too | Poor — controller-reconcile-dependent |
+| Rebuild/backfill complexity | Fair — derivable, needs one-shot job, no drift detection built in | Poor — no rebuild precedent, no drift detection | Fair — full scan re-derivation, same gap | Fair — `resource_version` per row aids diffing, but still needs new job |
+| Authorization correctness/leak risk | Fair — needs a second visibility-scoped table to satisfy 022; see §12 for gaps in even that plan | Poor — violates 022's "no post-hoc filter" outright as designed | Poor — same duplication problem, worse (index itself leaks) | Fair — explicitly documents it deviates from 022's "never short pages" guarantee |
+| Namespace isolation | Good — partition includes namespace | Fair — keyed by UID only, no partition-level guard | Good — partition includes namespace | Fair — UID-partitioned, namespace is a defense-in-depth column only |
+| memdb compatibility | Good — straightforward map mirror | Good | Fair — doubles index maintenance code paths | Good |
+| Controller-manager fit | Good — zero controller involvement | Poor — needs 2 new reconcilers, contradicts spec 042's Product-has-no-reconciler precedent | Good — zero controller involvement | Poor — needs a new Collection controller |
+| Behavior before any controller/backfill exists | Fair — universal fallback holds on deploy day, but the backfill *transition itself* has a silent under-count window (§13) | Poor — table is empty/absent, ambiguous empty-vs-unmaterialized | Good — doesn't depend on one | Poor — cannot ship without the missing controller |
+| Migration complexity | Fair — 2 tables, admission hook, backfill | Poor — 2 tables, 2 controllers, dual-path fallback, visibility duplication | Poor — 2 tables, mutation-path diffing, backfill, visibility duplication | Poor — most moving parts of all four |
+
+## 8. Recommended architecture
+
+**Adopt Candidate A — a `collection_membership` table pair, populated synchronously in `gitstore-api`'s existing admission/mutation path — as the permanent design, not an interim stopgap.**
+
+B and D are rejected outright: both require standing up controllers this codebase deliberately does not have. Spec 042 is direct precedent — it added a Product *cache* but explicitly declined to register a Product *reconciler* (`cmd/controller/main.go:191-196`), and a Collection controller has even less precedent (no `internal/collection` package exists at all, no many-to-many derived index has ever been built here). C is rejected because it does not eliminate full-namespace scans for negative-only selectors, which the schema explicitly permits, and its write cost (2K writes per product) with no controller to host the diff is strictly worse than A under the same "no controller" constraint.
+
+A wins because it needs zero new controller-manager work, reuses every existing convention (`(CreationTimestamp DESC, UID DESC)` clustering, `EncodeKeysetCursor`, `PageResult[T]`), and turns an O(namespace) scan-per-request into O(1) partition reads at the one-time cost of write-path hooks in code that already computes derived fields (spec 034's admission functions).
+
+This recommendation is adopted **with amendments** relative to the original Candidate A writeup, required by the three adversarial verification passes:
+
+- **§11** amends the bulk `ReplaceCollectionMembership` contract to fix a real cursor-instability bug found in verification.
+- **§12** amends `memberCount` and the migration-fallback path to close a real information-leak the auth-leak verifier constructed concretely.
+- **§13** amends the backfill/bootstrap story to name and bound (rather than silently absorb) the under-count window the staleness verifier found.
+
+None of these amendments changes the overall recommendation; they close gaps in how it must be built.
+
+## 9. ScyllaDB data model
+
+```cql
+CREATE TABLE IF NOT EXISTS collection_membership_by_collection (
+    namespace           text,
+    collection_uid       uuid,
+    product_created_at   timestamp,   -- the PRODUCT's own immutable CreationTimestamp, NOT a rewrite/index timestamp
+    product_uid           uuid,
+    product_name          text,
+    resource_version       text,       -- product's resource_version at last evaluation, for staleness detection
+    PRIMARY KEY ((namespace, collection_uid), product_created_at, product_uid)
+) WITH CLUSTERING ORDER BY (product_created_at DESC, product_uid DESC);
+
+CREATE TABLE IF NOT EXISTS collection_membership_by_product (
+    namespace       text,
+    product_uid     uuid,
+    collection_uid   uuid,
+    PRIMARY KEY ((namespace, product_uid), collection_uid)
+);
+```
+
+Design notes:
+
+- Partition key includes `namespace` on both tables (unlike the original candidate writeups' UID-only reverse-index shape), giving the same structural namespace isolation every other table in `001_initial_schema.cql` has, and giving `HasCollectionMembership` and any future public-scope variant a namespace-scoped partition to query.
+- `product_created_at` **must** be the product's own `CreationTimestamp`, never a write-time/rewrite timestamp — this is the fix for the pagination bug in §11. It is denormalized from the product row at every write (initial insert, incremental upsert, and bulk rewrite alike) rather than being generated fresh.
+- `resource_version` on the membership row is the product's `resource_version` at the time this membership row was last written — the basis for backfill-completeness / drift detection, not a version of the membership row itself.
+- A visibility-scoped twin table, `collection_membership_public_by_collection` (same shape, populated only for publicly visible products), is a **named, reserved-but-not-yet-built** part of this schema — see §12 for why it must exist before 022 ships, not after.
+
+## 10. Example CQL queries
+
+Forward page (`first`/`after`):
+```cql
+SELECT product_uid, product_name, product_created_at, resource_version
+FROM collection_membership_by_collection
+WHERE namespace = ? AND collection_uid = ?
+  AND (product_created_at, product_uid) < (?, ?)
+ORDER BY product_created_at DESC, product_uid DESC
+LIMIT 21;  -- first + 1, to compute hasNextPage
+```
+
+Backward page (`last`/`before`), reversing the inequality and re-reversing the result in application code, per `buildPaginatedSelect`'s existing convention (`scylla/pagination.go:92-104`):
+```cql
+SELECT product_uid, product_name, product_created_at, resource_version
+FROM collection_membership_by_collection
+WHERE namespace = ? AND collection_uid = ?
+  AND (product_created_at, product_uid) > (?, ?)
+ORDER BY product_created_at ASC, product_uid ASC
+LIMIT 21;
+```
+
+Existence check (migration-fallback signal, mirrors `HasRepositories`/`HasCatalogResources`):
+```cql
+SELECT product_uid FROM collection_membership_by_collection
+WHERE namespace = ? AND collection_uid = ?
+LIMIT 1;
+```
+
+Reverse lookup (used by the Product-triggered incremental writer to find current memberships before diffing):
+```cql
+SELECT collection_uid FROM collection_membership_by_product
+WHERE namespace = ? AND product_uid = ?;
+```
+
+Incremental write (single product, single collection, on label-driven match-state flip):
+```cql
+INSERT INTO collection_membership_by_collection
+  (namespace, collection_uid, product_created_at, product_uid, product_name, resource_version)
+VALUES (?, ?, ?, ?, ?, ?);
+
+INSERT INTO collection_membership_by_product (namespace, product_uid, collection_uid)
+VALUES (?, ?, ?);
+```
+(and the corresponding `DELETE ... WHERE namespace = ? AND collection_uid = ? AND product_created_at = ? AND product_uid = ?` / reverse-table delete for products that no longer match.)
+
+Bulk rewrite (Collection selector change) is deliberately **not** expressed as a single statement — see §11 for why a naive `DELETE partition` + `INSERT ...` loop is unsafe, and for the diff-based rewrite this design requires instead.
+
+## 11. Pagination and cursor semantics
+
+Cursor format, ordering, and windowing are unchanged from every other Relay connection in this codebase: `EncodeKeysetCursor(product_created_at, product_uid)` / `DecodeKeysetCursor` (`keyset_cursor.go:23-51`), `(CreationTimestamp DESC, UID DESC)` ordering, `limit+1` read to compute `hasNextPage`, fed into the existing generic `PageResult[T]`-based connection builder (the one `Category`/`Namespace` already use) rather than `BuildProductConnectionFromSlice`, which is retired for this path.
+
+### 11.1 The bulk-rewrite cursor-instability bug (confirmed by adversarial review) and its fix
+
+The original Candidate A contract specified `ReplaceCollectionMembership(ctx, namespace, collectionUID, productUIDs []uuid.UUID) error` for the "Collection selector changed" trigger, described only as a "full rewrite." Adversarial verification constructed a concrete failure: because this signature carries **no timestamps**, an implementation has no way to populate the clustering column `product_created_at` for surviving members except either (a) an uncosted extra per-product lookup of the real `CreationTimestamp` before every rewrite (not costed anywhere in the write-amplification analysis), or (b) stamping a fresh rewrite-time timestamp — the natural default for a delete-partition-then-reinsert loop.
+
+Under (b), the trace is: a client fetches page 1 of a 3-member collection (cursor = last item's real `CreationTimestamp`), an *unrelated, membership-preserving* Collection selector edit fires a full rewrite that re-stamps all rows with `now()`, and the client's page-2 request — using its now-stale cursor — finds that every surviving row's `product_created_at` is *greater* than the cursor (since `now()` is newer than the original timestamps), so the `< (?, ?)` predicate matches zero rows. The client receives `hasNextPage: false` and silently believes it has seen the whole collection, when in fact the untouched remaining members were dropped with no error, no short-page signal, and nothing distinguishing this from "the collection genuinely has 3 members."
+
+**Fix, adopted into this design's contract:**
+
+1. `product_created_at` in `collection_membership_by_collection` is always the **product's own immutable `CreationTimestamp`**, fetched from the authoritative product row (or already in hand, for the incremental path) — never a rewrite-time value. This is stated explicitly in the schema comment (§9) precisely to prevent an implementation from defaulting to `now()`.
+2. The Collection-selector-change trigger is specified as a **diff**, not a blind delete+reinsert: compute the new matching product-UID set, compare it against the current partition contents (read via the same `collection_membership_by_collection` partition, or via `collection_membership_by_product` for the reverse direction), and issue `INSERT`s only for newly-matching products (with their real `CreationTimestamp`) and `DELETE`s only for no-longer-matching products. Unaffected members are never touched, so their clustering key — and therefore any in-flight client's cursor — is never perturbed.
+3. This mirrors what the incremental `Upsert`/`Remove` path already does correctly (it diffs a single product against its current collection set using a real `CreationTimestamp` already in hand) — the fix simply extends the same diff discipline to the bulk path instead of treating "bulk" as license for a cheaper-looking blind rewrite.
+
+This closes the bug at the contract level; §16 reflects the corrected method signature.
+
+### 11.2 Residual, accepted keyset properties (inherited, not new)
+
+- A product added to a collection with a `CreationTimestamp` *older* than an in-flight client's last-consumed cursor position will not retroactively appear on an earlier page — standard keyset behavior, unchanged from every other paginated connection in this codebase, and not a new weakness introduced here.
+- A product removed from a collection between page fetches simply disappears with no dangling reference and no error — the standard, accepted "phantom/missing edge" tradeoff every keyset design in this codebase already carries.
+
+## 12. Authorization and information-leak analysis
+
+022 is unimplemented today, so this feature ships with **zero enforcement**, identical to current behavior for `Collection.products`, `Category.products`, and `Query.products` (§3). The contract below is written so that turning on 022 later requires no new schema migration for the connection itself — but adversarial review found that the original writeup's claim of "no additional migration" did not actually hold end-to-end, and this section adopts the fixes required to make it true.
+
+### 12.1 Where authorization is enforced (query-time projection selection, never post-hoc)
+
+`ListCollectionMembers(ctx, namespace, collectionUID, visibility, page)` resolves `visibility` from `auth.PrincipalFromContext(ctx)` (`auth/context.go:18-21`) and selects between `collection_membership_by_collection` (management scope) and `collection_membership_public_by_collection` (public scope) **before** building the paginated CQL query — exactly 022 §12.1-12.2's mandate, and exactly what rules out post-fetch filtering or the over-read/fill approach evaluated (and rejected) as Candidate D.
+
+### 12.2 Finding 1 (confirmed): unscoped `memberCount` is a label-predicate oracle — closed by design amendment
+
+Adversarial review constructed a concrete attack: an ordinary PUBLIC-scoped user creates a Collection with `matchLabels: {"internal-sku": "PROJECT-CHIMERA-v2"}`, queries `products(first:10)` (empty, correctly, since no public product matches) alongside `status.resolved.memberCount`. If `memberCount` is sourced from the single, unscoped `collection_membership_by_collection` table — as the original recommendation described it ("sourced from the membership table's row count going forward instead of a live scan," with no per-scope variant) — the mismatch (`products: []` but `memberCount: 1`) proves a hidden product exists with that exact label value. Because selectors support `In`/`NotIn`/`Exists`/`DoesNotExist`, this generalizes into a binary-search oracle over the entire label space of products the caller cannot see — precisely the "counts... reveal whether a resource exists" leak 022 §13 prohibits by name.
+
+**Design amendment, adopted:** `memberCount` is **not** a single collection-wide value once 022 ships. It must be computed from the same scope-specific table `ListCollectionMembers` selects for the requesting principal — i.e., `memberCount` is a per-request/per-scope derived value (or, if it must remain a stored field on `Collection.status.resolved`, it is split into a scope-specific pair, e.g. an internal `memberCount` used for management-scope reads and a separately maintained public-scope count for public reads). This is a genuine scope expansion of the original "reserve `visibility` on `ListCollectionMembers` now, no future migration needed" claim: **the visibility reservation must extend to the count path from day one**, or the leak goes live silently the moment 022 turns on scoping with no further code change. This document treats that extension as part of the baseline contract (§16), not as follow-up work.
+
+### 12.3 Finding 2 (confirmed): the migration fallback is a full, ungated bypass of 022
+
+The fallback path for a not-yet-backfilled collection is "today's live `ListProductsByLabelSelector` scan" (§13), which per §3 has **zero authorization applied** — it is precisely the ungated full-namespace scan 022 exists to replace. As originally written, nothing prevented 022 from being enabled before backfill completes, or before a large-namespace backfill job reaches every collection. **Design amendment, adopted:** enabling 022's enforcement in `ListCollectionMembers` and completing the Collection-membership backfill are treated as a single, sequenced rollout gate, not two independent workstreams — 022 (whenever it ships) must not be turned on for the Collection-membership read path until the backfill job's completion is verifiable (§13 defines the completeness signal this requires). Until 022 ships, the fallback's lack of authorization is unchanged from current production behavior, so this is a rollout-ordering constraint, not a new regression, but it is written down explicitly here so it is not lost when 022 is scheduled.
+
+### 12.4 Finding 3 (plausible, flagged as an open question, not fully closed here)
+
+If Product visibility/publish state is a field independent of `Labels` (near-certain under 022's design, which treats "published vs. unpublished" as orthogonal to label-based selector matching), then a Product transitioning public→private via a mutation that does not touch `Labels` will not fire the label-diff trigger that maintains `collection_membership_public_by_collection`. Two bad outcomes follow: either the stale public-index row keeps serving the now-private product's full node data through the Collection path (a direct §13 violation, and inconsistent with `product(id:)` correctly returning `NOT_FOUND` for the same product), or a defensive per-row re-check at read time drops the stale entry and reproduces the exact short-page-vs-`memberCount` mismatch Finding 1 already demonstrates.
+
+This is **not fully resolved by this design** — it is listed as an explicit unresolved question in §19 with a required action: whenever 022 defines the concrete visibility/publish-state field, the Collection-membership write triggers in §16 must be extended to include "Product visibility transition" as a third trigger (alongside label change and selector change), symmetrically maintaining the public-scoped table. This document commits to that extension being mandatory before 022 enforcement is turned on for this path, per §12.3's sequencing gate.
+
+### 12.5 Axes checked and found sound
+
+- **Cursor forgery/replay**: `DecodeKeysetCursor` validates only the `"keyset"` tag, timestamp parseability, and id — it does not check row existence, so a forged cursor for a real-but-hidden product's `(timestamp, uid)` is indistinguishable from one for a non-existent tuple; no observable leak beyond Findings 1/3 above. (The cursor format not being visibility-bound, per 022 §12.2's stricter requirement, is a spec-compliance gap worth closing defensively but was not turned into an independent exploit.)
+- **`hasNextPage`/short pages on the primary connection**: safe, provided the twin scope-specific tables are implemented and kept in sync as required by §16/§12.4 — pagination runs entirely inside one consistent, correctly-scoped table with no post-hoc filtering.
+- **Error messages**: `ErrNotFound` is reused undifferentiated for missing collection/product, matching 022 §13's mandate; no new differentiation introduced.
+- **Ordering**: uniform `(CreationTimestamp DESC, UID DESC)` regardless of which table is queried; no additional leakage beyond the inherent, unavoidable property of any filtered keyset list.
+
+## 13. Consistency, staleness, rebuild, and backfill behavior
+
+### 13.1 Authoritative vs. derived data
+
+`Product.Labels` and `Collection.Spec.Selector` remain authoritative — unchanged, still the source data. `collection_membership_by_collection`/`collection_membership_by_product` (and their future public-scoped twins) are a fully rebuildable derived index: any drift can be repaired by re-running `catalog.MatchesLabels` (`catalog/selector.go:8-46`) against the authoritative tables. `Collection.status.resolved.memberCount`'s doc comment — "a cached hint; collection.products is authoritative" — is preserved, except "authoritative" now means "authoritative derived index," not "recomputed live every request," and (per §12.2) is scope-specific rather than a single value.
+
+### 13.2 Steady-state consistency
+
+Writes are synchronous, inside the same request as the triggering `CreateProduct`/`UpdateProduct`/`DeleteProduct`/`CreateCollection`/`UpdateCollection` call. No cross-partition transaction exists between the forward and reverse tables (ScyllaDB gives no such primitive), so a crash mid-write can desync them; this is an accepted, bounded risk (repaired by the same rebuild mechanism as backfill, §13.4), not eliminated.
+
+### 13.3 The backfill/bootstrap gap (confirmed by adversarial review) — named and bounded, not hand-waved
+
+Adversarial review traced a concrete, previously-unnamed failure mode. On the day this design ships, every Collection/Product row that existed **before** deploy has zero membership rows, because admission hooks only fire on new writes. `HasCollectionMembership(collectionUID)` returning `false` correctly triggers a fallback to the live `ListProductsByLabelSelector` scan — this holds and is correct on literal deploy day, before any backfill job runs.
+
+The gap is in the backfill job's transition window, not its absence. Since ScyllaDB gives no cross-partition, arbitrary-size atomic transaction (confirmed: no materialized view, no aggregate column anywhere in `001_initial_schema.cql`), a backfill job populating a collection with, say, 500 members necessarily writes those rows incrementally. Mid-backfill, for a collection currently at 1-of-500 written rows: `HasCollectionMembership(X)` returns **true** (a `LIMIT 1` existence check needs only one row), so the resolver switches off the live-scan fallback and reads the partially-populated table directly — returning a fully-formed, error-free 1-edge connection with `hasNextPage: false`. This is a **silent under-count, structurally indistinguishable from a genuine 1-member collection**, and it reproduces — inside Candidate A's own migration mechanism, narrowed from "permanent" to "a race window" — exactly the failure mode this design's own decision matrix used to reject Candidate B ("empty-vs-unmaterialized ambiguity"). `HasCollectionMembership`/`HasRepositories`/`HasCatalogResources`'s `LIMIT 1` semantics (designed for spec 041's precondition-check use case) cannot express "fully populated" vs. "partially populated" — repurposing an existence check as a migration-completeness signal is a category error, not a minor gap.
+
+**Design amendments, adopted, to bound this window instead of leaving it open-ended:**
+
+1. **A per-collection backfill-completion marker is required**, not just a job that "populates all existing collections." Concretely: reuse the existing `CollectionStatus.observedGeneration`/`conditions` fields already present on the schema (`shared/schemas/collection.graphqls:215-235`, same shape as `CategoryTaxonomyStatus`) to record a condition such as `MembershipBackfilled: true` written atomically as the *last* step of that collection's backfill (after all rows are written), analogous to how `categorytaxonomy.Reconciler` only reports `Resolved` once its computation is complete. `HasCollectionMembership` continues to answer "is there at least one row" for the cheap common case, but the resolver's decision to trust the materialized table for a *given* collection is gated on this condition being present, not merely on row existence.
+2. Until that condition is set for a collection, `ListCollectionMembers` **must** continue to use the live-scan fallback for that specific collection, even if `HasCollectionMembership` would return `true` — closing the exact race window traced above.
+3. The backfill job itself (new, does not exist today, and this document does not claim otherwise) is scoped as: for each Collection lacking `MembershipBackfilled`, diff-write its full membership set (using the same diff discipline as §11's bulk-rewrite fix, not a blind delete+reinsert), then set the condition. This gives an automatable, testable completion signal instead of relying on operator judgment to know when the fallback branch can be safely deleted.
+4. `Collection.status.resolved.memberCount` during the backfill window reports whatever the (possibly partial) materialized table currently holds **only if** the fallback-gating condition from (2) is respected — i.e., during backfill, `memberCount` is sourced from the live scan just like `products` is, so the two never visibly disagree mid-migration. This directly addresses the adversarial finding that the original design's `memberCount` would "corroborate rather than flag the wrong answer" during the race.
+
+### 13.4 Rebuild and drift detection going forward
+
+Post-backfill, drift detection is not fully automatic — this document does not claim a checksum/reconciliation job exists. It commits to the same `resource_version`-per-row mechanism (§9) being sufficient to support a future diff-based repair job (compare each membership row's stored `resource_version` against the current product's `resource_version`; a mismatch means the row is stale and must be re-evaluated), but building that job is out of scope for this design and is listed as an open question in §19, not silently assumed solved.
+
+## 14. Memdb compatibility
+
+Both tables mirror straightforwardly onto `go-memdb`: `map[uuid.UUID][]membershipRow` keyed by `(namespace, collectionUID)` for the forward index, `map[uuid.UUID][]uuid.UUID` keyed by `(namespace, productUID)` for the reverse index, sorted via the existing `paginateSlice`/`compareKeyset` helpers (`memdb/backend.go:18-33,114-127`) rather than CQL clustering order. This also **fixes** the previously-unenforced sort defect noted in §2.1: `ListCollectionMembers`'s memdb implementation must sort by `(CreationTimestamp DESC, UID DESC)` before returning, unlike today's `ListProductsByLabelSelector`, which does not. No structural blocker exists for the write-time diff logic either — it is backend-agnostic Go code (label evaluation via `catalog.MatchesLabels`) sitting above both `Datastore` implementations.
+
+## 15. Controller-manager integration and future controller responsibilities
+
+**Zero Product/Collection controllers are introduced by this design.** Everything — admission-time writes, reads, backfill — lives inside `gitstore-api`. `gitstore-controller-manager` is untouched: no new `Reconciler`, no new `ListWatcher`, no new eventbus consumer, no interaction with the Product-cache-without-a-reconciler pattern from spec 042 (`categorytaxonomy/products.go:44-116`).
+
+**Ownership going forward:** `collection_membership_by_collection`/`collection_membership_by_product` (and their public-scope twins) are owned permanently by `gitstore-api`'s datastore layer, by design, to preserve single-request write consistency (§13.2). If a future Collection or Product controller is justified for unrelated reasons (e.g., enriching `status.resolved` with additional computed fields the way `CategoryTaxonomy`'s controller does for `Depth`/`Path`/`ChildCount`), it may **read** the membership table, but must never become a second writer to it — a second writer would reintroduce exactly the eventual-consistency/staleness profile this design exists to avoid (§8's rejection of Candidates B and D). This constraint should be written into any future controller's design doc as a hard dependency on this one.
+
+## 16. API and datastore contract changes
+
+New `Datastore` interface methods (`gitstore-api/internal/datastore/datastore.go`), alongside existing Product/Collection methods:
+
+- `ListCollectionMembers(ctx context.Context, namespace string, collectionUID uuid.UUID, visibility Visibility, page PageParams) (PageResult[*Product], error)` — primary read; replaces `ListProductsByLabelSelector` as the `Collection.Products` data source. `visibility` selects between the management and public-scoped tables (§12.1); required from day one, not deferred.
+- `CollectionMemberCount(ctx context.Context, namespace string, collectionUID uuid.UUID, visibility Visibility) (int, error)` — **new relative to the original recommendation**, added directly in response to §12.2's Finding 1: a scope-aware count, so `memberCount` can never be sourced from an unscoped table.
+- `ReplaceCollectionMembership(ctx context.Context, namespace string, collectionUID uuid.UUID, products []ProductRef) error` — Collection-selector-change trigger. **Signature changed from the original `productUIDs []uuid.UUID`** to carry each product's real `CreationTimestamp` (`ProductRef{UID, CreationTimestamp}`) and is specified as a diff against current partition contents, not a blind delete+reinsert — the §11.1 fix.
+- `UpsertCollectionMembership` / `RemoveCollectionMembership(ctx, namespace, collectionUID, productUID uuid.UUID) error` — incremental, Product-label-change trigger, diffed against `collection_membership_by_product`.
+- `HasCollectionMembership(ctx context.Context, namespace string, collectionUID uuid.UUID) (bool, error)` — cheap existence check, same "LIMIT 1, not a count" convention as `HasRepositories`/`HasCatalogResources`. Per §13.3, this is **not** sufficient on its own to gate the fallback-to-live-scan decision; it must be combined with the `MembershipBackfilled` condition check.
+
+**Types:** reuse existing `PageParams`/`PageResult[T]`, `EncodeKeysetCursor`/`DecodeKeysetCursor` unchanged — no new cursor format.
+
+**Ordering guarantee:** `(CreationTimestamp DESC, UID DESC)`, enforced by both backends, fixing memdb's currently-unenforced sort (§2.1, §14).
+
+**Error behavior:** `ErrNotFound` for missing collection/product, `ErrConflict` for optimistic-concurrency membership writes (mirroring `ApplyCategoryTaxonomyStatusPatch`'s `ResourceVersion` check pattern, `datastore.go:83-115`).
+
+**Resolver change:** `collectionResolver.Products` (`collection.resolvers.go:20-55`) drops the `spec.Selector`/`ListProductsByLabelSelector` call and calls `r.service.ListCollectionMembers`, feeding the returned `PageResult[*Product]` into the existing generic connection builder Category/Namespace already use, retiring `BuildProductConnectionFromSlice` for this path. `Collection.status.resolved.memberCount` resolves via `CollectionMemberCount`, scope-aware and backfill-window-aware per §13.3(4).
+
+## 17. Migration and rollout plan
+
+1. Ship the two Scylla tables (`collection_membership_by_collection`, `collection_membership_by_product`) plus the memdb equivalents, and the admission-path write hooks (incremental first, since it's the lower-risk path — bulk rewrite ships with the §11.1 diff logic from the start, never as a naive delete+reinsert).
+2. Ship `ListCollectionMembers`/`CollectionMemberCount` behind the `HasCollectionMembership` + `MembershipBackfilled`-condition gate described in §13.3; until a given collection's condition is set, both continue to use today's live scan, so behavior is unchanged for every not-yet-backfilled collection.
+3. Build and run the backfill job (diff-based per-collection rewrite, condition set only on completion, per §13.3(3)) as a one-shot operational task; monitor `MembershipBackfilled` coverage across all namespaces before proceeding.
+4. Once all collections report `MembershipBackfilled`, delete the fallback branch from the resolver — do not keep it as a permanent dual-source-of-truth.
+5. **Do not enable 022 enforcement for this path** (i.e., do not wire the `visibility` parameter to a real authz decision, and do not populate the public-scoped twin tables) until both (a) 022 itself ships, and (b) the visibility-transition trigger required by §12.4 is implemented — these are sequenced, not independent, per §12.3.
+
+## 18. Test strategy
+
+- **Unit**: `catalog.MatchesLabels` is already covered (`selector_test.go:16-107`); extend coverage to the diff functions (label-change diff, selector-change diff) with property-style tests asserting that unaffected members' `CreationTimestamp` is never rewritten across a bulk `ReplaceCollectionMembership` call (direct regression test for §11.1).
+- **Pagination correctness**: a test that pages a collection, performs a membership-preserving Collection selector edit mid-pagination (adding a redundant matchExpression that changes nothing), and asserts the next page still returns all originally-untouched members — this is the exact regression the adversarial pagination-correctness finding demonstrated as broken under the original signature.
+- **Leak regression**: a test asserting `CollectionMemberCount` under PUBLIC scope never exceeds the count of edges a PUBLIC-scoped `products` query would return for the same collection and selector, across `matchLabels`/`In`/`NotIn`/`Exists`/`DoesNotExist` selector shapes — direct regression for §12.2's Finding 1.
+- **Backfill-window regression**: a test that starts a fake partial backfill (writes 1-of-N rows, does not set `MembershipBackfilled`), and asserts `ListCollectionMembers`/`CollectionMemberCount` still return the live-scan result, not the partial materialized result — direct regression for §13.3.
+- **Dual-backend parity**: run the full `Collection.products` connection test suite against both memdb and Scylla backends, asserting identical ordering, cursor behavior, and count semantics — extending the existing pattern implied by the dual-implementation maintenance burden noted throughout the investigation.
+- **Cross-table consistency**: a test/tool that walks `collection_membership_by_collection` and `collection_membership_by_product` for a namespace and asserts they agree (every forward row has a matching reverse row and vice versa) — a minimal drift detector, given none exists elsewhere in the repo to reuse (§13.4).
+
+## 19. Risks and unresolved questions
+
+1. **Wide-partition/hotspot risk is unmitigated.** A single collection with a very broad selector (e.g., `Exists` on a common label) accumulates an unbounded number of clustering rows in one `(namespace, collection_uid)` partition. No sharding/bucketing scheme is designed here; mitigating this would require a synthetic bucket suffix on the partition key, which complicates cursor encoding and is deferred as a follow-up if any collection is observed approaching Scylla's practical per-partition row-count guidance.
+2. **Cross-table atomicity is not guaranteed.** `collection_membership_by_collection` and `collection_membership_by_product` are updated in the same logical operation but not atomically (no Scylla multi-partition transaction); a crash mid-write can desync them, recoverable only via the (not-yet-built) drift-detection/repair job in §13.4.
+3. **Visibility-transition trigger is a named gap, not a closed one (§12.4).** This document specifies that a Product's visibility/publish-state change must become a third membership-write trigger before 022 enforcement is turned on, but the concrete field and mechanics depend on 022's own not-yet-finalized design. Shipping this design's write-time hooks without that third trigger, then later enabling 022 without adding it, will reproduce Finding 3's leak exactly as described.
+4. **The backfill job and its completion signal do not exist yet.** §13.3 specifies the shape they must take (diff-based rewrite, `MembershipBackfilled` condition gating) but this document does not claim they are built; rollout (§17) is explicitly sequenced to prevent the ambiguity window from being silently absorbed.
+5. **Cursor format is not visibility-bound**, contrary to 022 §12.2's stricter requirement that a cursor encode enough scope information to prevent replay-across-scope probing. This was checked by adversarial review and not turned into an independent exploit given the other mitigations in §12, but it remains a spec-compliance gap relative to 022's letter, not just its spirit, and should be revisited when 022's cursor requirements are finalized.
+6. **`resource_version`-based drift detection (§13.4) is specified but not implemented.** No automated job exists today to detect or repair post-backfill drift; this is accepted as follow-up work, not a blocking gap for initial rollout, but should not be indefinitely deferred given the cross-table atomicity risk in item 2.
+7. **Scope of `CollectionMemberCount` beyond PUBLIC/MANAGEMENT.** If 022 eventually introduces finer-grained scopes than a binary PUBLIC/MANAGEMENT split, the two-table (management + public) design in §9/§12.1 would need to generalize; this document does not attempt to anticipate that and treats it as an explicit non-goal for this iteration.
+
+## 20. Phased implementation plan
+
+**Phase 1 — Datastore foundation (no behavior change).**
+Add the two Scylla tables and memdb equivalents; add `Datastore` interface methods (`ListCollectionMembers`, `CollectionMemberCount`, `ReplaceCollectionMembership` with the §11.1 diff contract, `UpsertCollectionMembership`, `RemoveCollectionMembership`, `HasCollectionMembership`); implement admission-path write hooks for both backends. `Collection.products` and `status.resolved.memberCount` continue to use today's live-scan path — nothing reads the new tables yet.
+
+**Phase 2 — Read path cutover, gated by backfill condition.**
+Change `collectionResolver.Products` to call `ListCollectionMembers` and `CollectionMemberCount`, both gated per collection on the `MembershipBackfilled` condition (§13.3). Add the fallback-branch test (§18) proving live-scan behavior is unchanged for any not-yet-gated collection. No visibility/authz parameter is wired to a real decision yet — `visibility` defaults to "management" (today's ungated behavior) for every caller, matching current production behavior exactly.
+
+**Phase 3 — Backfill.**
+Build and run the one-shot backfill job (diff-based per-collection rewrite, condition set only on full completion). Monitor coverage; do not delete the fallback branch until 100% of collections across all namespaces report `MembershipBackfilled`.
+
+**Phase 4 — Fallback removal.**
+Delete the live-scan fallback branch and `BuildProductConnectionFromSlice`'s usage for this path entirely. `ListCollectionMembers`/`CollectionMemberCount` become the sole source of truth for `Collection.products`/`memberCount`.
+
+**Phase 5 — 022 integration (sequenced with 022's own rollout, not before).**
+Implement the public-scoped twin tables (`collection_membership_public_by_collection`, `collection_membership_public_by_product`), wire the visibility-transition trigger (§12.4/item 3 in §19), wire `visibility` to a real authz decision derived from `auth.PrincipalFromContext`, and only then enable enforcement — per §12.3's explicit sequencing requirement that this phase must not ship ahead of both 022 itself and the visibility-transition trigger.
+
+Relevant files referenced throughout: `gitstore-api/internal/graph/resolver/collection.resolvers.go:20-55`, `gitstore-api/internal/graph/resolver/pagination.go:14-266`, `gitstore-api/internal/datastore/memdb/backend.go:18-33,114-127,592-607,686,771`, `gitstore-api/internal/datastore/scylla/backend.go:793-816,1140-1159`, `gitstore-api/internal/datastore/scylla/migrations/001_initial_schema.cql`, `gitstore-api/internal/datastore/scylla/pagination.go:72-121`, `gitstore-api/internal/catalog/collection.go:16-36`, `gitstore-api/internal/catalog/selector.go:8-46`, `gitstore-api/internal/catalog/selector_test.go:16-107`, `gitstore-api/internal/datastore/datastore.go:83-127,134-212`, `gitstore-api/internal/middleware/security/graphql.go:39-42,46-122`, `gitstore-api/internal/auth/provider/rbaclocal/provider.go:52-92`, `gitstore-api/internal/eventbus/eventbus.go`, `gitstore-controller-manager/internal/categorytaxonomy/reconciler.go:87-190`, `gitstore-controller-manager/internal/categorytaxonomy/products.go:44-116`, `gitstore-controller-manager/cmd/controller/main.go:130-139,170-212`, `gitstore-controller-manager/internal/status/patch.go`, `shared/schemas/collection.graphqls:156-256`, `shared/schemas/category.graphqls:161-224`, `docs/implementation/022-opa-data-authorization.md` (§2-3, §7, §12-13).

--- a/docs/implementation/099-ci-implementation-options.md
+++ b/docs/implementation/099-ci-implementation-options.md
@@ -1,7 +1,7 @@
 # CI Implementation Options for GitStore Actions
 
 **Date**: 2026-06-06
-**Status**: Exploration
+**Status**: 🟡 Exploration
 
 ## Goal
 

--- a/docs/implementation/T152-PROPER-GIT-PROTOCOL.md
+++ b/docs/implementation/T152-PROPER-GIT-PROTOCOL.md
@@ -1,7 +1,7 @@
 # T152: Implement Proper Git Protocol Solution (Production Architecture)
 
 **Date Updated**: 2026-05-09  
-**Status**: 🚫 SUPERSEDED by 004 (gRPC git service)  
+**Status**: 🚫 SUPERSEDED by [Spec 004 (gRPC git service)](../../specs/004-grpc-git-service)
 **Priority**: MEDIUM (not blocking MVP, but needed for production)  
 
 ---


### PR DESCRIPTION
## Summary

- document the proposed embedded OPA model for data-aware GraphQL catalog authorization, including semantic scopes, hybrid IAM ownership, fail-closed behavior, and authorization-aware query projections
- define a materialized collection-membership architecture for deterministic paginated product access, including consistency, backfill, cursor, and information-leak constraints
- refresh related implementation documents with corrected statuses, rollout phases, dependency references, and links to the new designs

## Testing

- Documentation-only changes; no runtime tests required
- `git diff --cached --check`
