### PR TITLE
fix: wrap authz provider with decision logger

### DIFF
--- a/gitstore-api/internal/app/server.go
+++ b/gitstore-api/internal/app/server.go
@@ -361,6 +361,9 @@ func buildProviderRegistry(cfg *config.Config, log *zap.Logger) (*auth.ProviderR
 	default:
 		return nil, nil, nil, fmt.Errorf("unknown authz provider %q", cfg.Auth.AuthZ.Provider)
 	}
+	// DecisionLogger is the required middleware that keeps every AuthZ decision
+	// consistent with the pluggable auth architecture audit contract.
+	authzProvider = auth.NewDecisionLogger(authzProvider, log)
 
 	// Build UserDir provider.
 	userdirProvider := userdirnone.New()

--- a/gitstore-api/internal/auth/logging.go
+++ b/gitstore-api/internal/auth/logging.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/gitstore-dev/gitstore/api/internal/middleware"
 	"go.uber.org/zap"
 )
 
@@ -32,6 +33,15 @@ func (d *DecisionLogger) Authorize(ctx context.Context, p *Principal, action str
 	decision, err := d.inner.Authorize(ctx, p, action, res)
 	latencyMs := time.Since(start).Milliseconds()
 
+	if decision.Provider == "" {
+		decision.Provider = d.inner.Name()
+	}
+	if decision.RequestID == "" && ctx != nil {
+		if requestID, ok := ctx.Value(middleware.RequestIDKey).(string); ok {
+			decision.RequestID = requestID
+		}
+	}
+
 	subject := "anon"
 	if p != nil {
 		subject = p.Subject
@@ -51,6 +61,7 @@ func (d *DecisionLogger) Authorize(ctx context.Context, p *Principal, action str
 		zap.String("action", action),
 		zap.String("resource_kind", res.Kind),
 		zap.String("resource_name", res.Name),
+		zap.String("request_id", decision.RequestID),
 		zap.String("outcome", outcomeStr),
 		zap.String("reason", decision.Reason),
 		zap.Int64("latency_ms", latencyMs),

--- a/gitstore-api/internal/auth/logging_test.go
+++ b/gitstore-api/internal/auth/logging_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	authpkg "github.com/gitstore-dev/gitstore/api/internal/auth"
+	"github.com/gitstore-dev/gitstore/api/internal/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type staticAuthZProvider struct {
+	name     string
+	decision authpkg.Decision
+}
+
+func (s *staticAuthZProvider) Name() string { return s.name }
+
+func (s *staticAuthZProvider) Authorize(_ context.Context, _ *authpkg.Principal, _ string, _ authpkg.ResourceContext) (authpkg.Decision, error) {
+	return s.decision, nil
+}
+
+func TestDecisionLogger_EmitsStructuredFieldsAndRequestID(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+	provider := authpkg.NewDecisionLogger(&staticAuthZProvider{
+		name:     "rbac-local",
+		decision: authpkg.Allow("rbac-local", "allowed by policy"),
+	}, logger)
+
+	ctx := context.WithValue(context.Background(), middleware.RequestIDKey, "req-123")
+	decision, err := provider.Authorize(ctx, &authpkg.Principal{
+		Subject:    "alice",
+		Roles:      []string{"reader"},
+		AuthMethod: "test",
+	}, "namespace.read", authpkg.ResourceContext{Kind: "namespace", Name: "demo"})
+	require.NoError(t, err)
+	assert.Equal(t, "req-123", decision.RequestID)
+
+	entries := logs.All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "authz decision", entries[0].Message)
+
+	fields := entries[0].ContextMap()
+	assert.Equal(t, "rbac-local", fields["provider"])
+	assert.Equal(t, "alice", fields["subject"])
+	assert.Equal(t, "namespace.read", fields["action"])
+	assert.Equal(t, "namespace", fields["resource_kind"])
+	assert.Equal(t, "demo", fields["resource_name"])
+	assert.Equal(t, "req-123", fields["request_id"])
+	assert.Equal(t, "allow", fields["outcome"])
+}


### PR DESCRIPTION
Wrap the live authz provider in DecisionLogger so every authorization decision emits the required structured audit fields and request_id. This also adds a focused regression test for the middleware.