### PR TITLE
feat(scylla): harden projections and recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,16 @@ NAMESPACE_DISPLAY_NAME ?= GitStore Test
 NAMESPACE_TIER ?= USER
 REPOSITORY ?= catalog
 DEFAULT_BRANCH ?= main
+SCYLLA_TEST_ADDR ?= 127.0.0.1:9042
+SCYLLA_CAPACITY_PRODUCTS ?= 5000000
+SCYLLA_CAPACITY_CONCURRENCY ?= 32
+SCYLLA_CAPACITY_DURATION ?= 10m
 
 export API_URL ADMIN_USERNAME ADMIN_PASSWORD BOOTSTRAP_TOKEN BOOTSTRAP_TOKEN_CACHE
 export NAMESPACE NAMESPACE_DISPLAY_NAME NAMESPACE_TIER REPOSITORY DEFAULT_BRANCH
 
 .PHONY: help git api controller dev compose scylla compose-scylla ps logs stop down
-.PHONY: build test lint license-check pr-ready
+.PHONY: build test lint license-check pr-ready test-scylla-hardening test-scylla-integration test-scylla-capacity
 .PHONY: bootstrap bootstrap-token bootstrap-namespace bootstrap-repository git-clean-data
 .PHONY: admin-compose admin-down admin-stop admin-logs bootstrap-tools gen-admin-password gen-jwt-secret gen-hmac-secret
 
@@ -46,6 +50,10 @@ help: ## Show available targets and common variables.
 	@printf "  API_URL=%s\n" "$(API_URL)"
 	@printf "  ADMIN_USERNAME=%s\n" "$(ADMIN_USERNAME)"
 	@printf "  ADMIN_PASSWORD=<password> Required for login unless BOOTSTRAP_TOKEN or cached token is available\n"
+	@printf "  SCYLLA_TEST_ADDR=%s\n" "$(SCYLLA_TEST_ADDR)"
+	@printf "  SCYLLA_CAPACITY_PRODUCTS=%s\n" "$(SCYLLA_CAPACITY_PRODUCTS)"
+	@printf "  SCYLLA_CAPACITY_CONCURRENCY=%s\n" "$(SCYLLA_CAPACITY_CONCURRENCY)"
+	@printf "  SCYLLA_CAPACITY_DURATION=%s\n" "$(SCYLLA_CAPACITY_DURATION)"
 	@printf "  BOOTSTRAP_TOKEN=<token>   Use an existing bearer token for bootstrap\n"
 	@printf "  NAMESPACE=%s REPOSITORY=%s DEFAULT_BRANCH=%s\n" "$(NAMESPACE)" "$(REPOSITORY)" "$(DEFAULT_BRANCH)"
 
@@ -144,6 +152,21 @@ test: ## Run Rust and Go test suites.
 	@cd "$(GIT_SERVICE_DIR)" && cargo test --verbose
 	@cd "$(API_DIR)" && go test -count=1 -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 	@cd "$(CONTROLLER_MANAGER_DIR)" && go test -count=1 -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+test-scylla-hardening: ## Run focused datastore hardening tests without an external Scylla instance.
+	@cd "$(API_DIR)" && go test -count=1 ./internal/datastore/... ./tests/contract/datastore/...
+
+test-scylla-integration: ## Run tagged datastore hardening tests against Scylla.
+	@cd "$(API_DIR)" && GITSTORE_TEST_SCYLLA_ADDR="$(SCYLLA_TEST_ADDR)" \
+		go test -tags scylla -count=1 -timeout 180s ./internal/datastore/scylla/... ./tests/contract/datastore/...
+
+test-scylla-capacity: ## Run the opt-in Scylla capacity and soak test.
+	@cd "$(API_DIR)" && GITSTORE_TEST_SCYLLA_ADDR="$(SCYLLA_TEST_ADDR)" \
+		GITSTORE_SCYLLA_CAPACITY_PRODUCTS="$(SCYLLA_CAPACITY_PRODUCTS)" \
+		GITSTORE_SCYLLA_CAPACITY_CONCURRENCY="$(SCYLLA_CAPACITY_CONCURRENCY)" \
+		GITSTORE_SCYLLA_CAPACITY_DURATION="$(SCYLLA_CAPACITY_DURATION)" \
+		GITSTORE_SCYLLA_CAPACITY_RUN=1 \
+		go test -tags scylla -count=1 -timeout 0 -run TestScyllaCapacity ./internal/datastore/scylla/...
 
 lint: ## Run Rust formatting/clippy and Go formatting/vet/staticcheck.
 	@cd "$(GIT_SERVICE_DIR)" && cargo fmt --all -- --check

--- a/gitstore-api/cmd/gitctl/main.go
+++ b/gitstore-api/cmd/gitctl/main.go
@@ -5,66 +5,223 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
+	"flag"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
 	"strings"
 
+	"github.com/gitstore-dev/gitstore/api/internal/config"
+	"github.com/gitstore-dev/gitstore/api/internal/datastore/scylla"
 	"golang.org/x/crypto/bcrypt"
 )
 
+type projectionRepairClient interface {
+	Audit(context.Context) (scylla.RepairPlan, error)
+	Apply(context.Context, scylla.RepairPlan) (scylla.RepairResult, error)
+	Close()
+}
+
+var openProjectionRepair = func(cfg config.ScyllaConfig) (projectionRepairClient, error) {
+	return scylla.OpenProjectionRepairService(cfg)
+}
+
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "Usage: gitctl <subcommand> [args]\n")
-		fmt.Fprintf(os.Stderr, "Subcommands:\n")
-		fmt.Fprintf(os.Stderr, "  hash-password <password>\n")
-		fmt.Fprintf(os.Stderr, "  gen-jwt-secret\n")
-		fmt.Fprintf(os.Stderr, "  gen-hmac-secret\n")
-		os.Exit(2)
+	os.Exit(run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		printUsage(stderr)
+		return 2
 	}
 
-	switch os.Args[1] {
+	switch args[0] {
 	case "hash-password":
 		var password string
-		if len(os.Args) >= 3 {
-			password = os.Args[2]
+		if len(args) >= 2 {
+			password = args[1]
 		} else {
-			// Read from stdin to avoid exposing the password in the process list.
-			scanner := bufio.NewScanner(os.Stdin)
+			scanner := bufio.NewScanner(stdin)
 			if !scanner.Scan() {
-				fmt.Fprintf(os.Stderr, "Error reading password from stdin\n")
-				os.Exit(1)
+				fmt.Fprintln(stderr, "Error reading password from stdin")
+				return 1
 			}
 			password = strings.TrimRight(scanner.Text(), "\r\n")
 		}
 		hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error generating hash: %v\n", err)
-			os.Exit(1)
+			fmt.Fprintf(stderr, "Error generating hash: %v\n", err)
+			return 1
 		}
-		fmt.Println(string(hash))
+		fmt.Fprintln(stdout, string(hash))
+		return 0
 
 	case "gen-jwt-secret":
-		secret, err := randomBase64URLSecret()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error generating secret: %v\n", err)
-			os.Exit(1)
-		}
-		fmt.Printf("GITSTORE_AUTH__JWT__SECRET=%s\n", secret)
+		return printSecret(stdout, stderr, "GITSTORE_AUTH__JWT__SECRET")
 
 	case "gen-hmac-secret":
-		secret, err := randomBase64URLSecret()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error generating secret: %v\n", err)
-			os.Exit(1)
-		}
-		fmt.Printf("GITSTORE_AUTH__GRPC__HMAC_SECRET=%s\n", secret)
+		return printSecret(stdout, stderr, "GITSTORE_AUTH__GRPC__HMAC_SECRET")
+
+	case "scylla-projection-audit":
+		return runProjectionAudit(args[1:], stdout, stderr)
+
+	case "scylla-projection-repair":
+		return runProjectionRepair(args[1:], stdout, stderr)
 
 	default:
-		fmt.Fprintf(os.Stderr, "Unknown subcommand: %s\n", os.Args[1])
-		os.Exit(2)
+		fmt.Fprintf(stderr, "Unknown subcommand: %s\n", args[0])
+		printUsage(stderr)
+		return 2
 	}
+}
+
+func printUsage(output io.Writer) {
+	fmt.Fprintln(output, "Usage: gitctl <subcommand> [args]")
+	fmt.Fprintln(output, "Subcommands:")
+	fmt.Fprintln(output, "  hash-password <password>")
+	fmt.Fprintln(output, "  gen-jwt-secret")
+	fmt.Fprintln(output, "  gen-hmac-secret")
+	fmt.Fprintln(output, "  scylla-projection-audit [Scylla flags]")
+	fmt.Fprintln(output, "  scylla-projection-repair (--dry-run | --confirm) [Scylla flags]")
+}
+
+func printSecret(stdout, stderr io.Writer, key string) int {
+	secret, err := randomBase64URLSecret()
+	if err != nil {
+		fmt.Fprintf(stderr, "Error generating secret: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "%s=%s\n", key, secret)
+	return 0
+}
+
+func runProjectionAudit(args []string, stdout, stderr io.Writer) int {
+	flags, cfg := newScyllaFlagSet("scylla-projection-audit", stderr)
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	client, err := openProjectionRepair(cfg())
+	if err != nil {
+		fmt.Fprintf(stderr, "Error opening Scylla projection audit: %v\n", err)
+		return 1
+	}
+	defer client.Close()
+
+	plan, err := client.Audit(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "Error auditing Scylla projections: %v\n", err)
+		return 1
+	}
+	if err := writeJSON(stdout, plan); err != nil {
+		fmt.Fprintf(stderr, "Error writing audit result: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runProjectionRepair(args []string, stdout, stderr io.Writer) int {
+	flags, cfg := newScyllaFlagSet("scylla-projection-repair", stderr)
+	dryRun := flags.Bool("dry-run", false, "print the repair plan without mutating Scylla")
+	confirm := flags.Bool("confirm", false, "confirm conditional projection mutations")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if !*dryRun && !*confirm {
+		fmt.Fprintln(stderr, "scylla-projection-repair requires --dry-run or explicit --confirm")
+		return 2
+	}
+
+	client, err := openProjectionRepair(cfg())
+	if err != nil {
+		fmt.Fprintf(stderr, "Error opening Scylla projection repair: %v\n", err)
+		return 1
+	}
+	defer client.Close()
+
+	plan, err := client.Audit(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "Error planning Scylla projection repair: %v\n", err)
+		return 1
+	}
+	if *dryRun {
+		if err := writeJSON(stdout, plan); err != nil {
+			fmt.Fprintf(stderr, "Error writing repair plan: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	result, err := client.Apply(context.Background(), plan)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error applying Scylla projection repair: %v\n", err)
+		if writeErr := writeJSON(stdout, result); writeErr != nil {
+			fmt.Fprintf(stderr, "Error writing partial repair result: %v\n", writeErr)
+		}
+		return 1
+	}
+	if err := writeJSON(stdout, result); err != nil {
+		fmt.Fprintf(stderr, "Error writing repair result: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func newScyllaFlagSet(name string, stderr io.Writer) (*flag.FlagSet, func() config.ScyllaConfig) {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	hosts := flags.String("hosts", envOrDefault("GITSTORE_DATASTORE__SCYLLA__HOSTS", "localhost:9042"), "comma-separated Scylla host:port endpoints")
+	keyspace := flags.String("keyspace", envOrDefault("GITSTORE_DATASTORE__SCYLLA__KEYSPACE", "gitstore"), "Scylla keyspace")
+	username := flags.String("username", os.Getenv("GITSTORE_DATASTORE__SCYLLA__USERNAME"), "Scylla username")
+	tls := flags.Bool("tls", envBool("GITSTORE_DATASTORE__SCYLLA__TLS"), "enable TLS")
+	disableShardAware := flags.Bool(
+		"disable-shard-aware-port",
+		envBool("GITSTORE_DATASTORE__SCYLLA__DISABLE_SHARD_AWARE_PORT"),
+		"disable shard-aware port discovery",
+	)
+	return flags, func() config.ScyllaConfig {
+		return config.ScyllaConfig{
+			Hosts:                 splitNonEmpty(*hosts),
+			Keyspace:              *keyspace,
+			Username:              *username,
+			Password:              os.Getenv("GITSTORE_DATASTORE__SCYLLA__PASSWORD"),
+			TLS:                   *tls,
+			DisableShardAwarePort: *disableShardAware,
+		}
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func envBool(key string) bool {
+	value, err := strconv.ParseBool(os.Getenv(key))
+	return err == nil && value
+}
+
+func splitNonEmpty(value string) []string {
+	var result []string
+	for _, item := range strings.Split(value, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func writeJSON(output io.Writer, value any) error {
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
 }
 
 func randomBase64URLSecret() (string, error) {

--- a/gitstore-api/cmd/gitctl/main_test.go
+++ b/gitstore-api/cmd/gitctl/main_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitstore-dev/gitstore/api/internal/config"
+	"github.com/gitstore-dev/gitstore/api/internal/datastore/scylla"
+)
+
+func TestProjectionRepairRequiresExplicitConfirmation(t *testing.T) {
+	original := openProjectionRepair
+	t.Cleanup(func() { openProjectionRepair = original })
+	called := false
+	openProjectionRepair = func(config.ScyllaConfig) (projectionRepairClient, error) {
+		called = true
+		return &fakeProjectionRepairClient{}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"scylla-projection-repair"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("run() code = %d, want 2", code)
+	}
+	if called {
+		t.Fatal("repair opened Scylla without confirmation")
+	}
+	if !strings.Contains(stderr.String(), "--dry-run or explicit --confirm") {
+		t.Fatalf("stderr = %q, want confirmation guidance", stderr.String())
+	}
+}
+
+func TestProjectionRepairDryRunPrintsPlanWithoutApply(t *testing.T) {
+	client := &fakeProjectionRepairClient{
+		plan: scylla.RepairPlan{Findings: []scylla.ProjectionFinding{{
+			Type: scylla.FindingMissing, Kind: "Namespace", UID: "uid",
+			Table: "namespaces_by_name", Key: "demo", Repairable: true,
+		}}},
+	}
+	withFakeProjectionClient(t, client)
+
+	var stdout, stderr bytes.Buffer
+	code := run(
+		[]string{"scylla-projection-repair", "--dry-run", "--hosts", "scylla-a:9042,scylla-b:9042"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if client.applyCalls != 0 {
+		t.Fatalf("dry run applied %d repairs", client.applyCalls)
+	}
+	if !strings.Contains(stdout.String(), `"type": "missing"`) {
+		t.Fatalf("stdout = %q, want stable JSON finding", stdout.String())
+	}
+}
+
+func TestProjectionRepairConfirmedAppliesAndVerifies(t *testing.T) {
+	client := &fakeProjectionRepairClient{
+		plan: scylla.RepairPlan{Actions: []scylla.RepairAction{{
+			Type: scylla.RepairInsert, Kind: "Namespace", UID: "uid", ExpectedResourceVersion: "7",
+			After: &scylla.ProjectionRecord{Table: "namespaces_by_name", UID: "uid", Name: "demo"},
+		}}},
+		result: scylla.RepairResult{PlannedActions: 1, AppliedActions: 1},
+	}
+	withFakeProjectionClient(t, client)
+
+	var stdout, stderr bytes.Buffer
+	code := run(
+		[]string{"scylla-projection-repair", "--confirm", "--keyspace", "gitstore"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if client.applyCalls != 1 {
+		t.Fatalf("apply calls = %d, want 1", client.applyCalls)
+	}
+	if !strings.Contains(stdout.String(), `"appliedActions": 1`) {
+		t.Fatalf("stdout = %q, want applied action summary", stdout.String())
+	}
+}
+
+func TestProjectionAuditPrintsMachineReadableSummary(t *testing.T) {
+	client := &fakeProjectionRepairClient{plan: scylla.RepairPlan{}}
+	withFakeProjectionClient(t, client)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"scylla-projection-audit"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != `{
+  "findings": null,
+  "actions": null
+}` {
+		t.Fatalf("stdout = %q, want stable JSON summary", stdout.String())
+	}
+}
+
+func withFakeProjectionClient(t *testing.T, client *fakeProjectionRepairClient) {
+	t.Helper()
+	original := openProjectionRepair
+	t.Cleanup(func() { openProjectionRepair = original })
+	openProjectionRepair = func(config.ScyllaConfig) (projectionRepairClient, error) {
+		return client, nil
+	}
+}
+
+type fakeProjectionRepairClient struct {
+	plan       scylla.RepairPlan
+	result     scylla.RepairResult
+	auditErr   error
+	applyErr   error
+	applyCalls int
+}
+
+func (f *fakeProjectionRepairClient) Audit(context.Context) (scylla.RepairPlan, error) {
+	return f.plan, f.auditErr
+}
+
+func (f *fakeProjectionRepairClient) Apply(context.Context, scylla.RepairPlan) (scylla.RepairResult, error) {
+	f.applyCalls++
+	return f.result, f.applyErr
+}
+
+func (f *fakeProjectionRepairClient) Close() {}

--- a/gitstore-api/internal/datastore/instrumented.go
+++ b/gitstore-api/internal/datastore/instrumented.go
@@ -6,6 +6,7 @@ package datastore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/gitstore-dev/gitstore/api/internal/catalog"
@@ -19,8 +20,7 @@ type InstrumentedDatastore struct {
 	next    Datastore
 	backend string
 	log     *zap.Logger
-	dur     *prometheus.HistogramVec
-	errs    *prometheus.CounterVec
+	metrics *datastoreMetrics
 }
 
 // NewInstrumentedDatastore returns a Datastore that records metrics and logs
@@ -33,18 +33,28 @@ func NewInstrumentedDatastore(next Datastore, backend string, log *zap.Logger) D
 // NewInstrumentedDatastoreWithRegistry is like NewInstrumentedDatastore but
 // registers metrics on reg, enabling isolated registries in tests.
 func NewInstrumentedDatastoreWithRegistry(next Datastore, backend string, log *zap.Logger, reg prometheus.Registerer) Datastore {
-	dur, errs := newMetrics(reg)
-	return &InstrumentedDatastore{next: next, backend: backend, log: log, dur: dur, errs: errs}
+	return &InstrumentedDatastore{next: next, backend: backend, log: log, metrics: newMetrics(reg)}
 }
 
 func (d *InstrumentedDatastore) observe(op string, start time.Time, err error) {
 	elapsed := time.Since(start)
-	d.dur.WithLabelValues(op, d.backend).Observe(elapsed.Seconds())
+	d.metrics.duration.WithLabelValues(op, d.backend).Observe(elapsed.Seconds())
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return
 		}
-		d.errs.WithLabelValues(op, d.backend).Inc()
+		d.metrics.errors.WithLabelValues(op, d.backend).Inc()
+		var repair *RepairRequiredError
+		if errors.As(err, &repair) {
+			kind := repair.Step.ResourceKind
+			projection := repair.Step.Projection
+			operation := repair.Step.Operation
+			d.metrics.projectionFailures.WithLabelValues(operation, d.backend, kind, projection).Inc()
+			d.metrics.compensationAttempts.WithLabelValues(operation, d.backend, kind, projection).Inc()
+			if repair.Compensation != nil {
+				d.metrics.compensationFailures.WithLabelValues(operation, d.backend, kind, projection).Inc()
+			}
+		}
 		d.log.Error("datastore operation failed",
 			zap.String("operation", op),
 			zap.String("backend", d.backend),
@@ -54,46 +64,69 @@ func (d *InstrumentedDatastore) observe(op string, start time.Time, err error) {
 	}
 }
 
+func (d *InstrumentedDatastore) observeFinding(finding ProjectionFinding) {
+	d.metrics.findings.WithLabelValues(
+		finding.Operation,
+		d.backend,
+		finding.ResourceKind,
+		finding.Projection,
+		string(finding.Type),
+	).Inc()
+	d.log.Warn("datastore projection inconsistency",
+		zap.String("operation", finding.Operation),
+		zap.String("backend", d.backend),
+		zap.String("resource_kind", finding.ResourceKind),
+		zap.String("resource_uid", finding.ResourceUID),
+		zap.String("projection", finding.Projection),
+		zap.String("lookup_key", finding.LookupKey),
+		zap.String("finding_type", string(finding.Type)),
+	)
+}
+
+func (d *InstrumentedDatastore) withFindingObserver(ctx context.Context) context.Context {
+	return WithProjectionFindingObserver(ctx, d.observeFinding)
+}
+
 // ── Product ────────────────────────────────────────────────────────────────
 
 func (d *InstrumentedDatastore) CreateProduct(ctx context.Context, p *Product) error {
 	start := time.Now()
-	err := d.next.CreateProduct(ctx, p)
+	err := d.next.CreateProduct(d.withFindingObserver(ctx), p)
 	d.observe("CreateProduct", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) GetProduct(ctx context.Context, id string) (*Product, error) {
 	start := time.Now()
-	v, err := d.next.GetProduct(ctx, id)
+	v, err := d.next.GetProduct(d.withFindingObserver(ctx), id)
 	d.observe("GetProduct", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) GetProductByName(ctx context.Context, namespace, name string) (*Product, error) {
 	start := time.Now()
-	v, err := d.next.GetProductByName(ctx, namespace, name)
+	v, err := d.next.GetProductByName(d.withFindingObserver(ctx), namespace, name)
 	d.observe("GetProductByName", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) ListProducts(ctx context.Context, namespace string, params PageParams) (*PageResult[Product], error) {
 	start := time.Now()
-	v, err := d.next.ListProducts(ctx, namespace, params)
+	v, err := d.next.ListProducts(d.withFindingObserver(ctx), namespace, params)
 	d.observe("ListProducts", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) UpdateProduct(ctx context.Context, p *Product) error {
 	start := time.Now()
-	err := d.next.UpdateProduct(ctx, p)
+	err := d.next.UpdateProduct(d.withFindingObserver(ctx), p)
 	d.observe("UpdateProduct", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) DeleteProduct(ctx context.Context, id string) error {
 	start := time.Now()
-	err := d.next.DeleteProduct(ctx, id)
+	err := d.next.DeleteProduct(d.withFindingObserver(ctx), id)
 	d.observe("DeleteProduct", start, err)
 	return err
 }
@@ -102,49 +135,49 @@ func (d *InstrumentedDatastore) DeleteProduct(ctx context.Context, id string) er
 
 func (d *InstrumentedDatastore) CreateCategoryTaxonomy(ctx context.Context, c *CategoryTaxonomy) error {
 	start := time.Now()
-	err := d.next.CreateCategoryTaxonomy(ctx, c)
+	err := d.next.CreateCategoryTaxonomy(d.withFindingObserver(ctx), c)
 	d.observe("CreateCategoryTaxonomy", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) GetCategoryTaxonomy(ctx context.Context, uid string) (*CategoryTaxonomy, error) {
 	start := time.Now()
-	v, err := d.next.GetCategoryTaxonomy(ctx, uid)
+	v, err := d.next.GetCategoryTaxonomy(d.withFindingObserver(ctx), uid)
 	d.observe("GetCategoryTaxonomy", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) GetCategoryTaxonomyByName(ctx context.Context, namespace, name string) (*CategoryTaxonomy, error) {
 	start := time.Now()
-	v, err := d.next.GetCategoryTaxonomyByName(ctx, namespace, name)
+	v, err := d.next.GetCategoryTaxonomyByName(d.withFindingObserver(ctx), namespace, name)
 	d.observe("GetCategoryTaxonomyByName", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) ListCategoryTaxonomies(ctx context.Context, namespace string, params PageParams) (*PageResult[CategoryTaxonomy], error) {
 	start := time.Now()
-	v, err := d.next.ListCategoryTaxonomies(ctx, namespace, params)
+	v, err := d.next.ListCategoryTaxonomies(d.withFindingObserver(ctx), namespace, params)
 	d.observe("ListCategoryTaxonomies", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) UpdateCategoryTaxonomy(ctx context.Context, c *CategoryTaxonomy) error {
 	start := time.Now()
-	err := d.next.UpdateCategoryTaxonomy(ctx, c)
+	err := d.next.UpdateCategoryTaxonomy(d.withFindingObserver(ctx), c)
 	d.observe("UpdateCategoryTaxonomy", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) UpdateCategoryTaxonomyStatus(ctx context.Context, namespace, name string, patch CategoryTaxonomyStatusPatch) (*CategoryTaxonomy, error) {
 	start := time.Now()
-	c, err := d.next.UpdateCategoryTaxonomyStatus(ctx, namespace, name, patch)
+	c, err := d.next.UpdateCategoryTaxonomyStatus(d.withFindingObserver(ctx), namespace, name, patch)
 	d.observe("UpdateCategoryTaxonomyStatus", start, err)
 	return c, err
 }
 
 func (d *InstrumentedDatastore) DeleteCategoryTaxonomy(ctx context.Context, uid string) error {
 	start := time.Now()
-	err := d.next.DeleteCategoryTaxonomy(ctx, uid)
+	err := d.next.DeleteCategoryTaxonomy(d.withFindingObserver(ctx), uid)
 	d.observe("DeleteCategoryTaxonomy", start, err)
 	return err
 }
@@ -153,56 +186,56 @@ func (d *InstrumentedDatastore) DeleteCategoryTaxonomy(ctx context.Context, uid 
 
 func (d *InstrumentedDatastore) CreateProductVariant(ctx context.Context, v *ProductVariant) error {
 	start := time.Now()
-	err := d.next.CreateProductVariant(ctx, v)
+	err := d.next.CreateProductVariant(d.withFindingObserver(ctx), v)
 	d.observe("CreateProductVariant", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) GetProductVariant(ctx context.Context, uid string) (*ProductVariant, error) {
 	start := time.Now()
-	result, err := d.next.GetProductVariant(ctx, uid)
+	result, err := d.next.GetProductVariant(d.withFindingObserver(ctx), uid)
 	d.observe("GetProductVariant", start, err)
 	return result, err
 }
 
 func (d *InstrumentedDatastore) GetProductVariantByName(ctx context.Context, namespace, name string) (*ProductVariant, error) {
 	start := time.Now()
-	result, err := d.next.GetProductVariantByName(ctx, namespace, name)
+	result, err := d.next.GetProductVariantByName(d.withFindingObserver(ctx), namespace, name)
 	d.observe("GetProductVariantByName", start, err)
 	return result, err
 }
 
 func (d *InstrumentedDatastore) GetProductVariantBySKU(ctx context.Context, namespace, sku string) (*ProductVariant, error) {
 	start := time.Now()
-	result, err := d.next.GetProductVariantBySKU(ctx, namespace, sku)
+	result, err := d.next.GetProductVariantBySKU(d.withFindingObserver(ctx), namespace, sku)
 	d.observe("GetProductVariantBySKU", start, err)
 	return result, err
 }
 
 func (d *InstrumentedDatastore) ListProductVariants(ctx context.Context, namespace string, params PageParams) (*PageResult[ProductVariant], error) {
 	start := time.Now()
-	result, err := d.next.ListProductVariants(ctx, namespace, params)
+	result, err := d.next.ListProductVariants(d.withFindingObserver(ctx), namespace, params)
 	d.observe("ListProductVariants", start, err)
 	return result, err
 }
 
 func (d *InstrumentedDatastore) ListProductVariantsByProductRef(ctx context.Context, namespace, productRefName string) ([]*ProductVariant, error) {
 	start := time.Now()
-	result, err := d.next.ListProductVariantsByProductRef(ctx, namespace, productRefName)
+	result, err := d.next.ListProductVariantsByProductRef(d.withFindingObserver(ctx), namespace, productRefName)
 	d.observe("ListProductVariantsByProductRef", start, err)
 	return result, err
 }
 
 func (d *InstrumentedDatastore) UpdateProductVariant(ctx context.Context, v *ProductVariant) error {
 	start := time.Now()
-	err := d.next.UpdateProductVariant(ctx, v)
+	err := d.next.UpdateProductVariant(d.withFindingObserver(ctx), v)
 	d.observe("UpdateProductVariant", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) DeleteProductVariant(ctx context.Context, uid string) error {
 	start := time.Now()
-	err := d.next.DeleteProductVariant(ctx, uid)
+	err := d.next.DeleteProductVariant(d.withFindingObserver(ctx), uid)
 	d.observe("DeleteProductVariant", start, err)
 	return err
 }
@@ -211,49 +244,49 @@ func (d *InstrumentedDatastore) DeleteProductVariant(ctx context.Context, uid st
 
 func (d *InstrumentedDatastore) CreateCollection(ctx context.Context, c *Collection) error {
 	start := time.Now()
-	err := d.next.CreateCollection(ctx, c)
+	err := d.next.CreateCollection(d.withFindingObserver(ctx), c)
 	d.observe("CreateCollection", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) GetCollection(ctx context.Context, uid string) (*Collection, error) {
 	start := time.Now()
-	v, err := d.next.GetCollection(ctx, uid)
+	v, err := d.next.GetCollection(d.withFindingObserver(ctx), uid)
 	d.observe("GetCollection", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) GetCollectionByName(ctx context.Context, namespace, name string) (*Collection, error) {
 	start := time.Now()
-	v, err := d.next.GetCollectionByName(ctx, namespace, name)
+	v, err := d.next.GetCollectionByName(d.withFindingObserver(ctx), namespace, name)
 	d.observe("GetCollectionByName", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) ListCollections(ctx context.Context, namespace string, params PageParams) (*PageResult[Collection], error) {
 	start := time.Now()
-	v, err := d.next.ListCollections(ctx, namespace, params)
+	v, err := d.next.ListCollections(d.withFindingObserver(ctx), namespace, params)
 	d.observe("ListCollections", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) UpdateCollection(ctx context.Context, c *Collection) error {
 	start := time.Now()
-	err := d.next.UpdateCollection(ctx, c)
+	err := d.next.UpdateCollection(d.withFindingObserver(ctx), c)
 	d.observe("UpdateCollection", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) DeleteCollection(ctx context.Context, uid string) error {
 	start := time.Now()
-	err := d.next.DeleteCollection(ctx, uid)
+	err := d.next.DeleteCollection(d.withFindingObserver(ctx), uid)
 	d.observe("DeleteCollection", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) ListProductsByLabelSelector(ctx context.Context, namespace string, selector catalog.LabelSelector) ([]*Product, error) {
 	start := time.Now()
-	v, err := d.next.ListProductsByLabelSelector(ctx, namespace, selector)
+	v, err := d.next.ListProductsByLabelSelector(d.withFindingObserver(ctx), namespace, selector)
 	d.observe("ListProductsByLabelSelector", start, err)
 	return v, err
 }
@@ -262,56 +295,56 @@ func (d *InstrumentedDatastore) ListProductsByLabelSelector(ctx context.Context,
 
 func (d *InstrumentedDatastore) CreateNamespace(ctx context.Context, ns *Namespace) error {
 	start := time.Now()
-	err := d.next.CreateNamespace(ctx, ns)
+	err := d.next.CreateNamespace(d.withFindingObserver(ctx), ns)
 	d.observe("CreateNamespace", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) GetNamespace(ctx context.Context, id string) (*Namespace, error) {
 	start := time.Now()
-	v, err := d.next.GetNamespace(ctx, id)
+	v, err := d.next.GetNamespace(d.withFindingObserver(ctx), id)
 	d.observe("GetNamespace", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) GetNamespaceByName(ctx context.Context, name string) (*Namespace, error) {
 	start := time.Now()
-	v, err := d.next.GetNamespaceByName(ctx, name)
+	v, err := d.next.GetNamespaceByName(d.withFindingObserver(ctx), name)
 	d.observe("GetNamespaceByName", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) ListNamespaces(ctx context.Context, params PageParams) (*PageResult[Namespace], error) {
 	start := time.Now()
-	v, err := d.next.ListNamespaces(ctx, params)
+	v, err := d.next.ListNamespaces(d.withFindingObserver(ctx), params)
 	d.observe("ListNamespaces", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) UpdateNamespace(ctx context.Context, ns *Namespace, expectedResourceVersion string) error {
 	start := time.Now()
-	err := d.next.UpdateNamespace(ctx, ns, expectedResourceVersion)
+	err := d.next.UpdateNamespace(d.withFindingObserver(ctx), ns, expectedResourceVersion)
 	d.observe("UpdateNamespace", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) DeleteNamespace(ctx context.Context, id string) error {
 	start := time.Now()
-	err := d.next.DeleteNamespace(ctx, id)
+	err := d.next.DeleteNamespace(d.withFindingObserver(ctx), id)
 	d.observe("DeleteNamespace", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) DeleteNamespaceWithResourceVersion(ctx context.Context, id, expectedResourceVersion string) error {
 	start := time.Now()
-	err := d.next.DeleteNamespaceWithResourceVersion(ctx, id, expectedResourceVersion)
+	err := d.next.DeleteNamespaceWithResourceVersion(d.withFindingObserver(ctx), id, expectedResourceVersion)
 	d.observe("DeleteNamespaceWithResourceVersion", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) HasRepositories(ctx context.Context, namespaceID string) (bool, error) {
 	start := time.Now()
-	v, err := d.next.HasRepositories(ctx, namespaceID)
+	v, err := d.next.HasRepositories(d.withFindingObserver(ctx), namespaceID)
 	d.observe("HasRepositories", start, err)
 	return v, err
 }
@@ -320,42 +353,55 @@ func (d *InstrumentedDatastore) HasRepositories(ctx context.Context, namespaceID
 
 func (d *InstrumentedDatastore) CreateRepository(ctx context.Context, r *Repository) error {
 	start := time.Now()
-	err := d.next.CreateRepository(ctx, r)
+	err := d.next.CreateRepository(d.withFindingObserver(ctx), r)
 	d.observe("CreateRepository", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) GetRepository(ctx context.Context, id string) (*Repository, error) {
 	start := time.Now()
-	v, err := d.next.GetRepository(ctx, id)
+	v, err := d.next.GetRepository(d.withFindingObserver(ctx), id)
 	d.observe("GetRepository", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) ListRepositoriesByNamespace(ctx context.Context, namespaceID string, params PageParams) (*PageResult[Repository], error) {
 	start := time.Now()
-	v, err := d.next.ListRepositoriesByNamespace(ctx, namespaceID, params)
+	v, err := d.next.ListRepositoriesByNamespace(d.withFindingObserver(ctx), namespaceID, params)
 	d.observe("ListRepositoriesByNamespace", start, err)
+	return v, err
+}
+
+func (d *InstrumentedDatastore) ListRepositories(ctx context.Context, params PageParams) (*PageResult[Repository], error) {
+	start := time.Now()
+	lister, ok := d.next.(GlobalRepositoryLister)
+	if !ok {
+		err := fmt.Errorf("%w: backend does not support global repository listing", ErrInvalidArgument)
+		d.observe("ListRepositories", start, err)
+		return nil, err
+	}
+	v, err := lister.ListRepositories(d.withFindingObserver(ctx), params)
+	d.observe("ListRepositories", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) UpdateRepository(ctx context.Context, r *Repository, expectedResourceVersion string) error {
 	start := time.Now()
-	err := d.next.UpdateRepository(ctx, r, expectedResourceVersion)
+	err := d.next.UpdateRepository(d.withFindingObserver(ctx), r, expectedResourceVersion)
 	d.observe("UpdateRepository", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) DeleteRepository(ctx context.Context, id string) error {
 	start := time.Now()
-	err := d.next.DeleteRepository(ctx, id)
+	err := d.next.DeleteRepository(d.withFindingObserver(ctx), id)
 	d.observe("DeleteRepository", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) HasCatalogResources(ctx context.Context, repoID string) (bool, error) {
 	start := time.Now()
-	v, err := d.next.HasCatalogResources(ctx, repoID)
+	v, err := d.next.HasCatalogResources(d.withFindingObserver(ctx), repoID)
 	d.observe("HasCatalogResources", start, err)
 	return v, err
 }
@@ -364,42 +410,55 @@ func (d *InstrumentedDatastore) HasCatalogResources(ctx context.Context, repoID 
 
 func (d *InstrumentedDatastore) CreateNamespaceMapping(ctx context.Context, m *NamespaceMapping) error {
 	start := time.Now()
-	err := d.next.CreateNamespaceMapping(ctx, m)
+	err := d.next.CreateNamespaceMapping(d.withFindingObserver(ctx), m)
 	d.observe("CreateNamespaceMapping", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) LookupRepository(ctx context.Context, namespaceID, name string) (*NamespaceMapping, error) {
 	start := time.Now()
-	v, err := d.next.LookupRepository(ctx, namespaceID, name)
+	v, err := d.next.LookupRepository(d.withFindingObserver(ctx), namespaceID, name)
 	d.observe("LookupRepository", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) LookupNamespaceByRepoID(ctx context.Context, repoID string) (*NamespaceMapping, error) {
 	start := time.Now()
-	v, err := d.next.LookupNamespaceByRepoID(ctx, repoID)
+	v, err := d.next.LookupNamespaceByRepoID(d.withFindingObserver(ctx), repoID)
 	d.observe("LookupNamespaceByRepoID", start, err)
+	return v, err
+}
+
+func (d *InstrumentedDatastore) LookupNamespaceByRepositoryID(ctx context.Context, repositoryID string) (*NamespaceMapping, error) {
+	start := time.Now()
+	lookup, ok := d.next.(RepositoryNamespaceLookup)
+	if !ok {
+		err := fmt.Errorf("%w: backend does not support canonical repository namespace lookup", ErrInvalidArgument)
+		d.observe("LookupNamespaceByRepositoryID", start, err)
+		return nil, err
+	}
+	v, err := lookup.LookupNamespaceByRepositoryID(d.withFindingObserver(ctx), repositoryID)
+	d.observe("LookupNamespaceByRepositoryID", start, err)
 	return v, err
 }
 
 func (d *InstrumentedDatastore) RenameRepository(ctx context.Context, namespaceID, oldName, newName string) error {
 	start := time.Now()
-	err := d.next.RenameRepository(ctx, namespaceID, oldName, newName)
+	err := d.next.RenameRepository(d.withFindingObserver(ctx), namespaceID, oldName, newName)
 	d.observe("RenameRepository", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) TransferRepository(ctx context.Context, repoID, fromNamespaceID, toNamespaceID string) error {
 	start := time.Now()
-	err := d.next.TransferRepository(ctx, repoID, fromNamespaceID, toNamespaceID)
+	err := d.next.TransferRepository(d.withFindingObserver(ctx), repoID, fromNamespaceID, toNamespaceID)
 	d.observe("TransferRepository", start, err)
 	return err
 }
 
 func (d *InstrumentedDatastore) DeleteNamespaceMapping(ctx context.Context, namespaceID, name string) error {
 	start := time.Now()
-	err := d.next.DeleteNamespaceMapping(ctx, namespaceID, name)
+	err := d.next.DeleteNamespaceMapping(d.withFindingObserver(ctx), namespaceID, name)
 	d.observe("DeleteNamespaceMapping", start, err)
 	return err
 }

--- a/gitstore-api/internal/datastore/instrumented_test.go
+++ b/gitstore-api/internal/datastore/instrumented_test.go
@@ -19,14 +19,18 @@ import (
 
 // stubDatastore is a minimal Datastore stub for decorator tests.
 type stubDatastore struct {
-	getProductErr error
-	getProductVal *datastore.Product
+	getProductErr     error
+	getProductVal     *datastore.Product
+	getProductFinding *datastore.ProjectionFinding
 }
 
 func (s *stubDatastore) CreateProduct(_ context.Context, _ *datastore.Product) error {
 	return s.getProductErr
 }
-func (s *stubDatastore) GetProduct(_ context.Context, _ string) (*datastore.Product, error) {
+func (s *stubDatastore) GetProduct(ctx context.Context, _ string) (*datastore.Product, error) {
+	if s.getProductFinding != nil {
+		datastore.ReportProjectionFinding(ctx, *s.getProductFinding)
+	}
 	return s.getProductVal, s.getProductErr
 }
 func (s *stubDatastore) GetProductByName(_ context.Context, _, _ string) (*datastore.Product, error) {
@@ -173,7 +177,7 @@ func (s *stubDatastore) Close() error { return nil }
 // and a fresh Prometheus registry so tests don't collide with global metrics.
 func newTestInstrumented(t *testing.T, stub datastore.Datastore) (datastore.Datastore, *observer.ObservedLogs, *prometheus.Registry) {
 	t.Helper()
-	core, logs := observer.New(zap.ErrorLevel)
+	core, logs := observer.New(zap.DebugLevel)
 	log := zap.New(core)
 	reg := prometheus.NewRegistry()
 	return datastore.NewInstrumentedDatastoreWithRegistry(stub, "test-backend", log, reg), logs, reg
@@ -223,6 +227,37 @@ func histogramObservationCount(t *testing.T, reg *prometheus.Registry, op, backe
 				if opLabel == op && beLabel == backend {
 					return m.GetHistogram().GetSampleCount()
 				}
+			}
+		}
+	}
+	return 0
+}
+
+func labeledCounterValue(t *testing.T, reg *prometheus.Registry, metric string, labels map[string]string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != metric {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			matches := true
+			for key, want := range labels {
+				found := false
+				for _, lp := range m.GetLabel() {
+					if lp.GetName() == key && lp.GetValue() == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				return m.GetCounter().GetValue()
 			}
 		}
 	}
@@ -310,4 +345,65 @@ func TestInstrumentedDatastore_NoLogOnSuccess(t *testing.T) {
 	inst.GetProduct(context.Background(), "p1") //nolint:errcheck
 
 	assert.Equal(t, 0, logs.Len())
+}
+
+func TestInstrumentedDatastore_RepairRequiredMetricsUseBoundedLabels(t *testing.T) {
+	stub := &stubDatastore{getProductErr: datastore.NewRepairRequiredError(
+		datastore.MutationStep{
+			Operation:    "create",
+			ResourceKind: "Product",
+			Projection:   "products_by_name",
+			Action:       "reserve",
+		},
+		errors.New("primary"),
+		errors.New("compensation"),
+	)}
+	inst, logs, reg := newTestInstrumented(t, stub)
+
+	inst.GetProduct(context.Background(), "sensitive-resource-id") //nolint:errcheck
+
+	assert.Equal(t, float64(1), labeledCounterValue(t, reg,
+		"gitstore_datastore_projection_write_failures_total",
+		map[string]string{"operation": "create", "backend": "test-backend", "projection": "products_by_name"}))
+	assert.Equal(t, float64(1), labeledCounterValue(t, reg,
+		"gitstore_datastore_compensation_failures_total",
+		map[string]string{"operation": "create", "backend": "test-backend", "projection": "products_by_name"}))
+	require.Equal(t, 1, logs.Len())
+	assert.NotContains(t, logs.All()[0].ContextMap(), "resource_uid")
+}
+
+func TestInstrumentedDatastore_ProjectionFindingIsObserved(t *testing.T) {
+	finding := datastore.ProjectionFinding{
+		Operation:    "lookup",
+		ResourceKind: "Product",
+		ResourceUID:  "sensitive-resource-id",
+		Projection:   "products_by_name",
+		LookupKey:    "tenant/widget",
+		Type:         datastore.FindingDangling,
+	}
+	stub := &stubDatastore{
+		getProductVal:     &datastore.Product{UID: "p1"},
+		getProductFinding: &finding,
+	}
+	inst, logs, reg := newTestInstrumented(t, stub)
+	var callerObserved datastore.ProjectionFinding
+	ctx := datastore.WithProjectionFindingObserver(context.Background(), func(observed datastore.ProjectionFinding) {
+		callerObserved = observed
+	})
+
+	_, err := inst.GetProduct(ctx, "p1")
+	require.NoError(t, err)
+
+	assert.Equal(t, finding, callerObserved)
+	assert.Equal(t, float64(1), labeledCounterValue(t, reg,
+		"gitstore_datastore_projection_findings_total",
+		map[string]string{
+			"operation":     "lookup",
+			"backend":       "test-backend",
+			"resource_kind": "Product",
+			"projection":    "products_by_name",
+			"finding_type":  "dangling",
+		}))
+	require.Equal(t, 1, logs.Len())
+	assert.Equal(t, "datastore projection inconsistency", logs.All()[0].Message)
 }

--- a/gitstore-api/internal/datastore/metrics.go
+++ b/gitstore-api/internal/datastore/metrics.go
@@ -5,9 +5,18 @@ package datastore
 
 import "github.com/prometheus/client_golang/prometheus"
 
-// newMetrics creates a latency histogram and error counter registered on reg.
-func newMetrics(reg prometheus.Registerer) (*prometheus.HistogramVec, *prometheus.CounterVec) {
-	dur := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+type datastoreMetrics struct {
+	duration             *prometheus.HistogramVec
+	errors               *prometheus.CounterVec
+	projectionFailures   *prometheus.CounterVec
+	compensationAttempts *prometheus.CounterVec
+	compensationFailures *prometheus.CounterVec
+	findings             *prometheus.CounterVec
+}
+
+func newMetrics(reg prometheus.Registerer) *datastoreMetrics {
+	metrics := &datastoreMetrics{}
+	metrics.duration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "gitstore",
 		Subsystem: "datastore",
 		Name:      "operation_duration_seconds",
@@ -15,13 +24,48 @@ func newMetrics(reg prometheus.Registerer) (*prometheus.HistogramVec, *prometheu
 		Buckets:   prometheus.DefBuckets,
 	}, []string{"operation", "backend"})
 
-	errs := prometheus.NewCounterVec(prometheus.CounterOpts{
+	metrics.errors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "gitstore",
 		Subsystem: "datastore",
 		Name:      "operation_errors_total",
 		Help:      "Total datastore operation errors.",
 	}, []string{"operation", "backend"})
 
-	reg.MustRegister(dur, errs)
-	return dur, errs
+	metrics.projectionFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "gitstore",
+		Subsystem: "datastore",
+		Name:      "projection_write_failures_total",
+		Help:      "Projection write failures requiring compensation or repair.",
+	}, []string{"operation", "backend", "resource_kind", "projection"})
+
+	metrics.compensationAttempts = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "gitstore",
+		Subsystem: "datastore",
+		Name:      "compensation_attempts_total",
+		Help:      "Mutation compensation attempts.",
+	}, []string{"operation", "backend", "resource_kind", "projection"})
+
+	metrics.compensationFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "gitstore",
+		Subsystem: "datastore",
+		Name:      "compensation_failures_total",
+		Help:      "Mutation compensation failures requiring operator repair.",
+	}, []string{"operation", "backend", "resource_kind", "projection"})
+
+	metrics.findings = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "gitstore",
+		Subsystem: "datastore",
+		Name:      "projection_findings_total",
+		Help:      "Observed missing, dangling, duplicate, or stale projections.",
+	}, []string{"operation", "backend", "resource_kind", "projection", "finding_type"})
+
+	reg.MustRegister(
+		metrics.duration,
+		metrics.errors,
+		metrics.projectionFailures,
+		metrics.compensationAttempts,
+		metrics.compensationFailures,
+		metrics.findings,
+	)
+	return metrics
 }

--- a/gitstore-api/internal/datastore/recovery.go
+++ b/gitstore-api/internal/datastore/recovery.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var ErrRepairRequired = errors.New("datastore: repair required")
+
+type MutationStep struct {
+	Operation    string
+	ResourceKind string
+	ResourceUID  string
+	Projection   string
+	LookupKey    string
+	Action       string
+}
+
+type RepairRequiredError struct {
+	Step         MutationStep
+	Primary      error
+	Compensation error
+}
+
+func NewRepairRequiredError(step MutationStep, primary, compensation error) error {
+	return &RepairRequiredError{
+		Step:         step,
+		Primary:      primary,
+		Compensation: compensation,
+	}
+}
+
+func (e *RepairRequiredError) Error() string {
+	return fmt.Sprintf("%s: operation=%s resource_kind=%s projection=%s action=%s: primary=%v: compensation=%v",
+		ErrRepairRequired, e.Step.Operation, e.Step.ResourceKind, e.Step.Projection, e.Step.Action,
+		e.Primary, e.Compensation)
+}
+
+func (e *RepairRequiredError) Unwrap() error {
+	return errors.Join(ErrRepairRequired, e.Primary)
+}
+
+type FindingType string
+
+const (
+	FindingMissing   FindingType = "missing"
+	FindingDangling  FindingType = "dangling"
+	FindingDuplicate FindingType = "duplicate"
+	FindingStale     FindingType = "stale"
+)
+
+type ProjectionFinding struct {
+	ResourceKind string
+	ResourceUID  string
+	Projection   string
+	LookupKey    string
+	Operation    string
+	Type         FindingType
+}
+
+type ProjectionFindingObserver func(ProjectionFinding)
+
+type projectionFindingObserverKey struct{}
+
+func WithProjectionFindingObserver(ctx context.Context, observer ProjectionFindingObserver) context.Context {
+	if observer == nil {
+		return ctx
+	}
+	if existing, ok := ctx.Value(projectionFindingObserverKey{}).(ProjectionFindingObserver); ok {
+		next := observer
+		observer = func(finding ProjectionFinding) {
+			existing(finding)
+			next(finding)
+		}
+	}
+	return context.WithValue(ctx, projectionFindingObserverKey{}, observer)
+}
+
+func ReportProjectionFinding(ctx context.Context, finding ProjectionFinding) {
+	if ctx == nil {
+		return
+	}
+	if observer, ok := ctx.Value(projectionFindingObserverKey{}).(ProjectionFindingObserver); ok {
+		observer(finding)
+	}
+}

--- a/gitstore-api/internal/datastore/recovery_test.go
+++ b/gitstore-api/internal/datastore/recovery_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package datastore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepairRequiredErrorRetainsPrimaryAndCompensationFailures(t *testing.T) {
+	primary := errors.New("write projection")
+	compensation := errors.New("release reservation")
+	step := datastore.MutationStep{
+		Operation:    "create",
+		ResourceKind: "Product",
+		Projection:   "products_by_name",
+		Action:       "reserve",
+	}
+
+	err := datastore.NewRepairRequiredError(step, primary, compensation)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, datastore.ErrRepairRequired)
+	assert.ErrorIs(t, err, primary)
+	var repair *datastore.RepairRequiredError
+	require.ErrorAs(t, err, &repair)
+	assert.Equal(t, step, repair.Step)
+	assert.ErrorIs(t, repair.Compensation, compensation)
+}
+
+func TestProjectionFindingFields(t *testing.T) {
+	finding := datastore.ProjectionFinding{
+		ResourceKind: "Repository",
+		ResourceUID:  "repo-1",
+		Projection:   "namespace_mappings",
+		LookupKey:    "tenant/catalog",
+		Operation:    "lookup",
+		Type:         datastore.FindingStale,
+	}
+
+	assert.Equal(t, "Repository", finding.ResourceKind)
+	assert.Equal(t, datastore.FindingStale, finding.Type)
+}
+
+func TestProjectionFindingObserverReceivesFinding(t *testing.T) {
+	var observed datastore.ProjectionFinding
+	ctx := datastore.WithProjectionFindingObserver(context.Background(), func(finding datastore.ProjectionFinding) {
+		observed = finding
+	})
+	expected := datastore.ProjectionFinding{
+		ResourceKind: "ProductVariant",
+		ResourceUID:  "variant-1",
+		Projection:   "product_variant_by_sku",
+		LookupKey:    "shop/sku-1",
+		Operation:    "get_by_sku",
+		Type:         datastore.FindingDangling,
+	}
+
+	datastore.ReportProjectionFinding(ctx, expected)
+
+	assert.Equal(t, expected, observed)
+}

--- a/gitstore-api/internal/datastore/scylla/backend.go
+++ b/gitstore-api/internal/datastore/scylla/backend.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"strconv"
 	"strings"
@@ -25,27 +26,31 @@ import (
 
 // scyllaDatastore implements datastore.Datastore backed by ScyllaDB.
 type scyllaDatastore struct {
-	session                         gocqlx.Session
-	log                             *zap.Logger
-	productByNamespaceTable         *table.Table
-	productByNameTable              *table.Table
-	productByUIDTable               *table.Table
-	categoryTaxonomyTable           *table.Table
-	categoryTaxonomyByNameTable     *table.Table
-	categoryTaxonomyByUIDTable      *table.Table
-	collectionTable                 *table.Table
-	collectionByNameTable           *table.Table
-	collectionByUIDTable            *table.Table
-	productVariantByNamespaceTable  *table.Table
-	productVariantByNameTable       *table.Table
-	productVariantByUIDTable        *table.Table
-	productVariantBySKUTable        *table.Table
-	productVariantByProductRefTable *table.Table
-	namespaceByIDTable              *table.Table
-	namespaceByNameTable            *table.Table
-	namespaceByBucketTable          *table.Table
-	repositoryTable                 *table.Table
-	namespaceMappingTable           *table.Table
+	session                           gocqlx.Session
+	log                               *zap.Logger
+	productByNamespaceTable           *table.Table
+	productByNameTable                *table.Table
+	productByUIDTable                 *table.Table
+	categoryTaxonomyTable             *table.Table
+	categoryTaxonomyByNameTable       *table.Table
+	categoryTaxonomyByUIDTable        *table.Table
+	collectionTable                   *table.Table
+	collectionByNameTable             *table.Table
+	collectionByUIDTable              *table.Table
+	productVariantByNamespaceTable    *table.Table
+	productVariantByNameTable         *table.Table
+	productVariantByUIDTable          *table.Table
+	productVariantBySKUTable          *table.Table
+	productVariantByProductRefTable   *table.Table
+	namespaceByUIDTable               *table.Table
+	namespaceByNameTable              *table.Table
+	namespaceByBucketTable            *table.Table
+	repositoryByUIDTable              *table.Table
+	repositoryByNamespaceTable        *table.Table
+	repositoryByBucketTable           *table.Table
+	namespaceMappingTable             *table.Table
+	namespaceMappingByRepositoryTable *table.Table
+	mutations                         *mutationExecutor
 }
 
 // row structs mirror the CQL columns.
@@ -61,10 +66,15 @@ type productRow struct {
 	Generation        int64             `db:"generation"`
 	ResourceVersion   string            `db:"resource_version"`
 	Revision          string            `db:"revision"`
+	CreationActor     string            `db:"creation_actor"`
+	UpdateTimestamp   time.Time         `db:"update_timestamp"`
+	UpdateActor       string            `db:"update_actor"`
 	Labels            map[string]string `db:"labels"`
 	Annotations       map[string]string `db:"annotations"`
 	OwnerReferences   string            `db:"owner_references"`
-	RepositoryID      string            `db:"repository_id"`
+	Finalizers        []string          `db:"finalizers"`
+	DeletionTimestamp *time.Time        `db:"deletion_timestamp"`
+	RepositoryID      *gocql.UUID       `db:"repository_id"`
 	SourcePath        string            `db:"source_path"`
 	GitCommitSHA      string            `db:"git_commit_sha"`
 	GitRef            string            `db:"git_ref"`
@@ -91,18 +101,24 @@ type productUIDRow struct {
 type categoryTaxonomyRow struct {
 	Namespace         string            `db:"namespace"`
 	CreationTimestamp time.Time         `db:"creation_timestamp"`
-	UID               string            `db:"uid"`
+	UID               gocql.UUID        `db:"uid"`
 	Name              string            `db:"name"`
 	APIVersion        string            `db:"api_version"`
 	Kind              string            `db:"kind"`
 	Generation        int64             `db:"generation"`
 	ResourceVersion   string            `db:"resource_version"`
 	Revision          string            `db:"revision"`
+	CreationActor     string            `db:"creation_actor"`
+	UpdateTimestamp   time.Time         `db:"update_timestamp"`
+	UpdateActor       string            `db:"update_actor"`
 	Labels            map[string]string `db:"labels"`
 	Annotations       map[string]string `db:"annotations"`
+	OwnerReferences   string            `db:"owner_references"`
+	Finalizers        []string          `db:"finalizers"`
+	DeletionTimestamp *time.Time        `db:"deletion_timestamp"`
 	ParentName        string            `db:"parent_name"`
 	AncestorPath      string            `db:"ancestor_path"`
-	RepositoryID      string            `db:"repository_id"`
+	RepositoryID      *gocql.UUID       `db:"repository_id"`
 	SourcePath        string            `db:"source_path"`
 	GitCommitSHA      string            `db:"git_commit_sha"`
 	GitRef            string            `db:"git_ref"`
@@ -136,9 +152,15 @@ type collectionRow struct {
 	Generation        int64             `db:"generation"`
 	ResourceVersion   string            `db:"resource_version"`
 	Revision          string            `db:"revision"`
+	CreationActor     string            `db:"creation_actor"`
+	UpdateTimestamp   time.Time         `db:"update_timestamp"`
+	UpdateActor       string            `db:"update_actor"`
 	Labels            map[string]string `db:"labels"`
 	Annotations       map[string]string `db:"annotations"`
-	RepositoryID      string            `db:"repository_id"`
+	OwnerReferences   string            `db:"owner_references"`
+	Finalizers        []string          `db:"finalizers"`
+	DeletionTimestamp *time.Time        `db:"deletion_timestamp"`
+	RepositoryID      *gocql.UUID       `db:"repository_id"`
 	SourcePath        string            `db:"source_path"`
 	GitCommitSHA      string            `db:"git_commit_sha"`
 	GitRef            string            `db:"git_ref"`
@@ -170,12 +192,17 @@ type productVariantRow struct {
 	Generation        int64             `db:"generation"`
 	ResourceVersion   string            `db:"resource_version"`
 	Revision          string            `db:"revision"`
+	CreationActor     string            `db:"creation_actor"`
+	UpdateTimestamp   time.Time         `db:"update_timestamp"`
+	UpdateActor       string            `db:"update_actor"`
 	Labels            map[string]string `db:"labels"`
 	Annotations       map[string]string `db:"annotations"`
 	OwnerReferences   string            `db:"owner_references"`
+	Finalizers        []string          `db:"finalizers"`
+	DeletionTimestamp *time.Time        `db:"deletion_timestamp"`
 	SKU               string            `db:"sku"`
 	ProductRefName    string            `db:"product_ref_name"`
-	RepositoryID      string            `db:"repository_id"`
+	RepositoryID      *gocql.UUID       `db:"repository_id"`
 	SourcePath        string            `db:"source_path"`
 	GitCommitSHA      string            `db:"git_commit_sha"`
 	GitRef            string            `db:"git_ref"`
@@ -212,31 +239,41 @@ type productVariantProductRefRow struct {
 }
 
 type namespaceRow struct {
-	ID                gocql.UUID `db:"id"`
-	Name              string     `db:"name"`
-	Title             string     `db:"title"`
-	Tier              string     `db:"tier"`
-	Spec              string     `db:"spec"`
-	Generation        int64      `db:"generation"`
-	ResourceVersion   string     `db:"resource_version"`
-	Status            string     `db:"status"`
-	DeletionTimestamp *time.Time `db:"deletion_timestamp"`
-	Finalizers        []string   `db:"finalizers"`
-	CreationTimestamp time.Time  `db:"creation_timestamp"`
-	CreationActor     string     `db:"creation_actor"`
-	UpdateTimestamp   time.Time  `db:"update_timestamp"`
-	UpdateActor       string     `db:"update_actor"`
+	APIVersion        string            `db:"api_version"`
+	Kind              string            `db:"kind"`
+	UID               gocql.UUID        `db:"uid"`
+	Name              string            `db:"name"`
+	Title             string            `db:"title"`
+	Tier              string            `db:"tier"`
+	Generation        int64             `db:"generation"`
+	ResourceVersion   string            `db:"resource_version"`
+	Revision          string            `db:"revision"`
+	CreationTimestamp time.Time         `db:"creation_timestamp"`
+	CreationActor     string            `db:"creation_actor"`
+	UpdateTimestamp   time.Time         `db:"update_timestamp"`
+	UpdateActor       string            `db:"update_actor"`
+	Labels            map[string]string `db:"labels"`
+	Annotations       map[string]string `db:"annotations"`
+	OwnerReferences   string            `db:"owner_references"`
+	Finalizers        []string          `db:"finalizers"`
+	DeletionTimestamp *time.Time        `db:"deletion_timestamp"`
+	SourcePath        string            `db:"source_path"`
+	GitCommitSHA      string            `db:"git_commit_sha"`
+	GitRef            string            `db:"git_ref"`
+	Spec              string            `db:"spec"`
+	Body              string            `db:"body"`
+	Status            string            `db:"status"`
 }
 
 type namespaceNameRow struct {
 	Name string     `db:"name"`
-	ID   gocql.UUID `db:"id"`
+	UID  gocql.UUID `db:"uid"`
 }
 
 type namespaceIndexRow struct {
 	Bucket            string     `db:"bucket"`
 	CreationTimestamp time.Time  `db:"creation_timestamp"`
-	ID                gocql.UUID `db:"id"`
+	UID               gocql.UUID `db:"uid"`
 }
 
 // New opens a ScyllaDB connection, runs pending migrations, and returns a Datastore.
@@ -273,27 +310,31 @@ func New(cfg config.ScyllaConfig, log *zap.Logger) (datastore.Datastore, error) 
 	}
 
 	return &scyllaDatastore{
-		session:                         gocqlx.NewSession(rawSession),
-		log:                             log,
-		productByNamespaceTable:         ProductByNamespace,
-		productByNameTable:              ProductByName,
-		productByUIDTable:               ProductByUID,
-		categoryTaxonomyTable:           CategoryTaxonomy,
-		categoryTaxonomyByNameTable:     CategoryTaxonomyByName,
-		categoryTaxonomyByUIDTable:      CategoryTaxonomyByUID,
-		collectionTable:                 Collection,
-		collectionByNameTable:           CollectionByName,
-		collectionByUIDTable:            CollectionByUID,
-		productVariantByNamespaceTable:  ProductVariantByNamespace,
-		productVariantByNameTable:       ProductVariantByName,
-		productVariantByUIDTable:        ProductVariantByUID,
-		productVariantBySKUTable:        ProductVariantBySKU,
-		productVariantByProductRefTable: ProductVariantByProductRef,
-		namespaceByIDTable:              NamespaceByID,
-		namespaceByNameTable:            NamespaceByName,
-		namespaceByBucketTable:          NamespaceByBucket,
-		repositoryTable:                 Repository,
-		namespaceMappingTable:           NamespaceMapping,
+		session:                           gocqlx.NewSession(rawSession),
+		log:                               log,
+		productByNamespaceTable:           ProductByNamespace,
+		productByNameTable:                ProductByName,
+		productByUIDTable:                 ProductByUID,
+		categoryTaxonomyTable:             CategoryTaxonomy,
+		categoryTaxonomyByNameTable:       CategoryTaxonomyByName,
+		categoryTaxonomyByUIDTable:        CategoryTaxonomyByUID,
+		collectionTable:                   Collection,
+		collectionByNameTable:             CollectionByName,
+		collectionByUIDTable:              CollectionByUID,
+		productVariantByNamespaceTable:    ProductVariantByNamespace,
+		productVariantByNameTable:         ProductVariantByName,
+		productVariantByUIDTable:          ProductVariantByUID,
+		productVariantBySKUTable:          ProductVariantBySKU,
+		productVariantByProductRefTable:   ProductVariantByProductRef,
+		namespaceByUIDTable:               NamespaceByUID,
+		namespaceByNameTable:              NamespaceByName,
+		namespaceByBucketTable:            NamespaceByBucket,
+		repositoryByUIDTable:              RepositoryByUID,
+		repositoryByNamespaceTable:        RepositoryByNamespace,
+		repositoryByBucketTable:           RepositoryByBucket,
+		namespaceMappingTable:             NamespaceMapping,
+		namespaceMappingByRepositoryTable: NamespaceMappingByRepository,
+		mutations:                         newMutationExecutor(nil),
 	}, nil
 }
 
@@ -325,38 +366,88 @@ func (s *scyllaDatastore) Close() error {
 // ── Product ───────────────────────────────────────────────────────────────────
 
 func (s *scyllaDatastore) CreateProduct(ctx context.Context, p *datastore.Product) error {
-	if _, err := s.GetProduct(ctx, p.UID); err == nil {
-		return fmt.Errorf("%w: product uid %s", datastore.ErrAlreadyExists, p.UID)
+	if p == nil || p.UID == "" || p.Namespace == "" || p.Name == "" {
+		return fmt.Errorf("%w: product uid, namespace, and name are required", datastore.ErrInvalidArgument)
 	}
-	if _, err := s.GetProductByName(ctx, p.Namespace, p.Name); err == nil {
-		return fmt.Errorf("%w: product %s/%s", datastore.ErrAlreadyExists, p.Namespace, p.Name)
+	uid, err := gocql.ParseUUID(p.UID)
+	if err != nil {
+		return fmt.Errorf("%w: invalid product uid %s", datastore.ErrInvalidArgument, p.UID)
 	}
 	if p.CreationTimestamp.IsZero() {
 		p.CreationTimestamp = time.Now().UTC().Truncate(time.Millisecond)
 	}
 	row := toProductRow(p)
-
-	insNS, _ := s.productByNamespaceTable.Insert()
-	insName, _ := s.productByNameTable.Insert()
-	insUID, _ := s.productByUIDTable.Insert()
-
-	// LOGGED BATCH spans three different partition keys (namespace, name, uid).
-	// This crosses partition boundaries which is a ScyllaDB anti-pattern at scale
-	// (incurs a coordinator-side batchlog write per operation).
-	// TODO: switch to UNLOGGED BATCH + application-layer retry before production ramp.
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query(insNS, row.Namespace, row.CreationTimestamp, row.UID, row.Name, row.APIVersion, row.Kind,
-		row.Generation, row.ResourceVersion, row.Revision, row.Labels, row.Annotations,
-		row.OwnerReferences, row.RepositoryID, row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status)
-	b.Query(insName, row.Namespace, row.Name, row.UID, row.CreationTimestamp)
-	b.Query(insUID, row.UID, row.Namespace, row.CreationTimestamp)
-	if err := s.session.ExecuteBatch(b); err != nil {
+	var (
+		existed      bool
+		nameReserved bool
+		uidReserved  bool
+	)
+	err = s.mutations.execute(ctx,
+		mutationAction{
+			Step: catalogueStep("create", "Product", p.UID, "products_by_name", p.Namespace+"/"+p.Name, "reserve-name"),
+			Apply: func(ctx context.Context) error {
+				var reserveErr error
+				nameReserved, reserveErr = s.reserveNameOwned(ctx, "Product", "products_by_name", row.Namespace, row.Name, uid, row.CreationTimestamp)
+				return reserveErr
+			},
+			Compensate: func(ctx context.Context) error {
+				if !nameReserved {
+					return nil
+				}
+				return s.releaseName(ctx, "products_by_name", row.Namespace, row.Name, uid)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("create", "Product", p.UID, "products_by_uid", p.UID, "reserve-uid"),
+			Apply: func(ctx context.Context) error {
+				var reserveErr error
+				uidReserved, reserveErr = s.reserveUIDOwned(ctx, "Product", "products_by_uid", row.Namespace, uid, row.CreationTimestamp)
+				return reserveErr
+			},
+			Compensate: func(ctx context.Context) error {
+				if !uidReserved {
+					return nil
+				}
+				return s.releaseUID(ctx, "products_by_uid", row.Namespace, uid, row.CreationTimestamp)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("create", "Product", p.UID, "products_by_namespace", p.UID, "write-authoritative"),
+			Apply: func(ctx context.Context) error {
+				applied, applyErr := s.insertAuthoritative(ctx, s.productByNamespaceTable, row)
+				if applyErr != nil {
+					return applyErr
+				}
+				if !applied {
+					current, getErr := s.getProductByKey(row.Namespace, row.CreationTimestamp, uid)
+					if getErr != nil {
+						return getErr
+					}
+					if current.UID != p.UID || current.Name != p.Name {
+						return fmt.Errorf("%w: product uid %s already has a different authoritative row", datastore.ErrAlreadyExists, p.UID)
+					}
+					existed = true
+				}
+				return nil
+			},
+			Compensate: func(ctx context.Context) error {
+				if existed {
+					return nil
+				}
+				return s.deleteProductAuthoritative(ctx, row, row.ResourceVersion)
+			},
+		},
+	)
+	if err != nil {
 		return fmt.Errorf("scylla: create product: %w", err)
+	}
+	if existed {
+		return fmt.Errorf("%w: product uid %s", datastore.ErrAlreadyExists, p.UID)
 	}
 	return nil
 }
 
-func (s *scyllaDatastore) GetProduct(_ context.Context, uid string) (*datastore.Product, error) {
+func (s *scyllaDatastore) GetProduct(ctx context.Context, uid string) (*datastore.Product, error) {
 	parsedUID, err := gocql.ParseUUID(uid)
 	if err != nil {
 		return nil, fmt.Errorf("%w: invalid product uid %s", datastore.ErrNotFound, uid)
@@ -370,11 +461,17 @@ func (s *scyllaDatastore) GetProduct(_ context.Context, uid string) (*datastore.
 		}
 		return nil, fmt.Errorf("scylla: get product (uid lookup): %w", err)
 	}
-	// Step 2: (namespace, creation_timestamp, uid) -> full row
-	return s.getProductByKey(uidRow.Namespace, uidRow.CreationTimestamp, uidRow.UID)
+	product, err := s.getProductByKey(uidRow.Namespace, uidRow.CreationTimestamp, uidRow.UID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "Product", ResourceUID: uid, Projection: "products_by_uid",
+			LookupKey: uid, Operation: "get", Type: datastore.FindingDangling,
+		})
+	}
+	return product, err
 }
 
-func (s *scyllaDatastore) GetProductByName(_ context.Context, namespace, name string) (*datastore.Product, error) {
+func (s *scyllaDatastore) GetProductByName(ctx context.Context, namespace, name string) (*datastore.Product, error) {
 	// Step 1: (namespace, name) -> (uid, creation_timestamp)
 	getName, nameNames := s.productByNameTable.Get()
 	var nameRow productNameRow
@@ -384,8 +481,22 @@ func (s *scyllaDatastore) GetProductByName(_ context.Context, namespace, name st
 		}
 		return nil, fmt.Errorf("scylla: get product by name (name lookup): %w", err)
 	}
-	// Step 2: full row from products_by_namespace
-	return s.getProductByKey(nameRow.Namespace, nameRow.CreationTimestamp, nameRow.UID)
+	product, err := s.getProductByKey(nameRow.Namespace, nameRow.CreationTimestamp, nameRow.UID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "Product", ResourceUID: nameRow.UID.String(), Projection: "products_by_name",
+			LookupKey: namespace + "/" + name, Operation: "get_by_name", Type: datastore.FindingDangling,
+		})
+		return nil, err
+	}
+	if err == nil && (product.Name != name || product.Namespace != namespace) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "Product", ResourceUID: nameRow.UID.String(), Projection: "products_by_name",
+			LookupKey: namespace + "/" + name, Operation: "get_by_name", Type: datastore.FindingStale,
+		})
+		return nil, fmt.Errorf("%w: stale product name projection %s/%s", datastore.ErrNotFound, namespace, name)
+	}
+	return product, err
 }
 
 // getProductByKey fetches a full product row from products_by_namespace by its complete primary key.
@@ -427,32 +538,53 @@ func (s *scyllaDatastore) ListProducts(_ context.Context, namespace string, page
 }
 
 func (s *scyllaDatastore) UpdateProduct(ctx context.Context, p *datastore.Product) error {
-	existing, err := s.GetProductByName(ctx, p.Namespace, p.Name)
+	if p == nil {
+		return fmt.Errorf("%w: product is nil", datastore.ErrInvalidArgument)
+	}
+	uid, err := gocql.ParseUUID(p.UID)
+	if err != nil {
+		return fmt.Errorf("%w: invalid product uid %s", datastore.ErrInvalidArgument, p.UID)
+	}
+	var existing *datastore.Product
+	if p.CreationTimestamp.IsZero() {
+		existing, err = s.GetProduct(ctx, p.UID)
+	} else {
+		existing, err = s.getProductByKey(p.Namespace, p.CreationTimestamp, uid)
+	}
 	if err != nil {
 		return err
 	}
+	if existing.Namespace != p.Namespace || existing.Name != p.Name {
+		return fmt.Errorf("%w: product identity is immutable", datastore.ErrConflict)
+	}
+	if err := validateResourceVersionTransition(existing.ResourceVersion, p.ResourceVersion); err != nil {
+		return err
+	}
 	row := toProductRow(p)
-	// Preserve the original creation_timestamp so the primary key is unchanged.
 	row.CreationTimestamp = existing.CreationTimestamp
-	// Use the UID from the stored row, not the caller, so the WHERE clause targets
-	// the row that was actually found rather than a potentially stale caller value.
 	existingUID := mustParseUUID(existing.UID)
 
-	const updNS = "UPDATE products_by_namespace SET api_version=?, kind=?, generation=?, resource_version=?, " +
-		"revision=?, labels=?, annotations=?, owner_references=?, repository_id=?, source_path=?, git_commit_sha=?, git_ref=?, spec=?, body=?, status=? " +
-		"WHERE namespace=? AND creation_timestamp=? AND uid=?"
-
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query(updNS,
-		row.APIVersion, row.Kind, row.Generation, row.ResourceVersion,
-		row.Revision, row.Labels, row.Annotations, row.OwnerReferences,
-		row.RepositoryID, row.SourcePath,
-		row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
-		row.Namespace, row.CreationTimestamp, existingUID,
+	err = s.mutations.executeUpdate(ctx, row.ResourceVersion,
+		mutationAction{
+			Step: catalogueStep("update", "Product", p.UID, "products_by_namespace", p.UID, "update-authoritative"),
+			Apply: func(ctx context.Context) error {
+				return s.updateProductAuthoritative(ctx, row, existing.ResourceVersion)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("update", "Product", p.UID, "products_by_name", p.Namespace+"/"+p.Name, "converge-name"),
+			Apply: func(ctx context.Context) error {
+				return s.reserveName(ctx, "Product", "products_by_name", row.Namespace, row.Name, existingUID, row.CreationTimestamp)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("update", "Product", p.UID, "products_by_uid", p.UID, "converge-uid"),
+			Apply: func(ctx context.Context) error {
+				return s.reserveUID(ctx, "Product", "products_by_uid", row.Namespace, existingUID, row.CreationTimestamp)
+			},
+		},
 	)
-	// products_by_name and products_by_uid are index-only; their non-key columns
-	// (uid, creation_timestamp) do not change on update, so no update needed there.
-	if err := s.session.ExecuteBatch(b); err != nil {
+	if err != nil {
 		return fmt.Errorf("scylla: update product: %w", err)
 	}
 	return nil
@@ -465,15 +597,33 @@ func (s *scyllaDatastore) DeleteProduct(ctx context.Context, uid string) error {
 	}
 	parsedUID := mustParseUUID(uid)
 
-	delNS := "DELETE FROM products_by_namespace WHERE namespace=? AND creation_timestamp=? AND uid=?"
-	delName := "DELETE FROM products_by_name WHERE namespace=? AND name=?"
-	delUID := "DELETE FROM products_by_uid WHERE uid=?"
-
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query(delNS, p.Namespace, p.CreationTimestamp, parsedUID)
-	b.Query(delName, p.Namespace, p.Name)
-	b.Query(delUID, parsedUID)
-	if err := s.session.ExecuteBatch(b); err != nil {
+	err = s.mutations.executeDelete(ctx,
+		mutationAction{
+			Step: catalogueStep("delete", "Product", uid, "products_by_namespace", uid, "delete-authoritative"),
+			Apply: func(ctx context.Context) error {
+				return s.deleteProductAuthoritative(ctx, toProductRow(p), p.ResourceVersion)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("delete", "Product", uid, "products_by_name", p.Namespace+"/"+p.Name, "delete-name"),
+			Apply: func(ctx context.Context) error {
+				return s.releaseName(ctx, "products_by_name", p.Namespace, p.Name, parsedUID)
+			},
+			Compensate: func(ctx context.Context) error {
+				return s.reserveName(ctx, "Product", "products_by_name", p.Namespace, p.Name, parsedUID, p.CreationTimestamp)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("delete", "Product", uid, "products_by_uid", uid, "delete-uid"),
+			Apply: func(ctx context.Context) error {
+				return s.releaseUID(ctx, "products_by_uid", p.Namespace, parsedUID, p.CreationTimestamp)
+			},
+			Compensate: func(ctx context.Context) error {
+				return s.reserveUID(ctx, "Product", "products_by_uid", p.Namespace, parsedUID, p.CreationTimestamp)
+			},
+		},
+	)
+	if err != nil {
 		return fmt.Errorf("scylla: delete product: %w", err)
 	}
 	return nil
@@ -482,30 +632,83 @@ func (s *scyllaDatastore) DeleteProduct(ctx context.Context, uid string) error {
 // ── CategoryTaxonomy ──────────────────────────────────────────────────────────
 
 func (s *scyllaDatastore) CreateCategoryTaxonomy(ctx context.Context, c *datastore.CategoryTaxonomy) error {
-	if _, err := s.GetCategoryTaxonomy(ctx, c.UID); err == nil {
-		return fmt.Errorf("%w: category_taxonomy uid %s", datastore.ErrAlreadyExists, c.UID)
+	if c == nil || c.UID == "" || c.Namespace == "" || c.Name == "" {
+		return fmt.Errorf("%w: category taxonomy uid, namespace, and name are required", datastore.ErrInvalidArgument)
 	}
-	if _, err := s.GetCategoryTaxonomyByName(ctx, c.Namespace, c.Name); err == nil {
-		return fmt.Errorf("%w: category_taxonomy %s/%s", datastore.ErrAlreadyExists, c.Namespace, c.Name)
+	uid, err := gocql.ParseUUID(c.UID)
+	if err != nil {
+		return fmt.Errorf("%w: invalid category taxonomy uid %s", datastore.ErrInvalidArgument, c.UID)
 	}
 	if c.CreationTimestamp.IsZero() {
 		c.CreationTimestamp = time.Now().UTC().Truncate(time.Millisecond)
 	}
 	row := toCategoryTaxonomyRow(c)
-
-	insMain, _ := s.categoryTaxonomyTable.Insert()
-	insName, _ := s.categoryTaxonomyByNameTable.Insert()
-	insUID, _ := s.categoryTaxonomyByUIDTable.Insert()
-
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query(insMain, row.Namespace, row.CreationTimestamp, mustParseUUID(row.UID), row.Name,
-		row.APIVersion, row.Kind, row.Generation, row.ResourceVersion, row.Revision,
-		row.Labels, row.Annotations, row.ParentName, row.AncestorPath,
-		row.RepositoryID, row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status)
-	b.Query(insName, row.Namespace, row.Name, mustParseUUID(row.UID), row.CreationTimestamp)
-	b.Query(insUID, mustParseUUID(row.UID), row.Namespace, row.CreationTimestamp)
-	if err := s.session.ExecuteBatch(b); err != nil {
+	var (
+		existed      bool
+		nameReserved bool
+		uidReserved  bool
+	)
+	err = s.mutations.execute(ctx,
+		mutationAction{
+			Step: catalogueStep("create", "CategoryTaxonomy", c.UID, "category_taxonomy_by_name", c.Namespace+"/"+c.Name, "reserve-name"),
+			Apply: func(ctx context.Context) error {
+				var reserveErr error
+				nameReserved, reserveErr = s.reserveNameOwned(ctx, "CategoryTaxonomy", "category_taxonomy_by_name", row.Namespace, row.Name, uid, row.CreationTimestamp)
+				return reserveErr
+			},
+			Compensate: func(ctx context.Context) error {
+				if !nameReserved {
+					return nil
+				}
+				return s.releaseName(ctx, "category_taxonomy_by_name", row.Namespace, row.Name, uid)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("create", "CategoryTaxonomy", c.UID, "category_taxonomy_by_uid", c.UID, "reserve-uid"),
+			Apply: func(ctx context.Context) error {
+				var reserveErr error
+				uidReserved, reserveErr = s.reserveUIDOwned(ctx, "CategoryTaxonomy", "category_taxonomy_by_uid", row.Namespace, uid, row.CreationTimestamp)
+				return reserveErr
+			},
+			Compensate: func(ctx context.Context) error {
+				if !uidReserved {
+					return nil
+				}
+				return s.releaseUID(ctx, "category_taxonomy_by_uid", row.Namespace, uid, row.CreationTimestamp)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("create", "CategoryTaxonomy", c.UID, "category_taxonomy", c.UID, "write-authoritative"),
+			Apply: func(ctx context.Context) error {
+				applied, applyErr := s.insertAuthoritative(ctx, s.categoryTaxonomyTable, row)
+				if applyErr != nil {
+					return applyErr
+				}
+				if !applied {
+					current, getErr := s.getCategoryTaxonomyByKey(row.Namespace, row.CreationTimestamp, uid)
+					if getErr != nil {
+						return getErr
+					}
+					if current.UID != c.UID || current.Name != c.Name {
+						return fmt.Errorf("%w: category taxonomy uid %s already has a different authoritative row", datastore.ErrAlreadyExists, c.UID)
+					}
+					existed = true
+				}
+				return nil
+			},
+			Compensate: func(ctx context.Context) error {
+				if existed {
+					return nil
+				}
+				return s.deleteCategoryTaxonomyAuthoritative(ctx, row, row.ResourceVersion)
+			},
+		},
+	)
+	if err != nil {
 		return fmt.Errorf("scylla: create category_taxonomy: %w", err)
+	}
+	if existed {
+		return fmt.Errorf("%w: category taxonomy uid %s", datastore.ErrAlreadyExists, c.UID)
 	}
 	return nil
 }
@@ -524,7 +727,7 @@ func (s *scyllaDatastore) getCategoryTaxonomyByKey(namespace string, creationTim
 	return fromCategoryTaxonomyRow(&row), nil
 }
 
-func (s *scyllaDatastore) GetCategoryTaxonomy(_ context.Context, uid string) (*datastore.CategoryTaxonomy, error) {
+func (s *scyllaDatastore) GetCategoryTaxonomy(ctx context.Context, uid string) (*datastore.CategoryTaxonomy, error) {
 	parsedUID, err := gocql.ParseUUID(uid)
 	if err != nil {
 		return nil, fmt.Errorf("%w: invalid category_taxonomy uid %s", datastore.ErrNotFound, uid)
@@ -540,11 +743,17 @@ func (s *scyllaDatastore) GetCategoryTaxonomy(_ context.Context, uid string) (*d
 		}
 		return nil, fmt.Errorf("scylla: get category_taxonomy by uid: %w", err)
 	}
-	// Step 2: (namespace, creation_timestamp, uid) -> full row
-	return s.getCategoryTaxonomyByKey(uidRow.Namespace, uidRow.CreationTimestamp, uidRow.UID)
+	category, err := s.getCategoryTaxonomyByKey(uidRow.Namespace, uidRow.CreationTimestamp, uidRow.UID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "CategoryTaxonomy", ResourceUID: uid, Projection: "category_taxonomy_by_uid",
+			LookupKey: uid, Operation: "get", Type: datastore.FindingDangling,
+		})
+	}
+	return category, err
 }
 
-func (s *scyllaDatastore) GetCategoryTaxonomyByName(_ context.Context, namespace, name string) (*datastore.CategoryTaxonomy, error) {
+func (s *scyllaDatastore) GetCategoryTaxonomyByName(ctx context.Context, namespace, name string) (*datastore.CategoryTaxonomy, error) {
 	// Step 1: (namespace, name) -> (uid, creation_timestamp)
 	stmt, names := s.categoryTaxonomyByNameTable.Get()
 	var nameRow categoryTaxonomyNameRow
@@ -557,8 +766,22 @@ func (s *scyllaDatastore) GetCategoryTaxonomyByName(_ context.Context, namespace
 		}
 		return nil, fmt.Errorf("scylla: get category_taxonomy by name: %w", err)
 	}
-	// Step 2: (namespace, creation_timestamp, uid) -> full row
-	return s.getCategoryTaxonomyByKey(namespace, nameRow.CreationTimestamp, nameRow.UID)
+	category, err := s.getCategoryTaxonomyByKey(namespace, nameRow.CreationTimestamp, nameRow.UID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "CategoryTaxonomy", ResourceUID: nameRow.UID.String(), Projection: "category_taxonomy_by_name",
+			LookupKey: namespace + "/" + name, Operation: "get_by_name", Type: datastore.FindingDangling,
+		})
+		return nil, err
+	}
+	if err == nil && (category.Name != name || category.Namespace != namespace) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "CategoryTaxonomy", ResourceUID: nameRow.UID.String(), Projection: "category_taxonomy_by_name",
+			LookupKey: namespace + "/" + name, Operation: "get_by_name", Type: datastore.FindingStale,
+		})
+		return nil, fmt.Errorf("%w: stale category taxonomy name projection %s/%s", datastore.ErrNotFound, namespace, name)
+	}
+	return category, err
 }
 
 func (s *scyllaDatastore) ListCategoryTaxonomies(_ context.Context, namespace string, page datastore.PageParams) (*datastore.PageResult[datastore.CategoryTaxonomy], error) {
@@ -583,31 +806,53 @@ func (s *scyllaDatastore) ListCategoryTaxonomies(_ context.Context, namespace st
 }
 
 func (s *scyllaDatastore) UpdateCategoryTaxonomy(ctx context.Context, c *datastore.CategoryTaxonomy) error {
-	existing, err := s.GetCategoryTaxonomyByName(ctx, c.Namespace, c.Name)
+	if c == nil {
+		return fmt.Errorf("%w: category taxonomy is nil", datastore.ErrInvalidArgument)
+	}
+	uid, err := gocql.ParseUUID(c.UID)
+	if err != nil {
+		return fmt.Errorf("%w: invalid category taxonomy uid %s", datastore.ErrInvalidArgument, c.UID)
+	}
+	var existing *datastore.CategoryTaxonomy
+	if c.CreationTimestamp.IsZero() {
+		existing, err = s.GetCategoryTaxonomy(ctx, c.UID)
+	} else {
+		existing, err = s.getCategoryTaxonomyByKey(c.Namespace, c.CreationTimestamp, uid)
+	}
 	if err != nil {
 		return err
 	}
+	if existing.Namespace != c.Namespace || existing.Name != c.Name {
+		return fmt.Errorf("%w: category taxonomy identity is immutable", datastore.ErrConflict)
+	}
+	if err := validateResourceVersionTransition(existing.ResourceVersion, c.ResourceVersion); err != nil {
+		return err
+	}
 	row := toCategoryTaxonomyRow(c)
-	// Preserve the original creation_timestamp so the primary key is unchanged.
 	row.CreationTimestamp = existing.CreationTimestamp
 	existingUID := mustParseUUID(existing.UID)
 
-	const updMain = "UPDATE category_taxonomy SET name=?, api_version=?, kind=?, generation=?, resource_version=?, " +
-		"revision=?, labels=?, annotations=?, parent_name=?, ancestor_path=?, " +
-		"repository_id=?, source_path=?, git_commit_sha=?, git_ref=?, spec=?, body=?, status=? " +
-		"WHERE namespace=? AND creation_timestamp=? AND uid=?"
-
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query(updMain,
-		row.Name, row.APIVersion, row.Kind, row.Generation, row.ResourceVersion,
-		row.Revision, row.Labels, row.Annotations, row.ParentName, row.AncestorPath,
-		row.RepositoryID, row.SourcePath,
-		row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
-		row.Namespace, row.CreationTimestamp, existingUID,
+	err = s.mutations.executeUpdate(ctx, row.ResourceVersion,
+		mutationAction{
+			Step: catalogueStep("update", "CategoryTaxonomy", c.UID, "category_taxonomy", c.UID, "update-authoritative"),
+			Apply: func(ctx context.Context) error {
+				return s.updateCategoryTaxonomyAuthoritative(ctx, row, existing.ResourceVersion)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("update", "CategoryTaxonomy", c.UID, "category_taxonomy_by_name", c.Namespace+"/"+c.Name, "converge-name"),
+			Apply: func(ctx context.Context) error {
+				return s.reserveName(ctx, "CategoryTaxonomy", "category_taxonomy_by_name", row.Namespace, row.Name, existingUID, row.CreationTimestamp)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("update", "CategoryTaxonomy", c.UID, "category_taxonomy_by_uid", c.UID, "converge-uid"),
+			Apply: func(ctx context.Context) error {
+				return s.reserveUID(ctx, "CategoryTaxonomy", "category_taxonomy_by_uid", row.Namespace, existingUID, row.CreationTimestamp)
+			},
+		},
 	)
-	insUID, _ := s.categoryTaxonomyByUIDTable.Insert()
-	b.Query(insUID, existingUID, row.Namespace, row.CreationTimestamp)
-	if err := s.session.ExecuteBatch(b); err != nil {
+	if err != nil {
 		return fmt.Errorf("scylla: update category_taxonomy: %w", err)
 	}
 	return nil
@@ -655,14 +900,33 @@ func (s *scyllaDatastore) DeleteCategoryTaxonomy(ctx context.Context, uid string
 	}
 	parsedUID := mustParseUUID(uid)
 
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query("DELETE FROM category_taxonomy WHERE namespace=? AND creation_timestamp=? AND uid=?",
-		c.Namespace, c.CreationTimestamp, parsedUID)
-	b.Query("DELETE FROM category_taxonomy_by_name WHERE namespace=? AND name=?",
-		c.Namespace, c.Name)
-	b.Query("DELETE FROM category_taxonomy_by_uid WHERE uid=?",
-		parsedUID)
-	if err := s.session.ExecuteBatch(b); err != nil {
+	err = s.mutations.executeDelete(ctx,
+		mutationAction{
+			Step: catalogueStep("delete", "CategoryTaxonomy", uid, "category_taxonomy", uid, "delete-authoritative"),
+			Apply: func(ctx context.Context) error {
+				return s.deleteCategoryTaxonomyAuthoritative(ctx, toCategoryTaxonomyRow(c), c.ResourceVersion)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("delete", "CategoryTaxonomy", uid, "category_taxonomy_by_name", c.Namespace+"/"+c.Name, "delete-name"),
+			Apply: func(ctx context.Context) error {
+				return s.releaseName(ctx, "category_taxonomy_by_name", c.Namespace, c.Name, parsedUID)
+			},
+			Compensate: func(ctx context.Context) error {
+				return s.reserveName(ctx, "CategoryTaxonomy", "category_taxonomy_by_name", c.Namespace, c.Name, parsedUID, c.CreationTimestamp)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("delete", "CategoryTaxonomy", uid, "category_taxonomy_by_uid", uid, "delete-uid"),
+			Apply: func(ctx context.Context) error {
+				return s.releaseUID(ctx, "category_taxonomy_by_uid", c.Namespace, parsedUID, c.CreationTimestamp)
+			},
+			Compensate: func(ctx context.Context) error {
+				return s.reserveUID(ctx, "CategoryTaxonomy", "category_taxonomy_by_uid", c.Namespace, parsedUID, c.CreationTimestamp)
+			},
+		},
+	)
+	if err != nil {
 		return fmt.Errorf("scylla: delete category_taxonomy: %w", err)
 	}
 	return nil
@@ -671,34 +935,88 @@ func (s *scyllaDatastore) DeleteCategoryTaxonomy(ctx context.Context, uid string
 // ── Collection ────────────────────────────────────────────────────────────────
 
 func (s *scyllaDatastore) CreateCollection(ctx context.Context, c *datastore.Collection) error {
-	if _, err := s.GetCollection(ctx, c.UID); err == nil {
-		return fmt.Errorf("%w: collection uid %s", datastore.ErrAlreadyExists, c.UID)
+	if c == nil || c.UID == "" || c.Namespace == "" || c.Name == "" {
+		return fmt.Errorf("%w: collection uid, namespace, and name are required", datastore.ErrInvalidArgument)
 	}
-	if _, err := s.GetCollectionByName(ctx, c.Namespace, c.Name); err == nil {
-		return fmt.Errorf("%w: collection %s/%s", datastore.ErrAlreadyExists, c.Namespace, c.Name)
+	uid, err := gocql.ParseUUID(c.UID)
+	if err != nil {
+		return fmt.Errorf("%w: invalid collection uid %s", datastore.ErrInvalidArgument, c.UID)
 	}
 	if c.CreationTimestamp.IsZero() {
 		c.CreationTimestamp = time.Now().UTC().Truncate(time.Millisecond)
 	}
 	row := toCollectionRow(c)
-
-	insNS, _ := s.collectionTable.Insert()
-	insName, _ := s.collectionByNameTable.Insert()
-	insUID, _ := s.collectionByUIDTable.Insert()
-
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query(insNS, row.Namespace, row.CreationTimestamp, row.UID, row.Name, row.APIVersion, row.Kind,
-		row.Generation, row.ResourceVersion, row.Revision, row.Labels, row.Annotations,
-		row.RepositoryID, row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status)
-	b.Query(insName, row.Namespace, row.Name, row.UID, row.CreationTimestamp)
-	b.Query(insUID, row.UID, row.Namespace, row.CreationTimestamp)
-	if err := s.session.ExecuteBatch(b); err != nil {
+	var (
+		existed      bool
+		nameReserved bool
+		uidReserved  bool
+	)
+	err = s.mutations.execute(ctx,
+		mutationAction{
+			Step: catalogueStep("create", "Collection", c.UID, "collection_by_name", c.Namespace+"/"+c.Name, "reserve-name"),
+			Apply: func(ctx context.Context) error {
+				var reserveErr error
+				nameReserved, reserveErr = s.reserveNameOwned(ctx, "Collection", "collection_by_name", row.Namespace, row.Name, uid, row.CreationTimestamp)
+				return reserveErr
+			},
+			Compensate: func(ctx context.Context) error {
+				if !nameReserved {
+					return nil
+				}
+				return s.releaseName(ctx, "collection_by_name", row.Namespace, row.Name, uid)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("create", "Collection", c.UID, "collection_by_uid", c.UID, "reserve-uid"),
+			Apply: func(ctx context.Context) error {
+				var reserveErr error
+				uidReserved, reserveErr = s.reserveUIDOwned(ctx, "Collection", "collection_by_uid", row.Namespace, uid, row.CreationTimestamp)
+				return reserveErr
+			},
+			Compensate: func(ctx context.Context) error {
+				if !uidReserved {
+					return nil
+				}
+				return s.releaseUID(ctx, "collection_by_uid", row.Namespace, uid, row.CreationTimestamp)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("create", "Collection", c.UID, "collection", c.UID, "write-authoritative"),
+			Apply: func(ctx context.Context) error {
+				applied, applyErr := s.insertAuthoritative(ctx, s.collectionTable, row)
+				if applyErr != nil {
+					return applyErr
+				}
+				if !applied {
+					current, getErr := s.getCollectionByKey(row.Namespace, row.CreationTimestamp, uid)
+					if getErr != nil {
+						return getErr
+					}
+					if current.UID != c.UID || current.Name != c.Name {
+						return fmt.Errorf("%w: collection uid %s already has a different authoritative row", datastore.ErrAlreadyExists, c.UID)
+					}
+					existed = true
+				}
+				return nil
+			},
+			Compensate: func(ctx context.Context) error {
+				if existed {
+					return nil
+				}
+				return s.deleteCollectionAuthoritative(ctx, row, row.ResourceVersion)
+			},
+		},
+	)
+	if err != nil {
 		return fmt.Errorf("scylla: create collection: %w", err)
+	}
+	if existed {
+		return fmt.Errorf("%w: collection uid %s", datastore.ErrAlreadyExists, c.UID)
 	}
 	return nil
 }
 
-func (s *scyllaDatastore) GetCollection(_ context.Context, uid string) (*datastore.Collection, error) {
+func (s *scyllaDatastore) GetCollection(ctx context.Context, uid string) (*datastore.Collection, error) {
 	parsedUID, err := gocql.ParseUUID(uid)
 	if err != nil {
 		return nil, fmt.Errorf("%w: invalid collection uid %s", datastore.ErrNotFound, uid)
@@ -711,10 +1029,17 @@ func (s *scyllaDatastore) GetCollection(_ context.Context, uid string) (*datasto
 		}
 		return nil, fmt.Errorf("scylla: get collection (uid lookup): %w", err)
 	}
-	return s.getCollectionByKey(uidRow.Namespace, uidRow.CreationTimestamp, uidRow.UID)
+	collection, err := s.getCollectionByKey(uidRow.Namespace, uidRow.CreationTimestamp, uidRow.UID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "Collection", ResourceUID: uid, Projection: "collection_by_uid",
+			LookupKey: uid, Operation: "get", Type: datastore.FindingDangling,
+		})
+	}
+	return collection, err
 }
 
-func (s *scyllaDatastore) GetCollectionByName(_ context.Context, namespace, name string) (*datastore.Collection, error) {
+func (s *scyllaDatastore) GetCollectionByName(ctx context.Context, namespace, name string) (*datastore.Collection, error) {
 	getName, nameNames := s.collectionByNameTable.Get()
 	var nameRow collectionNameRow
 	if err := s.session.Query(getName, nameNames).BindMap(qb.M{"namespace": namespace, "name": name}).GetRelease(&nameRow); err != nil {
@@ -723,7 +1048,22 @@ func (s *scyllaDatastore) GetCollectionByName(_ context.Context, namespace, name
 		}
 		return nil, fmt.Errorf("scylla: get collection by name: %w", err)
 	}
-	return s.getCollectionByKey(nameRow.Namespace, nameRow.CreationTimestamp, nameRow.UID)
+	collection, err := s.getCollectionByKey(nameRow.Namespace, nameRow.CreationTimestamp, nameRow.UID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "Collection", ResourceUID: nameRow.UID.String(), Projection: "collection_by_name",
+			LookupKey: namespace + "/" + name, Operation: "get_by_name", Type: datastore.FindingDangling,
+		})
+		return nil, err
+	}
+	if err == nil && (collection.Name != name || collection.Namespace != namespace) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "Collection", ResourceUID: nameRow.UID.String(), Projection: "collection_by_name",
+			LookupKey: namespace + "/" + name, Operation: "get_by_name", Type: datastore.FindingStale,
+		})
+		return nil, fmt.Errorf("%w: stale collection name projection %s/%s", datastore.ErrNotFound, namespace, name)
+	}
+	return collection, err
 }
 
 func (s *scyllaDatastore) getCollectionByKey(namespace string, createdAt time.Time, uid gocql.UUID) (*datastore.Collection, error) {
@@ -764,27 +1104,53 @@ func (s *scyllaDatastore) ListCollections(_ context.Context, namespace string, p
 }
 
 func (s *scyllaDatastore) UpdateCollection(ctx context.Context, c *datastore.Collection) error {
-	existing, err := s.GetCollectionByName(ctx, c.Namespace, c.Name)
+	if c == nil {
+		return fmt.Errorf("%w: collection is nil", datastore.ErrInvalidArgument)
+	}
+	uid, err := gocql.ParseUUID(c.UID)
 	if err != nil {
+		return fmt.Errorf("%w: invalid collection uid %s", datastore.ErrInvalidArgument, c.UID)
+	}
+	var existing *datastore.Collection
+	if c.CreationTimestamp.IsZero() {
+		existing, err = s.GetCollection(ctx, c.UID)
+	} else {
+		existing, err = s.getCollectionByKey(c.Namespace, c.CreationTimestamp, uid)
+	}
+	if err != nil {
+		return err
+	}
+	if existing.Namespace != c.Namespace || existing.Name != c.Name {
+		return fmt.Errorf("%w: collection identity is immutable", datastore.ErrConflict)
+	}
+	if err := validateResourceVersionTransition(existing.ResourceVersion, c.ResourceVersion); err != nil {
 		return err
 	}
 	row := toCollectionRow(c)
 	row.CreationTimestamp = existing.CreationTimestamp
 	existingUID := mustParseUUID(existing.UID)
 
-	const updNS = "UPDATE collection SET api_version=?, kind=?, generation=?, resource_version=?, " +
-		"revision=?, labels=?, annotations=?, repository_id=?, source_path=?, git_commit_sha=?, git_ref=?, spec=?, body=?, status=? " +
-		"WHERE namespace=? AND creation_timestamp=? AND uid=?"
-
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query(updNS,
-		row.APIVersion, row.Kind, row.Generation, row.ResourceVersion,
-		row.Revision, row.Labels, row.Annotations,
-		row.RepositoryID, row.SourcePath,
-		row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
-		row.Namespace, row.CreationTimestamp, existingUID,
+	err = s.mutations.executeUpdate(ctx, row.ResourceVersion,
+		mutationAction{
+			Step: catalogueStep("update", "Collection", c.UID, "collection", c.UID, "update-authoritative"),
+			Apply: func(ctx context.Context) error {
+				return s.updateCollectionAuthoritative(ctx, row, existing.ResourceVersion)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("update", "Collection", c.UID, "collection_by_name", c.Namespace+"/"+c.Name, "converge-name"),
+			Apply: func(ctx context.Context) error {
+				return s.reserveName(ctx, "Collection", "collection_by_name", row.Namespace, row.Name, existingUID, row.CreationTimestamp)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("update", "Collection", c.UID, "collection_by_uid", c.UID, "converge-uid"),
+			Apply: func(ctx context.Context) error {
+				return s.reserveUID(ctx, "Collection", "collection_by_uid", row.Namespace, existingUID, row.CreationTimestamp)
+			},
+		},
 	)
-	if err := s.session.ExecuteBatch(b); err != nil {
+	if err != nil {
 		return fmt.Errorf("scylla: update collection: %w", err)
 	}
 	return nil
@@ -797,14 +1163,33 @@ func (s *scyllaDatastore) DeleteCollection(ctx context.Context, uid string) erro
 	}
 	parsedUID := mustParseUUID(uid)
 
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query("DELETE FROM collection WHERE namespace=? AND creation_timestamp=? AND uid=?",
-		c.Namespace, c.CreationTimestamp, parsedUID)
-	b.Query("DELETE FROM collection_by_name WHERE namespace=? AND name=?",
-		c.Namespace, c.Name)
-	b.Query("DELETE FROM collection_by_uid WHERE uid=?",
-		parsedUID)
-	if err := s.session.ExecuteBatch(b); err != nil {
+	err = s.mutations.executeDelete(ctx,
+		mutationAction{
+			Step: catalogueStep("delete", "Collection", uid, "collection", uid, "delete-authoritative"),
+			Apply: func(ctx context.Context) error {
+				return s.deleteCollectionAuthoritative(ctx, toCollectionRow(c), c.ResourceVersion)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("delete", "Collection", uid, "collection_by_name", c.Namespace+"/"+c.Name, "delete-name"),
+			Apply: func(ctx context.Context) error {
+				return s.releaseName(ctx, "collection_by_name", c.Namespace, c.Name, parsedUID)
+			},
+			Compensate: func(ctx context.Context) error {
+				return s.reserveName(ctx, "Collection", "collection_by_name", c.Namespace, c.Name, parsedUID, c.CreationTimestamp)
+			},
+		},
+		mutationAction{
+			Step: catalogueStep("delete", "Collection", uid, "collection_by_uid", uid, "delete-uid"),
+			Apply: func(ctx context.Context) error {
+				return s.releaseUID(ctx, "collection_by_uid", c.Namespace, parsedUID, c.CreationTimestamp)
+			},
+			Compensate: func(ctx context.Context) error {
+				return s.reserveUID(ctx, "Collection", "collection_by_uid", c.Namespace, parsedUID, c.CreationTimestamp)
+			},
+		},
+	)
+	if err != nil {
 		return fmt.Errorf("scylla: delete collection: %w", err)
 	}
 	return nil
@@ -838,43 +1223,123 @@ func (s *scyllaDatastore) ListProductsByLabelSelector(ctx context.Context, names
 // ── ProductVariant ────────────────────────────────────────────────────────────
 
 func (s *scyllaDatastore) CreateProductVariant(ctx context.Context, v *datastore.ProductVariant) error {
-	if _, err := s.GetProductVariant(ctx, v.UID); err == nil {
-		return fmt.Errorf("%w: product_variant uid %s", datastore.ErrAlreadyExists, v.UID)
+	if v == nil || v.UID == "" || v.Namespace == "" || v.Name == "" {
+		return fmt.Errorf("%w: product variant uid, namespace, and name are required", datastore.ErrInvalidArgument)
 	}
-	if _, err := s.GetProductVariantByName(ctx, v.Namespace, v.Name); err == nil {
-		return fmt.Errorf("%w: product_variant %s/%s", datastore.ErrAlreadyExists, v.Namespace, v.Name)
-	}
-	if _, err := s.GetProductVariantBySKU(ctx, v.Namespace, v.SKU); err == nil {
-		return fmt.Errorf("%w: product_variant sku %s/%s", datastore.ErrAlreadyExists, v.Namespace, v.SKU)
+	uid, err := gocql.ParseUUID(v.UID)
+	if err != nil {
+		return fmt.Errorf("%w: invalid product variant uid %s", datastore.ErrInvalidArgument, v.UID)
 	}
 	if v.CreationTimestamp.IsZero() {
 		v.CreationTimestamp = time.Now().UTC().Truncate(time.Millisecond)
 	}
 	row := toProductVariantRow(v)
-
-	insNS, _ := s.productVariantByNamespaceTable.Insert()
-	insName, _ := s.productVariantByNameTable.Insert()
-	insUID, _ := s.productVariantByUIDTable.Insert()
-	insSKU, _ := s.productVariantBySKUTable.Insert()
-	insRef, _ := s.productVariantByProductRefTable.Insert()
-
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query(insNS, row.Namespace, row.CreationTimestamp, row.UID, row.Name, row.APIVersion, row.Kind,
-		row.Generation, row.ResourceVersion, row.Revision, row.Labels, row.Annotations,
-		row.OwnerReferences, row.SKU, row.ProductRefName, row.RepositoryID, row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status)
-	b.Query(insName, row.Namespace, row.Name, row.UID, row.CreationTimestamp)
-	b.Query(insUID, row.UID, row.Namespace, row.CreationTimestamp)
-	b.Query(insSKU, row.Namespace, row.SKU, row.UID, row.CreationTimestamp)
-	if row.ProductRefName != "" {
-		b.Query(insRef, row.Namespace, row.ProductRefName, row.UID, row.CreationTimestamp)
+	var (
+		existed      bool
+		nameReserved bool
+		uidReserved  bool
+		skuReserved  bool
+	)
+	actions := []mutationAction{
+		{
+			Step: catalogueStep("create", "ProductVariant", v.UID, "product_variant_by_name", v.Namespace+"/"+v.Name, "reserve-name"),
+			Apply: func(ctx context.Context) error {
+				var reserveErr error
+				nameReserved, reserveErr = s.reserveNameOwned(ctx, "ProductVariant", "product_variant_by_name", row.Namespace, row.Name, uid, row.CreationTimestamp)
+				return reserveErr
+			},
+			Compensate: func(ctx context.Context) error {
+				if !nameReserved {
+					return nil
+				}
+				return s.releaseName(ctx, "product_variant_by_name", row.Namespace, row.Name, uid)
+			},
+		},
+		{
+			Step: catalogueStep("create", "ProductVariant", v.UID, "product_variant_by_uid", v.UID, "reserve-uid"),
+			Apply: func(ctx context.Context) error {
+				var reserveErr error
+				uidReserved, reserveErr = s.reserveUIDOwned(ctx, "ProductVariant", "product_variant_by_uid", row.Namespace, uid, row.CreationTimestamp)
+				return reserveErr
+			},
+			Compensate: func(ctx context.Context) error {
+				if !uidReserved {
+					return nil
+				}
+				return s.releaseUID(ctx, "product_variant_by_uid", row.Namespace, uid, row.CreationTimestamp)
+			},
+		},
 	}
-	if err := s.session.ExecuteBatch(b); err != nil {
+	if row.SKU != "" {
+		actions = append(actions, mutationAction{
+			Step: catalogueStep("create", "ProductVariant", v.UID, "product_variant_by_sku", v.Namespace+"/"+v.SKU, "reserve-sku"),
+			Apply: func(ctx context.Context) error {
+				var reserveErr error
+				skuReserved, reserveErr = s.reserveSKUOwned(ctx, row.Namespace, row.SKU, uid, row.CreationTimestamp)
+				return reserveErr
+			},
+			Compensate: func(ctx context.Context) error {
+				if !skuReserved {
+					return nil
+				}
+				return s.releaseSKU(ctx, row.Namespace, row.SKU, uid)
+			},
+		})
+	}
+	actions = append(actions, mutationAction{
+		Step: catalogueStep("create", "ProductVariant", v.UID, "product_variant_by_namespace", v.UID, "write-authoritative"),
+		Apply: func(ctx context.Context) error {
+			applied, applyErr := s.insertAuthoritative(ctx, s.productVariantByNamespaceTable, row)
+			if applyErr != nil {
+				return applyErr
+			}
+			if !applied {
+				current, getErr := s.getProductVariantByKey(row.Namespace, row.CreationTimestamp, uid)
+				if getErr != nil {
+					return getErr
+				}
+				if current.UID != v.UID || current.Name != v.Name {
+					return fmt.Errorf("%w: product variant uid %s already has a different authoritative row", datastore.ErrAlreadyExists, v.UID)
+				}
+				existed = true
+			}
+			return nil
+		},
+		Compensate: func(ctx context.Context) error {
+			if existed {
+				return nil
+			}
+			return s.deleteProductVariantAuthoritative(ctx, row, row.ResourceVersion)
+		},
+	})
+	if row.ProductRefName != "" {
+		refRow := &productVariantProductRefRow{
+			Namespace: row.Namespace, ProductRefName: row.ProductRefName,
+			UID: uid, CreationTimestamp: row.CreationTimestamp,
+		}
+		actions = append(actions, mutationAction{
+			Step: catalogueStep("create", "ProductVariant", v.UID, "product_variant_by_product_ref", v.Namespace+"/"+v.ProductRefName, "write-product-ref"),
+			Apply: func(ctx context.Context) error {
+				return s.insertProjection(ctx, s.productVariantByProductRefTable, refRow)
+			},
+			Compensate: func(ctx context.Context) error {
+				if existed {
+					return nil
+				}
+				return s.deleteProductRefProjection(ctx, refRow)
+			},
+		})
+	}
+	if err := s.mutations.execute(ctx, actions...); err != nil {
 		return fmt.Errorf("scylla: create product_variant: %w", err)
+	}
+	if existed {
+		return fmt.Errorf("%w: product variant uid %s", datastore.ErrAlreadyExists, v.UID)
 	}
 	return nil
 }
 
-func (s *scyllaDatastore) GetProductVariant(_ context.Context, uid string) (*datastore.ProductVariant, error) {
+func (s *scyllaDatastore) GetProductVariant(ctx context.Context, uid string) (*datastore.ProductVariant, error) {
 	parsedUID, err := gocql.ParseUUID(uid)
 	if err != nil {
 		return nil, fmt.Errorf("%w: invalid product_variant uid %s", datastore.ErrNotFound, uid)
@@ -887,10 +1352,17 @@ func (s *scyllaDatastore) GetProductVariant(_ context.Context, uid string) (*dat
 		}
 		return nil, fmt.Errorf("scylla: get product_variant (uid lookup): %w", err)
 	}
-	return s.getProductVariantByKey(uidRow.Namespace, uidRow.CreationTimestamp, uidRow.UID)
+	variant, err := s.getProductVariantByKey(uidRow.Namespace, uidRow.CreationTimestamp, uidRow.UID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "ProductVariant", ResourceUID: uid, Projection: "product_variant_by_uid",
+			LookupKey: uid, Operation: "get", Type: datastore.FindingDangling,
+		})
+	}
+	return variant, err
 }
 
-func (s *scyllaDatastore) GetProductVariantByName(_ context.Context, namespace, name string) (*datastore.ProductVariant, error) {
+func (s *scyllaDatastore) GetProductVariantByName(ctx context.Context, namespace, name string) (*datastore.ProductVariant, error) {
 	stmt, names := s.productVariantByNameTable.Get()
 	var nameRow productVariantNameRow
 	if err := s.session.Query(stmt, names).BindMap(qb.M{"namespace": namespace, "name": name}).GetRelease(&nameRow); err != nil {
@@ -899,10 +1371,25 @@ func (s *scyllaDatastore) GetProductVariantByName(_ context.Context, namespace, 
 		}
 		return nil, fmt.Errorf("scylla: get product_variant by name: %w", err)
 	}
-	return s.getProductVariantByKey(nameRow.Namespace, nameRow.CreationTimestamp, nameRow.UID)
+	variant, err := s.getProductVariantByKey(nameRow.Namespace, nameRow.CreationTimestamp, nameRow.UID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "ProductVariant", ResourceUID: nameRow.UID.String(), Projection: "product_variant_by_name",
+			LookupKey: namespace + "/" + name, Operation: "get_by_name", Type: datastore.FindingDangling,
+		})
+		return nil, err
+	}
+	if err == nil && (variant.Name != name || variant.Namespace != namespace) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "ProductVariant", ResourceUID: nameRow.UID.String(), Projection: "product_variant_by_name",
+			LookupKey: namespace + "/" + name, Operation: "get_by_name", Type: datastore.FindingStale,
+		})
+		return nil, fmt.Errorf("%w: stale product variant name projection %s/%s", datastore.ErrNotFound, namespace, name)
+	}
+	return variant, err
 }
 
-func (s *scyllaDatastore) GetProductVariantBySKU(_ context.Context, namespace, sku string) (*datastore.ProductVariant, error) {
+func (s *scyllaDatastore) GetProductVariantBySKU(ctx context.Context, namespace, sku string) (*datastore.ProductVariant, error) {
 	stmt, names := s.productVariantBySKUTable.Get()
 	var skuRow productVariantSKURow
 	if err := s.session.Query(stmt, names).BindMap(qb.M{"namespace": namespace, "sku": sku}).GetRelease(&skuRow); err != nil {
@@ -911,7 +1398,22 @@ func (s *scyllaDatastore) GetProductVariantBySKU(_ context.Context, namespace, s
 		}
 		return nil, fmt.Errorf("scylla: get product_variant by sku: %w", err)
 	}
-	return s.getProductVariantByKey(skuRow.Namespace, skuRow.CreationTimestamp, skuRow.UID)
+	variant, err := s.getProductVariantByKey(skuRow.Namespace, skuRow.CreationTimestamp, skuRow.UID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "ProductVariant", ResourceUID: skuRow.UID.String(), Projection: "product_variant_by_sku",
+			LookupKey: namespace + "/" + sku, Operation: "get_by_sku", Type: datastore.FindingDangling,
+		})
+		return nil, err
+	}
+	if err == nil && (variant.SKU != sku || variant.Namespace != namespace) {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "ProductVariant", ResourceUID: skuRow.UID.String(), Projection: "product_variant_by_sku",
+			LookupKey: namespace + "/" + sku, Operation: "get_by_sku", Type: datastore.FindingStale,
+		})
+		return nil, fmt.Errorf("%w: stale product variant sku projection %s/%s", datastore.ErrNotFound, namespace, sku)
+	}
+	return variant, err
 }
 
 func (s *scyllaDatastore) getProductVariantByKey(namespace string, createdAt time.Time, uid gocql.UUID) (*datastore.ProductVariant, error) {
@@ -950,7 +1452,7 @@ func (s *scyllaDatastore) ListProductVariants(_ context.Context, namespace strin
 	return buildPageResult(items, limit, page), nil
 }
 
-func (s *scyllaDatastore) ListProductVariantsByProductRef(_ context.Context, namespace, productRefName string) ([]*datastore.ProductVariant, error) {
+func (s *scyllaDatastore) ListProductVariantsByProductRef(ctx context.Context, namespace, productRefName string) ([]*datastore.ProductVariant, error) {
 	cols := strings.Join(s.productVariantByProductRefTable.Metadata().Columns, ", ")
 	stmt := fmt.Sprintf(
 		"SELECT %s FROM product_variant_by_product_ref WHERE namespace = ? AND product_ref_name = ?",
@@ -964,6 +1466,19 @@ func (s *scyllaDatastore) ListProductVariantsByProductRef(_ context.Context, nam
 	for _, r := range refRows {
 		v, err := s.getProductVariantByKey(r.Namespace, r.CreationTimestamp, r.UID)
 		if err != nil {
+			if errors.Is(err, datastore.ErrNotFound) {
+				s.reportFinding(ctx, datastore.ProjectionFinding{
+					ResourceKind: "ProductVariant", ResourceUID: r.UID.String(), Projection: "product_variant_by_product_ref",
+					LookupKey: namespace + "/" + productRefName, Operation: "list_by_product_ref", Type: datastore.FindingDangling,
+				})
+			}
+			continue
+		}
+		if v.ProductRefName != productRefName {
+			s.reportFinding(ctx, datastore.ProjectionFinding{
+				ResourceKind: "ProductVariant", ResourceUID: r.UID.String(), Projection: "product_variant_by_product_ref",
+				LookupKey: namespace + "/" + productRefName, Operation: "list_by_product_ref", Type: datastore.FindingStale,
+			})
 			continue
 		}
 		result = append(result, v)
@@ -972,52 +1487,112 @@ func (s *scyllaDatastore) ListProductVariantsByProductRef(_ context.Context, nam
 }
 
 func (s *scyllaDatastore) UpdateProductVariant(ctx context.Context, v *datastore.ProductVariant) error {
-	existing, err := s.GetProductVariantByName(ctx, v.Namespace, v.Name)
+	if v == nil {
+		return fmt.Errorf("%w: product variant is nil", datastore.ErrInvalidArgument)
+	}
+	uid, err := gocql.ParseUUID(v.UID)
 	if err != nil {
+		return fmt.Errorf("%w: invalid product variant uid %s", datastore.ErrInvalidArgument, v.UID)
+	}
+	var existing *datastore.ProductVariant
+	if v.CreationTimestamp.IsZero() {
+		existing, err = s.GetProductVariant(ctx, v.UID)
+	} else {
+		existing, err = s.getProductVariantByKey(v.Namespace, v.CreationTimestamp, uid)
+	}
+	if err != nil {
+		return err
+	}
+	if existing.Namespace != v.Namespace || existing.Name != v.Name {
+		return fmt.Errorf("%w: product variant identity is immutable", datastore.ErrConflict)
+	}
+	if err := validateResourceVersionTransition(existing.ResourceVersion, v.ResourceVersion); err != nil {
 		return err
 	}
 	row := toProductVariantRow(v)
 	row.CreationTimestamp = existing.CreationTimestamp
 	existingUID := mustParseUUID(existing.UID)
+	skuConverged := row.SKU == ""
+	productRefConverged := row.ProductRefName == ""
 
-	const updNS = "UPDATE product_variant_by_namespace SET api_version=?, kind=?, generation=?, resource_version=?, " +
-		"revision=?, labels=?, annotations=?, owner_references=?, sku=?, product_ref_name=?, repository_id=?, source_path=?, git_commit_sha=?, git_ref=?, spec=?, body=?, status=? " +
-		"WHERE namespace=? AND creation_timestamp=? AND uid=?"
-
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query(updNS,
-		row.APIVersion, row.Kind, row.Generation, row.ResourceVersion,
-		row.Revision, row.Labels, row.Annotations, row.OwnerReferences,
-		row.SKU, row.ProductRefName, row.RepositoryID, row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
-		row.Namespace, row.CreationTimestamp, existingUID,
+	projections := []mutationAction{
+		{
+			Step: catalogueStep("update", "ProductVariant", v.UID, "product_variant_by_name", v.Namespace+"/"+v.Name, "converge-name"),
+			Apply: func(ctx context.Context) error {
+				return s.reserveName(ctx, "ProductVariant", "product_variant_by_name", row.Namespace, row.Name, existingUID, row.CreationTimestamp)
+			},
+		},
+		{
+			Step: catalogueStep("update", "ProductVariant", v.UID, "product_variant_by_uid", v.UID, "converge-uid"),
+			Apply: func(ctx context.Context) error {
+				return s.reserveUID(ctx, "ProductVariant", "product_variant_by_uid", row.Namespace, existingUID, row.CreationTimestamp)
+			},
+		},
+	}
+	if row.SKU != "" {
+		projections = append(projections, mutationAction{
+			Step: catalogueStep("update", "ProductVariant", v.UID, "product_variant_by_sku", v.Namespace+"/"+v.SKU, "converge-sku"),
+			Apply: func(ctx context.Context) error {
+				if err := s.reserveSKU(ctx, row.Namespace, row.SKU, existingUID, row.CreationTimestamp); err != nil {
+					return err
+				}
+				skuConverged = true
+				return nil
+			},
+		})
+	}
+	if existing.SKU != "" && existing.SKU != row.SKU {
+		projections = append(projections, mutationAction{
+			Step: catalogueStep("update", "ProductVariant", v.UID, "product_variant_by_sku", v.Namespace+"/"+existing.SKU, "delete-old-sku"),
+			Apply: func(ctx context.Context) error {
+				if !skuConverged {
+					return errors.New("new sku reservation has not converged")
+				}
+				return s.releaseSKU(ctx, row.Namespace, existing.SKU, existingUID)
+			},
+		})
+	}
+	if row.ProductRefName != "" {
+		refRow := &productVariantProductRefRow{
+			Namespace: row.Namespace, ProductRefName: row.ProductRefName,
+			UID: existingUID, CreationTimestamp: row.CreationTimestamp,
+		}
+		projections = append(projections, mutationAction{
+			Step: catalogueStep("update", "ProductVariant", v.UID, "product_variant_by_product_ref", v.Namespace+"/"+v.ProductRefName, "converge-product-ref"),
+			Apply: func(ctx context.Context) error {
+				if err := s.insertProjection(ctx, s.productVariantByProductRefTable, refRow); err != nil {
+					return err
+				}
+				productRefConverged = true
+				return nil
+			},
+		})
+	}
+	if existing.ProductRefName != "" && existing.ProductRefName != row.ProductRefName {
+		oldRef := &productVariantProductRefRow{
+			Namespace: row.Namespace, ProductRefName: existing.ProductRefName,
+			UID: existingUID, CreationTimestamp: row.CreationTimestamp,
+		}
+		projections = append(projections, mutationAction{
+			Step: catalogueStep("update", "ProductVariant", v.UID, "product_variant_by_product_ref", v.Namespace+"/"+existing.ProductRefName, "delete-old-product-ref"),
+			Apply: func(ctx context.Context) error {
+				if !productRefConverged {
+					return errors.New("new product reference projection has not converged")
+				}
+				return s.deleteProductRefProjection(ctx, oldRef)
+			},
+		})
+	}
+	err = s.mutations.executeUpdate(ctx, row.ResourceVersion,
+		mutationAction{
+			Step: catalogueStep("update", "ProductVariant", v.UID, "product_variant_by_namespace", v.UID, "update-authoritative"),
+			Apply: func(ctx context.Context) error {
+				return s.updateProductVariantAuthoritative(ctx, row, existing.ResourceVersion)
+			},
+		},
+		projections...,
 	)
-	// Maintain sku index: if SKU changed, delete old entry and insert new one.
-	oldSKU := existing.SKU
-	newSKU := v.SKU
-	if oldSKU != newSKU {
-		if oldSKU != "" {
-			b.Query("DELETE FROM product_variant_by_sku WHERE namespace=? AND sku=?",
-				row.Namespace, oldSKU)
-		}
-		if newSKU != "" {
-			insSKU, _ := s.productVariantBySKUTable.Insert()
-			b.Query(insSKU, row.Namespace, newSKU, existingUID, row.CreationTimestamp)
-		}
-	}
-	// Maintain product_ref index: if productRefName changed, delete old entry and insert new one.
-	oldRef := existing.ProductRefName
-	newRef := v.ProductRefName
-	if oldRef != newRef {
-		if oldRef != "" {
-			b.Query("DELETE FROM product_variant_by_product_ref WHERE namespace=? AND product_ref_name=? AND creation_timestamp=? AND uid=?",
-				row.Namespace, oldRef, row.CreationTimestamp, existingUID)
-		}
-		if newRef != "" {
-			insRef, _ := s.productVariantByProductRefTable.Insert()
-			b.Query(insRef, row.Namespace, newRef, existingUID, row.CreationTimestamp)
-		}
-	}
-	if err := s.session.ExecuteBatch(b); err != nil {
+	if err != nil {
 		return fmt.Errorf("scylla: update product_variant: %w", err)
 	}
 	return nil
@@ -1029,26 +1604,236 @@ func (s *scyllaDatastore) DeleteProductVariant(ctx context.Context, uid string) 
 		return err
 	}
 	parsedUID := mustParseUUID(uid)
-
-	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
-	b.Query("DELETE FROM product_variant_by_namespace WHERE namespace=? AND creation_timestamp=? AND uid=?",
-		v.Namespace, v.CreationTimestamp, parsedUID)
-	b.Query("DELETE FROM product_variant_by_name WHERE namespace=? AND name=?",
-		v.Namespace, v.Name)
-	b.Query("DELETE FROM product_variant_by_uid WHERE uid=?",
-		parsedUID)
+	projections := []mutationAction{
+		{
+			Step: catalogueStep("delete", "ProductVariant", uid, "product_variant_by_name", v.Namespace+"/"+v.Name, "delete-name"),
+			Apply: func(ctx context.Context) error {
+				return s.releaseName(ctx, "product_variant_by_name", v.Namespace, v.Name, parsedUID)
+			},
+			Compensate: func(ctx context.Context) error {
+				return s.reserveName(ctx, "ProductVariant", "product_variant_by_name", v.Namespace, v.Name, parsedUID, v.CreationTimestamp)
+			},
+		},
+		{
+			Step: catalogueStep("delete", "ProductVariant", uid, "product_variant_by_uid", uid, "delete-uid"),
+			Apply: func(ctx context.Context) error {
+				return s.releaseUID(ctx, "product_variant_by_uid", v.Namespace, parsedUID, v.CreationTimestamp)
+			},
+			Compensate: func(ctx context.Context) error {
+				return s.reserveUID(ctx, "ProductVariant", "product_variant_by_uid", v.Namespace, parsedUID, v.CreationTimestamp)
+			},
+		},
+	}
 	if v.SKU != "" {
-		b.Query("DELETE FROM product_variant_by_sku WHERE namespace=? AND sku=?",
-			v.Namespace, v.SKU)
+		projections = append(projections, mutationAction{
+			Step: catalogueStep("delete", "ProductVariant", uid, "product_variant_by_sku", v.Namespace+"/"+v.SKU, "delete-sku"),
+			Apply: func(ctx context.Context) error {
+				return s.releaseSKU(ctx, v.Namespace, v.SKU, parsedUID)
+			},
+			Compensate: func(ctx context.Context) error {
+				return s.reserveSKU(ctx, v.Namespace, v.SKU, parsedUID, v.CreationTimestamp)
+			},
+		})
 	}
 	if v.ProductRefName != "" {
-		b.Query("DELETE FROM product_variant_by_product_ref WHERE namespace=? AND product_ref_name=? AND creation_timestamp=? AND uid=?",
-			v.Namespace, v.ProductRefName, v.CreationTimestamp, parsedUID)
+		refRow := &productVariantProductRefRow{
+			Namespace: v.Namespace, ProductRefName: v.ProductRefName,
+			UID: parsedUID, CreationTimestamp: v.CreationTimestamp,
+		}
+		projections = append(projections, mutationAction{
+			Step: catalogueStep("delete", "ProductVariant", uid, "product_variant_by_product_ref", v.Namespace+"/"+v.ProductRefName, "delete-product-ref"),
+			Apply: func(ctx context.Context) error {
+				return s.deleteProductRefProjection(ctx, refRow)
+			},
+			Compensate: func(ctx context.Context) error {
+				return s.insertProjection(ctx, s.productVariantByProductRefTable, refRow)
+			},
+		})
 	}
-	if err := s.session.ExecuteBatch(b); err != nil {
+	err = s.mutations.executeDelete(ctx,
+		mutationAction{
+			Step: catalogueStep("delete", "ProductVariant", uid, "product_variant_by_namespace", uid, "delete-authoritative"),
+			Apply: func(ctx context.Context) error {
+				return s.deleteProductVariantAuthoritative(ctx, toProductVariantRow(v), v.ResourceVersion)
+			},
+		},
+		projections...,
+	)
+	if err != nil {
 		return fmt.Errorf("scylla: delete product_variant: %w", err)
 	}
 	return nil
+}
+
+func catalogueStep(operation, resourceKind, uid, projection, lookupKey, action string) datastore.MutationStep {
+	return datastore.MutationStep{
+		Operation:    operation,
+		ResourceKind: resourceKind,
+		ResourceUID:  uid,
+		Projection:   projection,
+		LookupKey:    lookupKey,
+		Action:       action,
+	}
+}
+
+func validateResourceVersionTransition(current, desired string) error {
+	if current == "" || desired == "" || current == desired {
+		return nil
+	}
+	currentVersion, currentOK := new(big.Int).SetString(current, 10)
+	desiredVersion, desiredOK := new(big.Int).SetString(desired, 10)
+	if !currentOK || !desiredOK || currentVersion.Sign() < 0 || desiredVersion.Sign() < 1 {
+		return fmt.Errorf("%w: invalid resource version transition %q -> %q", datastore.ErrConflict, current, desired)
+	}
+	if desiredVersion.Cmp(new(big.Int).Add(currentVersion, big.NewInt(1))) != 0 {
+		return fmt.Errorf("%w: stale resource version transition %q -> %q", datastore.ErrConflict, current, desired)
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) insertAuthoritative(ctx context.Context, target *table.Table, row any) (bool, error) {
+	statement, names := target.Insert()
+	applied, err := s.session.Query(statement+" IF NOT EXISTS", names).WithContext(ctx).
+		BindStruct(row).ExecCASRelease()
+	if err != nil {
+		return false, err
+	}
+	return applied, nil
+}
+
+func (s *scyllaDatastore) insertProjection(ctx context.Context, target *table.Table, row any) error {
+	statement, names := target.Insert()
+	return s.session.Query(statement, names).WithContext(ctx).BindStruct(row).ExecRelease()
+}
+
+func (s *scyllaDatastore) updateProductAuthoritative(ctx context.Context, row *productRow, expectedResourceVersion string) error {
+	const statement = "UPDATE products_by_namespace SET name=?,api_version=?,kind=?,generation=?,resource_version=?,revision=?," +
+		"creation_actor=?,update_timestamp=?,update_actor=?,labels=?,annotations=?,owner_references=?,finalizers=?,deletion_timestamp=?," +
+		"repository_id=?,source_path=?,git_commit_sha=?,git_ref=?,spec=?,body=?,status=? " +
+		"WHERE namespace=? AND creation_timestamp=? AND uid=? IF resource_version=?"
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).Bind(
+		row.Name, row.APIVersion, row.Kind, row.Generation, row.ResourceVersion, row.Revision,
+		row.CreationActor, row.UpdateTimestamp, row.UpdateActor, row.Labels, row.Annotations,
+		row.OwnerReferences, row.Finalizers, row.DeletionTimestamp, row.RepositoryID,
+		row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
+		row.Namespace, row.CreationTimestamp, row.UID, expectedResourceVersion,
+	).ExecCASRelease()
+	if err != nil {
+		return err
+	}
+	if !applied {
+		return datastore.ErrConflict
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) updateCategoryTaxonomyAuthoritative(ctx context.Context, row *categoryTaxonomyRow, expectedResourceVersion string) error {
+	const statement = "UPDATE category_taxonomy SET name=?,api_version=?,kind=?,generation=?,resource_version=?,revision=?," +
+		"creation_actor=?,update_timestamp=?,update_actor=?,labels=?,annotations=?,owner_references=?,finalizers=?,deletion_timestamp=?," +
+		"repository_id=?,source_path=?,git_commit_sha=?,git_ref=?,spec=?,body=?,status=?,parent_name=?,ancestor_path=? " +
+		"WHERE namespace=? AND creation_timestamp=? AND uid=? IF resource_version=?"
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).Bind(
+		row.Name, row.APIVersion, row.Kind, row.Generation, row.ResourceVersion, row.Revision,
+		row.CreationActor, row.UpdateTimestamp, row.UpdateActor, row.Labels, row.Annotations,
+		row.OwnerReferences, row.Finalizers, row.DeletionTimestamp, row.RepositoryID,
+		row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
+		row.ParentName, row.AncestorPath, row.Namespace, row.CreationTimestamp, row.UID, expectedResourceVersion,
+	).ExecCASRelease()
+	if err != nil {
+		return err
+	}
+	if !applied {
+		return datastore.ErrConflict
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) updateCollectionAuthoritative(ctx context.Context, row *collectionRow, expectedResourceVersion string) error {
+	const statement = "UPDATE collection SET name=?,api_version=?,kind=?,generation=?,resource_version=?,revision=?," +
+		"creation_actor=?,update_timestamp=?,update_actor=?,labels=?,annotations=?,owner_references=?,finalizers=?,deletion_timestamp=?," +
+		"repository_id=?,source_path=?,git_commit_sha=?,git_ref=?,spec=?,body=?,status=? " +
+		"WHERE namespace=? AND creation_timestamp=? AND uid=? IF resource_version=?"
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).Bind(
+		row.Name, row.APIVersion, row.Kind, row.Generation, row.ResourceVersion, row.Revision,
+		row.CreationActor, row.UpdateTimestamp, row.UpdateActor, row.Labels, row.Annotations,
+		row.OwnerReferences, row.Finalizers, row.DeletionTimestamp, row.RepositoryID,
+		row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
+		row.Namespace, row.CreationTimestamp, row.UID, expectedResourceVersion,
+	).ExecCASRelease()
+	if err != nil {
+		return err
+	}
+	if !applied {
+		return datastore.ErrConflict
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) updateProductVariantAuthoritative(ctx context.Context, row *productVariantRow, expectedResourceVersion string) error {
+	const statement = "UPDATE product_variant_by_namespace SET name=?,api_version=?,kind=?,generation=?,resource_version=?,revision=?," +
+		"creation_actor=?,update_timestamp=?,update_actor=?,labels=?,annotations=?,owner_references=?,finalizers=?,deletion_timestamp=?," +
+		"repository_id=?,source_path=?,git_commit_sha=?,git_ref=?,spec=?,body=?,status=?,sku=?,product_ref_name=? " +
+		"WHERE namespace=? AND creation_timestamp=? AND uid=? IF resource_version=?"
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).Bind(
+		row.Name, row.APIVersion, row.Kind, row.Generation, row.ResourceVersion, row.Revision,
+		row.CreationActor, row.UpdateTimestamp, row.UpdateActor, row.Labels, row.Annotations,
+		row.OwnerReferences, row.Finalizers, row.DeletionTimestamp, row.RepositoryID,
+		row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
+		row.SKU, row.ProductRefName, row.Namespace, row.CreationTimestamp, row.UID, expectedResourceVersion,
+	).ExecCASRelease()
+	if err != nil {
+		return err
+	}
+	if !applied {
+		return datastore.ErrConflict
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) deleteProductAuthoritative(ctx context.Context, row *productRow, expectedResourceVersion string) error {
+	return s.deleteAuthoritative(ctx,
+		"DELETE FROM products_by_namespace WHERE namespace=? AND creation_timestamp=? AND uid=? IF resource_version=?",
+		row.Namespace, row.CreationTimestamp, row.UID, expectedResourceVersion,
+	)
+}
+
+func (s *scyllaDatastore) deleteCategoryTaxonomyAuthoritative(ctx context.Context, row *categoryTaxonomyRow, expectedResourceVersion string) error {
+	return s.deleteAuthoritative(ctx,
+		"DELETE FROM category_taxonomy WHERE namespace=? AND creation_timestamp=? AND uid=? IF resource_version=?",
+		row.Namespace, row.CreationTimestamp, row.UID, expectedResourceVersion,
+	)
+}
+
+func (s *scyllaDatastore) deleteCollectionAuthoritative(ctx context.Context, row *collectionRow, expectedResourceVersion string) error {
+	return s.deleteAuthoritative(ctx,
+		"DELETE FROM collection WHERE namespace=? AND creation_timestamp=? AND uid=? IF resource_version=?",
+		row.Namespace, row.CreationTimestamp, row.UID, expectedResourceVersion,
+	)
+}
+
+func (s *scyllaDatastore) deleteProductVariantAuthoritative(ctx context.Context, row *productVariantRow, expectedResourceVersion string) error {
+	return s.deleteAuthoritative(ctx,
+		"DELETE FROM product_variant_by_namespace WHERE namespace=? AND creation_timestamp=? AND uid=? IF resource_version=?",
+		row.Namespace, row.CreationTimestamp, row.UID, expectedResourceVersion,
+	)
+}
+
+func (s *scyllaDatastore) deleteAuthoritative(ctx context.Context, statement string, args ...any) error {
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).Bind(args...).ExecCASRelease()
+	if err != nil {
+		return err
+	}
+	if !applied {
+		return datastore.ErrConflict
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) deleteProductRefProjection(ctx context.Context, row *productVariantProductRefRow) error {
+	return s.session.Query(
+		"DELETE FROM product_variant_by_product_ref WHERE namespace=? AND product_ref_name=? AND creation_timestamp=? AND uid=?",
+		nil,
+	).WithContext(ctx).Bind(row.Namespace, row.ProductRefName, row.CreationTimestamp, row.UID).ExecRelease()
 }
 
 // ── Namespace ─────────────────────────────────────────────────────────────────
@@ -1057,18 +1842,18 @@ func (s *scyllaDatastore) CreateNamespace(ctx context.Context, ns *datastore.Nam
 	if ns == nil {
 		return fmt.Errorf("%w: namespace is nil", datastore.ErrInvalidArgument)
 	}
-	if ns.ID == "" {
-		return fmt.Errorf("%w: namespace id is empty", datastore.ErrInvalidArgument)
+	if ns.UID == "" {
+		return fmt.Errorf("%w: namespace uid is empty", datastore.ErrInvalidArgument)
 	}
-	if _, err := gocql.ParseUUID(ns.ID); err != nil {
-		return fmt.Errorf("%w: invalid namespace id %s", datastore.ErrInvalidArgument, ns.ID)
+	if _, err := gocql.ParseUUID(ns.UID); err != nil {
+		return fmt.Errorf("%w: invalid namespace uid %s", datastore.ErrInvalidArgument, ns.UID)
 	}
 	datastore.NormalizeNamespaceContract(ns)
 	row := toNamespaceRow(ns)
 
-	const reserveName = "INSERT INTO namespaces_by_name (name, id) VALUES (?, ?) IF NOT EXISTS"
+	const reserveName = "INSERT INTO namespaces_by_name (name, uid) VALUES (?, ?) IF NOT EXISTS"
 	applied, err := s.session.Query(reserveName, nil).WithContext(ctx).
-		Bind(row.Name, row.ID).ExecCASRelease()
+		Bind(row.Name, row.UID).ExecCASRelease()
 	if err != nil {
 		return fmt.Errorf("scylla: reserve namespace name: %w", err)
 	}
@@ -1076,41 +1861,37 @@ func (s *scyllaDatastore) CreateNamespace(ctx context.Context, ns *datastore.Nam
 		return fmt.Errorf("%w: namespace name %s", datastore.ErrAlreadyExists, ns.Name)
 	}
 
-	const insertByID = "INSERT INTO namespaces_by_id " +
-		"(id, name, title, tier, spec, generation, resource_version, status, deletion_timestamp, finalizers, creation_timestamp, creation_actor, update_timestamp, update_actor) " +
-		"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS"
-	applied, err = s.session.Query(insertByID, nil).WithContext(ctx).Bind(
-		row.ID, row.Name, row.Title, row.Tier, row.Spec, row.Generation, row.ResourceVersion,
-		row.Status, row.DeletionTimestamp, row.Finalizers, row.CreationTimestamp, row.CreationActor, row.UpdateTimestamp, row.UpdateActor,
-	).ExecCASRelease()
+	insertByUID, names := s.namespaceByUIDTable.Insert()
+	applied, err = s.session.Query(insertByUID+" IF NOT EXISTS", names).WithContext(ctx).
+		BindStruct(row).ExecCASRelease()
 	if err != nil || !applied {
-		s.releaseNamespaceName(ctx, row.Name, row.ID)
+		s.releaseNamespaceName(ctx, row.Name, row.UID)
 		if err != nil {
-			return fmt.Errorf("scylla: create namespace by id: %w", err)
+			return fmt.Errorf("scylla: create namespace by uid: %w", err)
 		}
-		return fmt.Errorf("%w: namespace id %s", datastore.ErrAlreadyExists, ns.ID)
+		return fmt.Errorf("%w: namespace uid %s", datastore.ErrAlreadyExists, ns.UID)
 	}
 
-	const insertIndex = "INSERT INTO namespaces_by_bucket (bucket, creation_timestamp, id) VALUES (?, ?, ?)"
+	const insertIndex = "INSERT INTO namespaces_by_bucket (bucket, creation_timestamp, uid) VALUES (?, ?, ?)"
 	if err := s.session.Query(insertIndex, nil).WithContext(ctx).
-		Bind(namespaceBucket(row.CreationTimestamp), row.CreationTimestamp, row.ID).ExecRelease(); err != nil {
-		_ = s.session.Query("DELETE FROM namespaces_by_id WHERE id=?", nil).WithContext(ctx).Bind(row.ID).ExecRelease()
-		s.releaseNamespaceName(ctx, row.Name, row.ID)
+		Bind(namespaceBucket(row.CreationTimestamp), row.CreationTimestamp, row.UID).ExecRelease(); err != nil {
+		_ = s.session.Query("DELETE FROM namespaces_by_uid WHERE uid=?", nil).WithContext(ctx).Bind(row.UID).ExecRelease()
+		s.releaseNamespaceName(ctx, row.Name, row.UID)
 		return fmt.Errorf("scylla: create namespace listing index: %w", err)
 	}
 	return nil
 }
 
-func (s *scyllaDatastore) GetNamespace(ctx context.Context, id string) (*datastore.Namespace, error) {
-	uid, err := gocql.ParseUUID(id)
+func (s *scyllaDatastore) GetNamespace(ctx context.Context, uidString string) (*datastore.Namespace, error) {
+	uid, err := gocql.ParseUUID(uidString)
 	if err != nil {
-		return nil, fmt.Errorf("%w: invalid namespace id %s", datastore.ErrNotFound, id)
+		return nil, fmt.Errorf("%w: invalid namespace uid %s", datastore.ErrNotFound, uidString)
 	}
-	stmt, names := s.namespaceByIDTable.Get()
+	stmt, names := s.namespaceByUIDTable.Get()
 	var row namespaceRow
-	if err := s.session.Query(stmt, names).WithContext(ctx).BindMap(qb.M{"id": uid}).GetRelease(&row); err != nil {
+	if err := s.session.Query(stmt, names).WithContext(ctx).BindMap(qb.M{"uid": uid}).GetRelease(&row); err != nil {
 		if errors.Is(err, gocql.ErrNotFound) {
-			return nil, fmt.Errorf("%w: namespace id %s", datastore.ErrNotFound, id)
+			return nil, fmt.Errorf("%w: namespace uid %s", datastore.ErrNotFound, uidString)
 		}
 		return nil, fmt.Errorf("scylla: get namespace: %w", err)
 	}
@@ -1127,7 +1908,7 @@ func (s *scyllaDatastore) GetNamespaceByName(ctx context.Context, name string) (
 		}
 		return nil, fmt.Errorf("scylla: get namespace by name: %w", err)
 	}
-	namespace, err := s.GetNamespace(ctx, row.ID.String())
+	namespace, err := s.GetNamespace(ctx, row.UID.String())
 	if errors.Is(err, datastore.ErrNotFound) {
 		return nil, fmt.Errorf("%w: namespace name %s", datastore.ErrNotFound, name)
 	}
@@ -1163,7 +1944,7 @@ func (s *scyllaDatastore) ListNamespaces(ctx context.Context, page datastore.Pag
 
 	namespaces := make([]*datastore.Namespace, 0, len(rows))
 	for _, row := range rows {
-		namespace, err := s.GetNamespace(ctx, row.ID.String())
+		namespace, err := s.GetNamespace(ctx, row.UID.String())
 		if errors.Is(err, datastore.ErrNotFound) {
 			continue
 		}
@@ -1178,13 +1959,15 @@ func (s *scyllaDatastore) ListNamespaces(ctx context.Context, page datastore.Pag
 
 func (s *scyllaDatastore) UpdateNamespace(ctx context.Context, ns *datastore.Namespace, expectedResourceVersion string) error {
 	row := toNamespaceRow(ns)
-	const statement = "UPDATE namespaces_by_id SET name=?, title=?, tier=?, spec=?, generation=?, resource_version=?, " +
-		"status=?, deletion_timestamp=?, finalizers=?, creation_timestamp=?, creation_actor=?, update_timestamp=?, update_actor=? " +
-		"WHERE id=? IF resource_version=?"
+	const statement = "UPDATE namespaces_by_uid SET api_version=?, kind=?, name=?, title=?, tier=?, generation=?, resource_version=?, revision=?, " +
+		"creation_timestamp=?, creation_actor=?, update_timestamp=?, update_actor=?, labels=?, annotations=?, owner_references=?, " +
+		"finalizers=?, deletion_timestamp=?, source_path=?, git_commit_sha=?, git_ref=?, spec=?, body=?, status=? " +
+		"WHERE uid=? IF resource_version=?"
 	applied, err := s.session.Query(statement, nil).WithContext(ctx).Bind(
-		row.Name, row.Title, row.Tier, row.Spec, row.Generation, row.ResourceVersion,
-		row.Status, row.DeletionTimestamp, row.Finalizers, row.CreationTimestamp, row.CreationActor, row.UpdateTimestamp, row.UpdateActor,
-		row.ID, expectedResourceVersion,
+		row.APIVersion, row.Kind, row.Name, row.Title, row.Tier, row.Generation, row.ResourceVersion, row.Revision,
+		row.CreationTimestamp, row.CreationActor, row.UpdateTimestamp, row.UpdateActor, row.Labels, row.Annotations, row.OwnerReferences,
+		row.Finalizers, row.DeletionTimestamp, row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
+		row.UID, expectedResourceVersion,
 	).ExecCASRelease()
 	if err != nil {
 		return fmt.Errorf("scylla: update namespace: %w", err)
@@ -1195,47 +1978,67 @@ func (s *scyllaDatastore) UpdateNamespace(ctx context.Context, ns *datastore.Nam
 	return nil
 }
 
-func (s *scyllaDatastore) DeleteNamespace(ctx context.Context, id string) error {
-	ns, err := s.GetNamespace(ctx, id)
+func (s *scyllaDatastore) DeleteNamespace(ctx context.Context, uidString string) error {
+	ns, err := s.GetNamespace(ctx, uidString)
 	if err != nil {
 		return err
 	}
-	uid := mustParseUUID(id)
-	if err := s.session.Query("DELETE FROM namespaces_by_id WHERE id=?", nil).WithContext(ctx).
-		Bind(uid).ExecRelease(); err != nil {
+	if err := s.deleteNamespaceIndexes(ctx, ns); err != nil {
+		return err
+	}
+	uid := mustParseUUID(uidString)
+	if err := s.session.Query("DELETE FROM namespaces_by_uid WHERE uid=?", nil).WithContext(ctx).Bind(uid).ExecRelease(); err != nil {
+		if restoreErr := s.restoreNamespaceIndexes(ctx, ns); restoreErr != nil {
+			return datastore.NewRepairRequiredError(
+				datastore.MutationStep{
+					Operation:    "delete_namespace",
+					ResourceKind: "Namespace",
+					ResourceUID:  uidString,
+					Projection:   "namespaces_by_uid",
+					Action:       "delete_authoritative",
+				},
+				fmt.Errorf("scylla: delete namespace: %w", err),
+				restoreErr,
+			)
+		}
 		return fmt.Errorf("scylla: delete namespace: %w", err)
 	}
-	return s.deleteNamespaceIndexes(ctx, ns)
+	return nil
 }
 
-func (s *scyllaDatastore) DeleteNamespaceWithResourceVersion(ctx context.Context, id, expectedResourceVersion string) error {
-	ns, err := s.GetNamespace(ctx, id)
+func (s *scyllaDatastore) DeleteNamespaceWithResourceVersion(ctx context.Context, uidString, expectedResourceVersion string) error {
+	ns, err := s.GetNamespace(ctx, uidString)
 	if err != nil {
 		return err
 	}
-	const statement = "DELETE FROM namespaces_by_id WHERE id=? IF resource_version=?"
+	if err := s.deleteNamespaceIndexes(ctx, ns); err != nil {
+		return err
+	}
+	const statement = "DELETE FROM namespaces_by_uid WHERE uid=? IF resource_version=?"
 	applied, err := s.session.Query(statement, nil).WithContext(ctx).Bind(
-		mustParseUUID(id), expectedResourceVersion,
+		mustParseUUID(uidString), expectedResourceVersion,
 	).ExecCASRelease()
 	if err != nil {
+		_ = s.restoreNamespaceIndexes(ctx, ns)
 		return fmt.Errorf("scylla: delete namespace with resource version: %w", err)
 	}
 	if !applied {
+		_ = s.restoreNamespaceIndexes(ctx, ns)
 		return datastore.ErrConflict
 	}
-	return s.deleteNamespaceIndexes(ctx, ns)
+	return nil
 }
 
 func (s *scyllaDatastore) deleteNamespaceIndexes(ctx context.Context, ns *datastore.Namespace) error {
-	uid := mustParseUUID(ns.ID)
+	uid := mustParseUUID(ns.UID)
 	var cleanupErr error
 	if err := s.session.Query(
-		"DELETE FROM namespaces_by_bucket WHERE bucket=? AND creation_timestamp=? AND id=?",
+		"DELETE FROM namespaces_by_bucket WHERE bucket=? AND creation_timestamp=? AND uid=?",
 		nil,
 	).WithContext(ctx).Bind(namespaceBucket(ns.CreationTimestamp), ns.CreationTimestamp, uid).ExecRelease(); err != nil {
 		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete namespace listing index: %w", err))
 	}
-	const releaseName = "DELETE FROM namespaces_by_name WHERE name=? IF id=?"
+	const releaseName = "DELETE FROM namespaces_by_name WHERE name=? IF uid=?"
 	if _, err := s.session.Query(releaseName, nil).WithContext(ctx).
 		Bind(ns.Name, uid).ExecCASRelease(); err != nil {
 		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete namespace name index: %w", err))
@@ -1246,9 +2049,26 @@ func (s *scyllaDatastore) deleteNamespaceIndexes(ctx context.Context, ns *datast
 	return nil
 }
 
-func (s *scyllaDatastore) releaseNamespaceName(ctx context.Context, name string, id gocql.UUID) {
-	const statement = "DELETE FROM namespaces_by_name WHERE name=? IF id=?"
-	_, _ = s.session.Query(statement, nil).WithContext(ctx).Bind(name, id).ExecCASRelease()
+func (s *scyllaDatastore) restoreNamespaceIndexes(ctx context.Context, ns *datastore.Namespace) error {
+	uid := mustParseUUID(ns.UID)
+	if err := s.session.Query(
+		"INSERT INTO namespaces_by_name (name, uid) VALUES (?, ?)",
+		nil,
+	).WithContext(ctx).Bind(ns.Name, uid).ExecRelease(); err != nil {
+		return fmt.Errorf("restore namespace name index: %w", err)
+	}
+	if err := s.session.Query(
+		"INSERT INTO namespaces_by_bucket (bucket, creation_timestamp, uid) VALUES (?, ?, ?)",
+		nil,
+	).WithContext(ctx).Bind(namespaceBucket(ns.CreationTimestamp), ns.CreationTimestamp, uid).ExecRelease(); err != nil {
+		return fmt.Errorf("restore namespace listing index: %w", err)
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) releaseNamespaceName(ctx context.Context, name string, uid gocql.UUID) {
+	const statement = "DELETE FROM namespaces_by_name WHERE name=? IF uid=?"
+	_, _ = s.session.Query(statement, nil).WithContext(ctx).Bind(name, uid).ExecCASRelease()
 }
 
 // catalogTablesByRepositoryID lists every namespace-partitioned catalog table,
@@ -1270,11 +2090,6 @@ func (s *scyllaDatastore) HasCatalogResources(ctx context.Context, repoID string
 		}
 		return false, fmt.Errorf("scylla: has catalog resources: %w", err)
 	}
-	ns, err := s.GetNamespace(ctx, repo.NamespaceID)
-	if err != nil {
-		return false, fmt.Errorf("scylla: has catalog resources namespace: %w", err)
-	}
-
 	for _, tableName := range catalogTablesByRepositoryID {
 		stmt, names := qb.Select(tableName).
 			Columns("repository_id").
@@ -1283,11 +2098,11 @@ func (s *scyllaDatastore) HasCatalogResources(ctx context.Context, repoID string
 			AllowFiltering().
 			ToCql()
 		var row struct {
-			RepositoryID string `db:"repository_id"`
+			RepositoryID gocql.UUID `db:"repository_id"`
 		}
 		err := s.session.Query(stmt, names).BindMap(qb.M{
-			"namespace":     ns.Name,
-			"repository_id": repoID,
+			"namespace":     repo.Namespace,
+			"repository_id": mustParseUUID(repoID),
 		}).GetRelease(&row)
 		if err == nil {
 			return true, nil
@@ -1324,10 +2139,15 @@ func toProductRow(p *datastore.Product) *productRow {
 		Generation:        p.Generation,
 		ResourceVersion:   p.ResourceVersion,
 		Revision:          p.Revision,
+		CreationActor:     p.CreationActor,
+		UpdateTimestamp:   p.UpdateTimestamp,
+		UpdateActor:       p.UpdateActor,
 		Labels:            p.Labels,
 		Annotations:       p.Annotations,
 		OwnerReferences:   ownerReferences,
-		RepositoryID:      p.RepositoryID,
+		Finalizers:        append([]string(nil), p.Finalizers...),
+		DeletionTimestamp: p.DeletionTimestamp,
+		RepositoryID:      optionalUUID(p.RepositoryID),
 		SourcePath:        p.SourcePath,
 		GitCommitSHA:      p.GitCommitSHA,
 		GitRef:            p.GitRef,
@@ -1348,10 +2168,15 @@ func fromProductRow(r *productRow) *datastore.Product {
 		ResourceVersion:   r.ResourceVersion,
 		CreationTimestamp: r.CreationTimestamp,
 		Revision:          r.Revision,
+		CreationActor:     r.CreationActor,
+		UpdateTimestamp:   r.UpdateTimestamp,
+		UpdateActor:       r.UpdateActor,
 		Labels:            r.Labels,
 		Annotations:       r.Annotations,
 		OwnerReferences:   jsonOrNil(r.OwnerReferences),
-		RepositoryID:      r.RepositoryID,
+		Finalizers:        append([]string(nil), r.Finalizers...),
+		DeletionTimestamp: r.DeletionTimestamp,
+		RepositoryID:      uuidString(r.RepositoryID),
 		SourcePath:        r.SourcePath,
 		GitCommitSHA:      r.GitCommitSHA,
 		GitRef:            r.GitRef,
@@ -1380,18 +2205,24 @@ func toCategoryTaxonomyRow(c *datastore.CategoryTaxonomy) *categoryTaxonomyRow {
 	return &categoryTaxonomyRow{
 		Namespace:         c.Namespace,
 		Name:              c.Name,
-		UID:               c.UID,
+		UID:               mustParseUUID(c.UID),
 		APIVersion:        c.APIVersion,
 		Kind:              c.Kind,
 		Generation:        c.Generation,
 		ResourceVersion:   c.ResourceVersion,
 		CreationTimestamp: c.CreationTimestamp,
 		Revision:          c.Revision,
+		CreationActor:     c.CreationActor,
+		UpdateTimestamp:   c.UpdateTimestamp,
+		UpdateActor:       c.UpdateActor,
 		Labels:            c.Labels,
 		Annotations:       c.Annotations,
+		OwnerReferences:   string(c.OwnerReferences),
+		Finalizers:        append([]string(nil), c.Finalizers...),
+		DeletionTimestamp: c.DeletionTimestamp,
 		ParentName:        c.ParentName,
 		AncestorPath:      c.AncestorPath,
-		RepositoryID:      c.RepositoryID,
+		RepositoryID:      optionalUUID(c.RepositoryID),
 		SourcePath:        c.SourcePath,
 		GitCommitSHA:      c.GitCommitSHA,
 		GitRef:            c.GitRef,
@@ -1405,18 +2236,24 @@ func fromCategoryTaxonomyRow(r *categoryTaxonomyRow) *datastore.CategoryTaxonomy
 	return &datastore.CategoryTaxonomy{
 		Namespace:         r.Namespace,
 		Name:              r.Name,
-		UID:               r.UID,
+		UID:               r.UID.String(),
 		APIVersion:        r.APIVersion,
 		Kind:              r.Kind,
 		Generation:        r.Generation,
 		ResourceVersion:   r.ResourceVersion,
 		CreationTimestamp: r.CreationTimestamp,
 		Revision:          r.Revision,
+		CreationActor:     r.CreationActor,
+		UpdateTimestamp:   r.UpdateTimestamp,
+		UpdateActor:       r.UpdateActor,
 		Labels:            r.Labels,
 		Annotations:       r.Annotations,
+		OwnerReferences:   jsonOrNil(r.OwnerReferences),
+		Finalizers:        append([]string(nil), r.Finalizers...),
+		DeletionTimestamp: r.DeletionTimestamp,
 		ParentName:        r.ParentName,
 		AncestorPath:      r.AncestorPath,
-		RepositoryID:      r.RepositoryID,
+		RepositoryID:      uuidString(r.RepositoryID),
 		SourcePath:        r.SourcePath,
 		GitCommitSHA:      r.GitCommitSHA,
 		GitRef:            r.GitRef,
@@ -1437,9 +2274,15 @@ func toCollectionRow(c *datastore.Collection) *collectionRow {
 		Generation:        c.Generation,
 		ResourceVersion:   c.ResourceVersion,
 		Revision:          c.Revision,
+		CreationActor:     c.CreationActor,
+		UpdateTimestamp:   c.UpdateTimestamp,
+		UpdateActor:       c.UpdateActor,
 		Labels:            c.Labels,
 		Annotations:       c.Annotations,
-		RepositoryID:      c.RepositoryID,
+		OwnerReferences:   string(c.OwnerReferences),
+		Finalizers:        append([]string(nil), c.Finalizers...),
+		DeletionTimestamp: c.DeletionTimestamp,
+		RepositoryID:      optionalUUID(c.RepositoryID),
 		SourcePath:        c.SourcePath,
 		GitCommitSHA:      c.GitCommitSHA,
 		GitRef:            c.GitRef,
@@ -1460,9 +2303,15 @@ func fromCollectionRow(r *collectionRow) *datastore.Collection {
 		ResourceVersion:   r.ResourceVersion,
 		CreationTimestamp: r.CreationTimestamp,
 		Revision:          r.Revision,
+		CreationActor:     r.CreationActor,
+		UpdateTimestamp:   r.UpdateTimestamp,
+		UpdateActor:       r.UpdateActor,
 		Labels:            r.Labels,
 		Annotations:       r.Annotations,
-		RepositoryID:      r.RepositoryID,
+		OwnerReferences:   jsonOrNil(r.OwnerReferences),
+		Finalizers:        append([]string(nil), r.Finalizers...),
+		DeletionTimestamp: r.DeletionTimestamp,
+		RepositoryID:      uuidString(r.RepositoryID),
 		SourcePath:        r.SourcePath,
 		GitCommitSHA:      r.GitCommitSHA,
 		GitRef:            r.GitRef,
@@ -1483,12 +2332,17 @@ func toProductVariantRow(v *datastore.ProductVariant) *productVariantRow {
 		Generation:        v.Generation,
 		ResourceVersion:   v.ResourceVersion,
 		Revision:          v.Revision,
+		CreationActor:     v.CreationActor,
+		UpdateTimestamp:   v.UpdateTimestamp,
+		UpdateActor:       v.UpdateActor,
 		Labels:            v.Labels,
 		Annotations:       v.Annotations,
 		OwnerReferences:   string(v.OwnerReferences),
+		Finalizers:        append([]string(nil), v.Finalizers...),
+		DeletionTimestamp: v.DeletionTimestamp,
 		SKU:               v.SKU,
 		ProductRefName:    v.ProductRefName,
-		RepositoryID:      v.RepositoryID,
+		RepositoryID:      optionalUUID(v.RepositoryID),
 		SourcePath:        v.SourcePath,
 		GitCommitSHA:      v.GitCommitSHA,
 		GitRef:            v.GitRef,
@@ -1509,12 +2363,17 @@ func fromProductVariantRow(r *productVariantRow) *datastore.ProductVariant {
 		ResourceVersion:   r.ResourceVersion,
 		CreationTimestamp: r.CreationTimestamp,
 		Revision:          r.Revision,
+		CreationActor:     r.CreationActor,
+		UpdateTimestamp:   r.UpdateTimestamp,
+		UpdateActor:       r.UpdateActor,
 		Labels:            r.Labels,
 		Annotations:       r.Annotations,
 		OwnerReferences:   jsonOrNil(r.OwnerReferences),
+		Finalizers:        append([]string(nil), r.Finalizers...),
+		DeletionTimestamp: r.DeletionTimestamp,
 		SKU:               r.SKU,
 		ProductRefName:    r.ProductRefName,
-		RepositoryID:      r.RepositoryID,
+		RepositoryID:      uuidString(r.RepositoryID),
 		SourcePath:        r.SourcePath,
 		GitCommitSHA:      r.GitCommitSHA,
 		GitRef:            r.GitRef,
@@ -1535,39 +2394,59 @@ func mustParseUUID(s string) gocql.UUID {
 func toNamespaceRow(ns *datastore.Namespace) *namespaceRow {
 	datastore.NormalizeNamespaceContract(ns)
 	return &namespaceRow{
-		CreationTimestamp: ns.CreationTimestamp,
-		ID:                mustParseUUID(ns.ID),
+		APIVersion:        ns.APIVersion,
+		Kind:              ns.Kind,
+		UID:               mustParseUUID(ns.UID),
 		Name:              ns.Name,
 		Title:             ns.Title,
 		Tier:              string(ns.Tier),
-		Spec:              string(ns.Spec),
 		Generation:        ns.Generation,
 		ResourceVersion:   ns.ResourceVersion,
-		Status:            string(ns.Status),
-		DeletionTimestamp: ns.DeletionTimestamp,
-		Finalizers:        append([]string(nil), ns.Finalizers...),
+		Revision:          ns.Revision,
+		CreationTimestamp: ns.CreationTimestamp,
 		CreationActor:     ns.CreationActor,
 		UpdateTimestamp:   ns.UpdateTimestamp,
 		UpdateActor:       ns.UpdateActor,
+		Labels:            ns.Labels,
+		Annotations:       ns.Annotations,
+		OwnerReferences:   string(ns.OwnerReferences),
+		Finalizers:        append([]string(nil), ns.Finalizers...),
+		DeletionTimestamp: ns.DeletionTimestamp,
+		SourcePath:        ns.SourcePath,
+		GitCommitSHA:      ns.GitCommitSHA,
+		GitRef:            ns.GitRef,
+		Spec:              string(ns.Spec),
+		Body:              ns.Body,
+		Status:            string(ns.Status),
 	}
 }
 
 func fromNamespaceRow(r *namespaceRow) *datastore.Namespace {
 	namespace := &datastore.Namespace{
-		ID:                r.ID.String(),
+		APIVersion:        r.APIVersion,
+		Kind:              r.Kind,
+		UID:               r.UID.String(),
 		Name:              r.Name,
 		Title:             r.Title,
 		Tier:              datastore.NamespaceTier(r.Tier),
-		Spec:              []byte(r.Spec),
 		Generation:        r.Generation,
 		ResourceVersion:   r.ResourceVersion,
-		Status:            []byte(r.Status),
-		DeletionTimestamp: r.DeletionTimestamp,
-		Finalizers:        append([]string(nil), r.Finalizers...),
+		Revision:          r.Revision,
 		CreationTimestamp: r.CreationTimestamp,
 		CreationActor:     r.CreationActor,
 		UpdateTimestamp:   r.UpdateTimestamp,
 		UpdateActor:       r.UpdateActor,
+		Labels:            r.Labels,
+		Annotations:       r.Annotations,
+		OwnerReferences:   jsonOrNil(r.OwnerReferences),
+		Finalizers:        append([]string(nil), r.Finalizers...),
+		DeletionTimestamp: r.DeletionTimestamp,
+		SourcePath:        r.SourcePath,
+		GitCommitSHA:      r.GitCommitSHA,
+		GitRef:            r.GitRef,
+		Spec:              jsonOrNil(r.Spec),
+		Body:              r.Body,
+		Status:            jsonOrNil(r.Status),
 	}
 	datastore.NormalizeNamespaceContract(namespace)
 	return namespace

--- a/gitstore-api/internal/datastore/scylla/backend_recovery_test.go
+++ b/gitstore-api/internal/datastore/scylla/backend_recovery_test.go
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package scylla
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatalogueRowsPreserveCanonicalEnvelope(t *testing.T) {
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(time.Hour)
+	uid := uuid.New().String()
+	repositoryID := uuid.New().String()
+	owners := json.RawMessage(`[{"uid":"owner"}]`)
+	spec := json.RawMessage(`{"field":"value"}`)
+	status := json.RawMessage(`{"observedGeneration":4}`)
+
+	product := &datastore.Product{
+		UID: uid, Namespace: "shop", Name: "product", APIVersion: "catalog/v1", Kind: "Product",
+		Generation: 4, ResourceVersion: "7", Revision: "main@sha", CreationTimestamp: now,
+		CreationActor: "creator", UpdateTimestamp: now.Add(time.Minute), UpdateActor: "updater",
+		Labels: map[string]string{"a": "b"}, Annotations: map[string]string{"c": "d"},
+		OwnerReferences: owners, Finalizers: []string{"finalizer"}, DeletionTimestamp: &deletedAt,
+		RepositoryID: repositoryID, SourcePath: "products/product.md", GitCommitSHA: "sha", GitRef: "refs/heads/main",
+		Spec: spec, Body: "body", Status: status,
+	}
+	productRow := toProductRow(product)
+	assert.Equal(t, product.CreationActor, productRow.CreationActor)
+	assert.Equal(t, string(owners), productRow.OwnerReferences)
+	assert.Equal(t, product.Finalizers, productRow.Finalizers)
+	assert.Equal(t, &deletedAt, productRow.DeletionTimestamp)
+	require.NotNil(t, productRow.RepositoryID)
+	assert.Equal(t, repositoryID, productRow.RepositoryID.String())
+	assert.Equal(t, product, fromProductRow(productRow))
+
+	category := &datastore.CategoryTaxonomy{
+		UID: uid, Namespace: "shop", Name: "category", APIVersion: "catalog/v1", Kind: "CategoryTaxonomy",
+		Generation: 4, ResourceVersion: "7", Revision: "main@sha", CreationTimestamp: now,
+		CreationActor: "creator", UpdateTimestamp: now.Add(time.Minute), UpdateActor: "updater",
+		Labels: product.Labels, Annotations: product.Annotations, OwnerReferences: owners,
+		Finalizers: product.Finalizers, DeletionTimestamp: &deletedAt, ParentName: "parent", AncestorPath: "parent/category",
+		RepositoryID: repositoryID, SourcePath: "categories/category.md", GitCommitSHA: "sha", GitRef: "refs/heads/main",
+		Spec: spec, Body: "body", Status: status,
+	}
+	categoryRow := toCategoryTaxonomyRow(category)
+	assert.Equal(t, string(owners), categoryRow.OwnerReferences)
+	assert.Equal(t, category, fromCategoryTaxonomyRow(categoryRow))
+
+	collection := &datastore.Collection{
+		UID: uid, Namespace: "shop", Name: "collection", APIVersion: "catalog/v1", Kind: "Collection",
+		Generation: 4, ResourceVersion: "7", Revision: "main@sha", CreationTimestamp: now,
+		CreationActor: "creator", UpdateTimestamp: now.Add(time.Minute), UpdateActor: "updater",
+		Labels: product.Labels, Annotations: product.Annotations, OwnerReferences: owners,
+		Finalizers: product.Finalizers, DeletionTimestamp: &deletedAt, RepositoryID: repositoryID,
+		SourcePath: "collections/collection.md", GitCommitSHA: "sha", GitRef: "refs/heads/main",
+		Spec: spec, Body: "body", Status: status,
+	}
+	collectionRow := toCollectionRow(collection)
+	assert.Equal(t, string(owners), collectionRow.OwnerReferences)
+	assert.Equal(t, collection, fromCollectionRow(collectionRow))
+
+	variant := &datastore.ProductVariant{
+		UID: uid, Namespace: "shop", Name: "variant", APIVersion: "catalog/v1", Kind: "ProductVariant",
+		Generation: 4, ResourceVersion: "7", Revision: "main@sha", CreationTimestamp: now,
+		CreationActor: "creator", UpdateTimestamp: now.Add(time.Minute), UpdateActor: "updater",
+		Labels: product.Labels, Annotations: product.Annotations, OwnerReferences: owners,
+		Finalizers: product.Finalizers, DeletionTimestamp: &deletedAt, SKU: "sku", ProductRefName: "product",
+		RepositoryID: repositoryID, SourcePath: "variants/variant.md", GitCommitSHA: "sha", GitRef: "refs/heads/main",
+		Spec: spec, Body: "body", Status: status,
+	}
+	variantRow := toProductVariantRow(variant)
+	assert.Equal(t, string(owners), variantRow.OwnerReferences)
+	assert.Equal(t, variant, fromProductVariantRow(variantRow))
+}
+
+func TestCatalogueCreateCompensatesEveryFailureBoundary(t *testing.T) {
+	tests := []struct {
+		kind        string
+		projections []string
+	}{
+		{kind: "Product", projections: []string{"name", "uid", "authoritative"}},
+		{kind: "CategoryTaxonomy", projections: []string{"name", "uid", "authoritative"}},
+		{kind: "Collection", projections: []string{"name", "uid", "authoritative"}},
+		{kind: "ProductVariant", projections: []string{"name", "uid", "sku", "authoritative", "product-ref"}},
+	}
+
+	for _, test := range tests {
+		for _, failedProjection := range test.projections {
+			for _, point := range []failurePoint{failureBefore, failureAfter} {
+				t.Run(test.kind+"/"+failedProjection+"/"+string(point), func(t *testing.T) {
+					state := make(map[string]bool)
+					injector := newTestFailureInjector()
+					injector.fail("create-"+failedProjection, point)
+					executor := newMutationExecutor(injector)
+
+					err := executor.execute(context.Background(), createActions(test.kind, state, test.projections)...)
+
+					require.Error(t, err)
+					for _, projection := range test.projections {
+						assert.False(t, state[projection], "projection %s was not compensated", projection)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestCatalogueUpdateRollsForwardAfterProjectionFailure(t *testing.T) {
+	tests := []struct {
+		kind        string
+		projections []string
+	}{
+		{kind: "Product", projections: []string{"name", "uid"}},
+		{kind: "CategoryTaxonomy", projections: []string{"name", "uid"}},
+		{kind: "Collection", projections: []string{"name", "uid"}},
+		{kind: "ProductVariant", projections: []string{"name", "uid", "sku", "product-ref"}},
+	}
+	for _, test := range tests {
+		for _, failedProjection := range test.projections {
+			for _, point := range []failurePoint{failureBefore, failureAfter} {
+				t.Run(test.kind+"/"+failedProjection+"/"+string(point), func(t *testing.T) {
+					state := map[string]string{"authoritative": "old"}
+					for _, projection := range test.projections {
+						state[projection] = "old"
+					}
+					injector := newTestFailureInjector()
+					injector.fail("converge-"+failedProjection, point)
+					executor := newMutationExecutor(injector)
+
+					err := executor.executeUpdate(
+						context.Background(),
+						"2",
+						updateAuthoritativeAction(test.kind, state),
+						updateProjectionActions(test.kind, state, test.projections)...,
+					)
+
+					require.NoError(t, err)
+					for key, value := range state {
+						assert.Equal(t, "new", value, "%s did not roll forward", key)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestCatalogueUpdateReturnsRepairRequiredWithoutRollingBackAuthoritative(t *testing.T) {
+	state := map[string]string{"authoritative": "old", "old-sku": "present", "new-sku": "missing"}
+	executor := newMutationExecutor(nil)
+	newSKUConverged := false
+
+	err := executor.executeUpdate(
+		context.Background(),
+		"2",
+		mutationAction{
+			Step: datastore.MutationStep{ResourceKind: "ProductVariant", Projection: "authoritative", Action: "update-authoritative"},
+			Apply: func(context.Context) error {
+				state["authoritative"] = "new"
+				return nil
+			},
+		},
+		mutationAction{
+			Step: datastore.MutationStep{ResourceKind: "ProductVariant", Projection: "new-sku", Action: "converge-sku"},
+			Apply: func(context.Context) error {
+				return errors.New("persistent projection failure")
+			},
+		},
+		mutationAction{
+			Step: datastore.MutationStep{ResourceKind: "ProductVariant", Projection: "old-sku", Action: "delete-old-sku"},
+			Apply: func(context.Context) error {
+				if !newSKUConverged {
+					return errors.New("new sku has not converged")
+				}
+				state["old-sku"] = "deleted"
+				return nil
+			},
+		},
+	)
+
+	require.ErrorIs(t, err, datastore.ErrRepairRequired)
+	assert.Equal(t, "new", state["authoritative"])
+	assert.Equal(t, "present", state["old-sku"])
+	assert.Equal(t, "missing", state["new-sku"])
+}
+
+func TestCatalogueUpdateConvergesAfterAuthoritativePostCommitFailure(t *testing.T) {
+	state := map[string]string{"authoritative": "old", "name": "old"}
+	injector := newTestFailureInjector()
+	injector.fail("update-authoritative", failureAfter)
+	executor := newMutationExecutor(injector)
+
+	err := executor.executeUpdate(
+		context.Background(),
+		"2",
+		mutationAction{
+			Step: datastore.MutationStep{ResourceKind: "Product", Projection: "authoritative", Action: "update-authoritative"},
+			Apply: func(context.Context) error {
+				state["authoritative"] = "new"
+				return nil
+			},
+		},
+		mutationAction{
+			Step: datastore.MutationStep{ResourceKind: "Product", Projection: "name", Action: "converge-name"},
+			Apply: func(context.Context) error {
+				state["name"] = "new"
+				return nil
+			},
+		},
+	)
+
+	require.Error(t, err)
+	assert.Equal(t, "new", state["authoritative"])
+	assert.Equal(t, "new", state["name"])
+}
+
+func TestCatalogueUpdateAuthoritativeFailurePerformsNoProjectionWrites(t *testing.T) {
+	for _, applyFailure := range []bool{false, true} {
+		t.Run(map[bool]string{false: "before", true: "apply"}[applyFailure], func(t *testing.T) {
+			state := map[string]string{"authoritative": "old", "name": "old"}
+			injector := newTestFailureInjector()
+			if !applyFailure {
+				injector.fail("update-authoritative", failureBefore)
+			}
+			executor := newMutationExecutor(injector)
+			authoritative := updateAuthoritativeAction("Product", state)
+			if applyFailure {
+				authoritative.Apply = func(context.Context) error {
+					return errors.New("compare-and-set failed")
+				}
+			}
+
+			err := executor.executeUpdate(
+				context.Background(),
+				"2",
+				authoritative,
+				updateProjectionActions("Product", state, []string{"name"})...,
+			)
+
+			require.Error(t, err)
+			assert.Equal(t, "old", state["authoritative"])
+			assert.Equal(t, "old", state["name"])
+		})
+	}
+}
+
+func TestCatalogueStaleVersionPerformsNoWrites(t *testing.T) {
+	writes := 0
+	err := validateResourceVersionTransition("3", "2")
+	if err == nil {
+		writes++
+	}
+
+	require.ErrorIs(t, err, datastore.ErrConflict)
+	assert.Zero(t, writes)
+}
+
+func TestCatalogueDeleteRestoresExactPriorStateAtEveryPrecommitBoundary(t *testing.T) {
+	tests := []struct {
+		kind        string
+		projections []string
+	}{
+		{kind: "Product", projections: []string{"name", "uid"}},
+		{kind: "CategoryTaxonomy", projections: []string{"name", "uid"}},
+		{kind: "Collection", projections: []string{"name", "uid"}},
+		{kind: "ProductVariant", projections: []string{"name", "uid", "sku", "product-ref"}},
+	}
+	for _, test := range tests {
+		for _, failedStep := range append(append([]string(nil), test.projections...), "authoritative") {
+			for _, point := range []failurePoint{failureBefore, failureAfter} {
+				if failedStep == "authoritative" && point == failureAfter {
+					continue
+				}
+				t.Run(test.kind+"/"+failedStep+"/"+string(point), func(t *testing.T) {
+					state := map[string]bool{"authoritative": true}
+					for _, projection := range test.projections {
+						state[projection] = true
+					}
+					injector := newTestFailureInjector()
+					injector.fail("delete-"+failedStep, point)
+					executor := newMutationExecutor(injector)
+
+					err := executor.executeDelete(
+						context.Background(),
+						deleteAuthoritativeAction(state, nil),
+						deleteProjectionActions(state, test.projections)...,
+					)
+
+					require.Error(t, err)
+					for key, present := range state {
+						assert.True(t, present, "%s was not restored", key)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestCatalogueDeleteAfterAuthoritativeFailureKeepsDesiredFinalState(t *testing.T) {
+	state := map[string]bool{"authoritative": true, "name": true, "uid": true}
+	injector := newTestFailureInjector()
+	injector.fail("delete-authoritative", failureAfter)
+	executor := newMutationExecutor(injector)
+
+	err := executor.executeDelete(
+		context.Background(),
+		deleteAuthoritativeAction(state, nil),
+		deleteProjectionActions(state, []string{"name", "uid"})...,
+	)
+
+	require.Error(t, err)
+	assert.False(t, state["authoritative"])
+	assert.False(t, state["name"])
+	assert.False(t, state["uid"])
+}
+
+func TestCatalogueDeleteCompensationFailureRequiresRepair(t *testing.T) {
+	state := map[string]bool{"authoritative": true, "name": true}
+	executor := newMutationExecutor(nil)
+	projection := mutationAction{
+		Step: datastore.MutationStep{ResourceKind: "Collection", Projection: "name", Action: "delete-name"},
+		Apply: func(context.Context) error {
+			state["name"] = false
+			return nil
+		},
+		Compensate: func(context.Context) error {
+			return errors.New("restore failed")
+		},
+	}
+
+	err := executor.executeDelete(
+		context.Background(),
+		deleteAuthoritativeAction(state, errors.New("delete failed")),
+		projection,
+	)
+
+	require.ErrorIs(t, err, datastore.ErrRepairRequired)
+	assert.True(t, state["authoritative"])
+	assert.False(t, state["name"])
+}
+
+func createActions(kind string, state map[string]bool, projections []string) []mutationAction {
+	actions := make([]mutationAction, 0, len(projections))
+	for _, projection := range projections {
+		projection := projection
+		actions = append(actions, mutationAction{
+			Step: datastore.MutationStep{
+				Operation: "create", ResourceKind: kind, Projection: projection, Action: "create-" + projection,
+			},
+			Apply: func(context.Context) error {
+				state[projection] = true
+				return nil
+			},
+			Compensate: func(context.Context) error {
+				state[projection] = false
+				return nil
+			},
+		})
+	}
+	return actions
+}
+
+func updateAuthoritativeAction(kind string, state map[string]string) mutationAction {
+	return mutationAction{
+		Step: datastore.MutationStep{
+			Operation: "update", ResourceKind: kind, Projection: "authoritative", Action: "update-authoritative",
+		},
+		Apply: func(context.Context) error {
+			state["authoritative"] = "new"
+			return nil
+		},
+	}
+}
+
+func updateProjectionActions(kind string, state map[string]string, projections []string) []mutationAction {
+	actions := make([]mutationAction, 0, len(projections))
+	for _, projection := range projections {
+		projection := projection
+		actions = append(actions, mutationAction{
+			Step: datastore.MutationStep{
+				Operation: "update", ResourceKind: kind, Projection: projection, Action: "converge-" + projection,
+			},
+			Apply: func(context.Context) error {
+				state[projection] = "new"
+				return nil
+			},
+		})
+	}
+	return actions
+}
+
+func deleteProjectionActions(state map[string]bool, projections []string) []mutationAction {
+	actions := make([]mutationAction, 0, len(projections))
+	for _, projection := range projections {
+		projection := projection
+		actions = append(actions, mutationAction{
+			Step: datastore.MutationStep{Operation: "delete", Projection: projection, Action: "delete-" + projection},
+			Apply: func(context.Context) error {
+				state[projection] = false
+				return nil
+			},
+			Compensate: func(context.Context) error {
+				state[projection] = true
+				return nil
+			},
+		})
+	}
+	return actions
+}
+
+func deleteAuthoritativeAction(state map[string]bool, applyErr error) mutationAction {
+	return mutationAction{
+		Step: datastore.MutationStep{Operation: "delete", Projection: "authoritative", Action: "delete-authoritative"},
+		Apply: func(context.Context) error {
+			if applyErr != nil {
+				return applyErr
+			}
+			state["authoritative"] = false
+			return nil
+		},
+	}
+}

--- a/gitstore-api/internal/datastore/scylla/backend_test.go
+++ b/gitstore-api/internal/datastore/scylla/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/gitstore-dev/gitstore/api/internal/datastore/scylla"
 	"github.com/gocql/gocql"
 	"github.com/google/uuid"
+	"github.com/scylladb/gocqlx/v3/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -160,6 +162,11 @@ func newTestStore(t *testing.T) datastore.Datastore {
 	return store
 }
 
+func newTestStores(t *testing.T) (datastore.Datastore, datastore.Datastore) {
+	t.Helper()
+	return newTestStore(t), newTestStore(t)
+}
+
 func newID() string { return uuid.New().String() }
 
 func newProduct(namespace, name string) *datastore.Product {
@@ -199,9 +206,13 @@ func newProductVariant(namespace, name, sku, productRefName string) *datastore.P
 
 func newRepository() *datastore.Repository {
 	now := time.Now().UTC().Truncate(time.Millisecond)
+	uid := newID()
+	namespace := "namespace-" + newID()[:8]
 	return &datastore.Repository{
-		ID:                newID(),
-		NamespaceID:       newID(),
+		UID:               uid,
+		ID:                uid,
+		Namespace:         namespace,
+		NamespaceID:       namespace,
 		Name:              "repo-" + newID()[:8],
 		DefaultBranch:     "main",
 		StorageClass:      "default",
@@ -992,4 +1003,168 @@ func TestScylla_ListProducts_AfterLastCursor_ReturnsEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, r2.Items)
 	assert.False(t, r2.HasNext)
+}
+
+func TestScylla_NamespaceDirectUID_FullEnvelopeAndBodyRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	deletedAt := now.Add(time.Hour)
+	uid := newID()
+	namespace := &datastore.Namespace{
+		APIVersion:        "gitstore.dev/v1beta1",
+		Kind:              "Namespace",
+		UID:               uid,
+		ID:                uid,
+		Name:              "namespace-envelope-" + newID()[:8],
+		Generation:        7,
+		ResourceVersion:   "11",
+		Revision:          "main@sha1:namespace",
+		CreationTimestamp: now,
+		CreationActor:     "alice",
+		UpdateTimestamp:   now.Add(time.Minute),
+		UpdateActor:       "bob",
+		Labels:            map[string]string{"team": "catalog"},
+		Annotations:       map[string]string{"gitstore.dev/note": "namespace"},
+		OwnerReferences:   json.RawMessage(`[{"apiVersion":"gitstore.dev/v1beta1","kind":"Namespace","name":"owner","uid":"00000000-0000-0000-0000-000000000001"}]`),
+		Finalizers:        []string{"gitstore.dev/test"},
+		DeletionTimestamp: &deletedAt,
+		SourcePath:        "namespaces/example.md",
+		GitCommitSHA:      "namespace-sha",
+		GitRef:            "refs/heads/main",
+		Spec:              json.RawMessage(`{"title":"Canonical namespace","tier":"USER"}`),
+		Body:              "# Namespace\n\nRaw **Markdown** body.\n",
+		Status:            json.RawMessage(`{"observedGeneration":7,"conditions":[]}`),
+		Title:             "Canonical namespace",
+		Tier:              datastore.NamespaceTierUser,
+	}
+
+	require.NoError(t, store.CreateNamespace(ctx, namespace))
+
+	got, err := store.GetNamespace(ctx, uid)
+	require.NoError(t, err)
+	assert.Equal(t, namespace, got)
+
+	byName, err := store.GetNamespaceByName(ctx, namespace.Name)
+	require.NoError(t, err)
+	assert.Equal(t, namespace, byName)
+	assert.Equal(t, uid, got.UID)
+	assert.Equal(t, namespace.Body, got.Body)
+	assert.JSONEq(t, string(namespace.OwnerReferences), string(got.OwnerReferences))
+}
+
+func TestScylla_RepositoryDirectUIDPathReversePath_FullEnvelopeAndBodyRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	deletedAt := now.Add(time.Hour)
+	uid := newID()
+	namespace := "repository-envelope-" + newID()[:8]
+	repository := &datastore.Repository{
+		APIVersion:        "gitstore.dev/v1beta1",
+		Kind:              "Repository",
+		UID:               uid,
+		ID:                uid,
+		Namespace:         namespace,
+		NamespaceID:       namespace,
+		Name:              "canonical-" + newID()[:8],
+		Generation:        9,
+		ResourceVersion:   "13",
+		Revision:          "main@sha1:repository",
+		CreationTimestamp: now,
+		CreationActor:     "alice",
+		UpdateTimestamp:   now.Add(time.Minute),
+		UpdateActor:       "bob",
+		Labels:            map[string]string{"team": "catalog"},
+		Annotations:       map[string]string{"gitstore.dev/note": "repository"},
+		OwnerReferences:   json.RawMessage(`[{"apiVersion":"gitstore.dev/v1beta1","kind":"Namespace","name":"owner","uid":"00000000-0000-0000-0000-000000000001"}]`),
+		Finalizers:        []string{"gitstore.dev/test"},
+		DeletionTimestamp: &deletedAt,
+		RepositoryID:      uid,
+		SourcePath:        "repositories/canonical.md",
+		GitCommitSHA:      "repository-sha",
+		GitRef:            "refs/heads/main",
+		Spec:              json.RawMessage(`{"defaultBranch":"main","visibility":"PRIVATE"}`),
+		Body:              "# Repository\n\nRaw **Markdown** body.\n",
+		Status:            json.RawMessage(`{"observedGeneration":9,"conditions":[]}`),
+		DefaultBranch:     "main",
+		StorageClass:      "default",
+		MaxPackSizeBytes:  64 * 1024 * 1024,
+		MaxFileSizeBytes:  8 * 1024 * 1024,
+	}
+	mapping := &datastore.NamespaceMapping{
+		Namespace:    namespace,
+		NamespaceID:  namespace,
+		Name:         repository.Name,
+		RepositoryID: uid,
+		RepoID:       uid,
+	}
+
+	require.NoError(t, store.CreateRepository(ctx, repository))
+	require.NoError(t, store.CreateNamespaceMapping(ctx, mapping))
+
+	got, err := store.GetRepository(ctx, uid)
+	require.NoError(t, err)
+	assert.Equal(t, repository, got)
+	assert.Equal(t, uid, got.UID)
+	assert.Equal(t, namespace, got.Namespace)
+	assert.Equal(t, uid, got.RepositoryID)
+	assert.Equal(t, repository.Body, got.Body)
+	assert.JSONEq(t, string(repository.OwnerReferences), string(got.OwnerReferences))
+
+	byPath, err := store.LookupRepository(ctx, namespace, repository.Name)
+	require.NoError(t, err)
+	assert.Equal(t, mapping, byPath)
+
+	reverse, err := store.LookupNamespaceByRepoID(ctx, uid)
+	require.NoError(t, err)
+	assert.Equal(t, mapping, reverse)
+}
+
+func TestScylla_NamespaceRepositoryQueryShapeMetadata(t *testing.T) {
+	tests := []struct {
+		name  string
+		table interface {
+			Metadata() table.Metadata
+			Get(...string) (string, []string)
+		}
+		partKey  []string
+		sortKey  []string
+		whereKey string
+	}{
+		{"namespace UID", scylla.NamespaceByUID, []string{"uid"}, nil, "uid"},
+		{"namespace name", scylla.NamespaceByName, []string{"name"}, nil, "name"},
+		{"repository UID", scylla.RepositoryByUID, []string{"uid"}, nil, "uid"},
+		{"repository path", scylla.NamespaceMapping, []string{"namespace"}, []string{"name"}, "namespace"},
+		{"repository reverse path", scylla.NamespaceMappingByRepository, []string{"repository_id"}, nil, "repository_id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := tt.table.Metadata()
+			assert.Equal(t, tt.partKey, metadata.PartKey)
+			assert.Equal(t, tt.sortKey, metadata.SortKey)
+
+			statement, _ := tt.table.Get()
+			lower := strings.ToLower(statement)
+			assert.Contains(t, lower, "where "+tt.whereKey+"=")
+			assert.NotContains(t, lower, "allow filtering")
+			assert.NotContains(t, lower, " index ")
+		})
+	}
+
+	store := newTestStore(t)
+	require.NotNil(t, store)
+	session := newRawSession(t)
+	iter := session.Query(
+		`SELECT index_name FROM system_schema.indexes WHERE keyspace_name = ?`,
+		scyllaKeyspace,
+	).Iter()
+	var indexName string
+	for iter.Scan(&indexName) {
+		lower := strings.ToLower(indexName)
+		assert.NotContains(t, lower, "repository")
+		assert.NotContains(t, lower, "namespace_mapping")
+	}
+	require.NoError(t, iter.Close())
 }

--- a/gitstore-api/internal/datastore/scylla/capacity_test.go
+++ b/gitstore-api/internal/datastore/scylla/capacity_test.go
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+//go:build scylla
+
+package scylla_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql"
+)
+
+const (
+	partitionHardCeilingBytes = int64(100 * 1024 * 1024)
+	hotPartitionTargetBytes   = int64(10 * 1024 * 1024)
+)
+
+type capacityConfig struct {
+	Address       string
+	Keyspace      string
+	Namespace     string
+	Bucket        string
+	Products      int
+	PageSize      int
+	Mutations     int
+	Concurrency   int
+	SoakDuration  time.Duration
+	StrictHotSize bool
+}
+
+func loadCapacityConfig(t *testing.T) capacityConfig {
+	t.Helper()
+	address := os.Getenv("SCYLLA_TEST_ADDR")
+	if address == "" {
+		address = os.Getenv("GITSTORE_TEST_SCYLLA_ADDR")
+	}
+	soakDuration := envDuration(t, "GITSTORE_SCYLLA_CAPACITY_SOAK_DURATION", 0)
+	return capacityConfig{
+		Address:       address,
+		Keyspace:      envString("GITSTORE_SCYLLA_CAPACITY_KEYSPACE", "gitstore"),
+		Namespace:     envString("GITSTORE_SCYLLA_CAPACITY_NAMESPACE", "gitstore-capacity"),
+		Bucket:        envString("GITSTORE_SCYLLA_CAPACITY_BUCKET", time.Now().UTC().Format("2006-01")),
+		Products:      envInt(t, "GITSTORE_SCYLLA_CAPACITY_PRODUCTS", 5_000_000),
+		PageSize:      envInt(t, "GITSTORE_SCYLLA_CAPACITY_PAGE_SIZE", 100),
+		Mutations:     envInt(t, "GITSTORE_SCYLLA_CAPACITY_MUTATIONS", 1_000),
+		Concurrency:   envInt(t, "GITSTORE_SCYLLA_CAPACITY_CONCURRENCY", 2),
+		SoakDuration:  soakDuration,
+		StrictHotSize: os.Getenv("GITSTORE_SCYLLA_CAPACITY_ALLOW_HOT_PARTITIONS") != "1",
+	}
+}
+
+func envString(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func envInt(t *testing.T, key string, fallback int) int {
+	t.Helper()
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		t.Fatalf("%s must be a positive integer", key)
+	}
+	return value
+}
+
+func envDuration(t *testing.T, key string, fallback time.Duration) time.Duration {
+	t.Helper()
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	value, err := time.ParseDuration(raw)
+	if err != nil || value < 0 {
+		t.Fatalf("%s must be a non-negative duration: %v", key, err)
+	}
+	return value
+}
+
+func TestScyllaCapacityThresholds(t *testing.T) {
+	if partitionHardCeilingBytes != 100*1024*1024 {
+		t.Fatalf("partition hard ceiling = %d, want 100 MiB", partitionHardCeilingBytes)
+	}
+	if hotPartitionTargetBytes != 10*1024*1024 {
+		t.Fatalf("hot partition target = %d, want 10 MiB", hotPartitionTargetBytes)
+	}
+}
+
+func TestScyllaCapacity(t *testing.T) {
+	cfg := loadCapacityConfig(t)
+	if cfg.Address == "" {
+		t.Skip("set SCYLLA_TEST_ADDR to a dedicated Scylla capacity environment")
+	}
+	if os.Getenv("GITSTORE_SCYLLA_CAPACITY_RUN") != "1" {
+		t.Skip("set GITSTORE_SCYLLA_CAPACITY_RUN=1 after preloading the capacity dataset")
+	}
+	if cfg.Products < 5_000_000 {
+		t.Fatalf("GITSTORE_SCYLLA_CAPACITY_PRODUCTS=%d, want at least 5000000", cfg.Products)
+	}
+	if cfg.Concurrency < 2 {
+		t.Fatalf("GITSTORE_SCYLLA_CAPACITY_CONCURRENCY=%d, want at least 2 clients", cfg.Concurrency)
+	}
+
+	sessions := []*gocql.Session{
+		openCapacitySession(t, cfg),
+		openCapacitySession(t, cfg),
+	}
+	t.Cleanup(func() {
+		for _, session := range sessions {
+			session.Close()
+		}
+	})
+
+	t.Logf(
+		"capacity configuration: address=%s keyspace=%s products=%d page=%d mutations=%d concurrency=%d soak=%s",
+		cfg.Address, cfg.Keyspace, cfg.Products, cfg.PageSize, cfg.Mutations, cfg.Concurrency, cfg.SoakDuration,
+	)
+	assertPartitionSizes(t, sessions[0], cfg)
+	assertBoundedPage(t, sessions[0], cfg)
+	runMutationLoad(t, sessions, cfg, cfg.Mutations)
+	if cfg.SoakDuration > 0 {
+		runSoak(t, sessions, cfg)
+	}
+}
+
+func openCapacitySession(t *testing.T, cfg capacityConfig) *gocql.Session {
+	t.Helper()
+	host, portString, err := net.SplitHostPort(cfg.Address)
+	if err != nil {
+		t.Fatalf("SCYLLA_TEST_ADDR must be host:port: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("parse SCYLLA_TEST_ADDR port: %v", err)
+	}
+	cluster := gocql.NewCluster(host)
+	cluster.Port = port
+	cluster.Keyspace = cfg.Keyspace
+	cluster.Consistency = gocql.Quorum
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("open Scylla capacity session: %v", err)
+	}
+	return session
+}
+
+func assertPartitionSizes(t *testing.T, session *gocql.Session, cfg capacityConfig) {
+	t.Helper()
+	iter := session.Query("SELECT keyspace_name, table_name, partition_size FROM system.large_partitions").Iter()
+	var keyspace, table string
+	var size int64
+	seen := 0
+	for iter.Scan(&keyspace, &table, &size) {
+		if keyspace != cfg.Keyspace {
+			continue
+		}
+		seen++
+		if size > partitionHardCeilingBytes {
+			t.Errorf("%s partition size %d exceeds 100 MiB hard ceiling", table, size)
+		}
+		if cfg.StrictHotSize && size > hotPartitionTargetBytes {
+			t.Errorf("%s partition size %d exceeds 10 MiB hot-partition target", table, size)
+		}
+	}
+	if err := iter.Close(); err != nil {
+		t.Fatalf("read system.large_partitions: %v", err)
+	}
+	t.Logf("checked %d recorded large partitions for keyspace %s", seen, cfg.Keyspace)
+}
+
+func assertBoundedPage(t *testing.T, session *gocql.Session, cfg capacityConfig) {
+	t.Helper()
+	assertQueryBound(t, session.Query(
+		"SELECT creation_timestamp,uid FROM repositories_by_bucket WHERE bucket=? LIMIT ?",
+		cfg.Bucket, cfg.PageSize,
+	), cfg.PageSize, "repositories_by_bucket")
+	assertQueryBound(t, session.Query(
+		"SELECT creation_timestamp,uid FROM products_by_namespace WHERE namespace=? LIMIT ?",
+		cfg.Namespace, cfg.PageSize,
+	), cfg.PageSize, "products_by_namespace")
+}
+
+func assertQueryBound(t *testing.T, query *gocql.Query, limit int, table string) {
+	t.Helper()
+	iter := query.Iter()
+	var created time.Time
+	var uid gocql.UUID
+	rows := 0
+	for iter.Scan(&created, &uid) {
+		rows++
+	}
+	if err := iter.Close(); err != nil {
+		t.Fatalf("bounded page query %s: %v", table, err)
+	}
+	if rows > limit {
+		t.Fatalf("%s returned %d rows for limit %d", table, rows, limit)
+	}
+	t.Logf("%s bounded page returned %d rows (limit %d)", table, rows, limit)
+}
+
+func runMutationLoad(t *testing.T, sessions []*gocql.Session, cfg capacityConfig, mutations int) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var completed atomic.Int64
+	var firstErr error
+	var errMu sync.Mutex
+	var wg sync.WaitGroup
+	start := time.Now()
+	for worker := 0; worker < cfg.Concurrency; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			session := sessions[worker%len(sessions)]
+			for sequence := worker; sequence < mutations; sequence += cfg.Concurrency {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				if err := mutateCapacityMapping(session, cfg.Namespace, worker, sequence); err != nil {
+					errMu.Lock()
+					if firstErr == nil {
+						firstErr = err
+						cancel()
+					}
+					errMu.Unlock()
+					return
+				}
+				completed.Add(1)
+			}
+		}(worker)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		t.Fatalf("sustained mutation load: %v", firstErr)
+	}
+	if completed.Load() != int64(mutations) {
+		t.Fatalf("completed mutations = %d, want %d", completed.Load(), mutations)
+	}
+	if len(sessions) < 2 {
+		t.Fatal("capacity mutation load requires two independent clients")
+	}
+	t.Logf("completed %d projection mutation cycles in %s using %d clients", mutations, time.Since(start), len(sessions))
+}
+
+func mutateCapacityMapping(session *gocql.Session, namespace string, worker, sequence int) error {
+	name := fmt.Sprintf("capacity-%d-%d-%d", time.Now().UnixNano(), worker, sequence)
+	uid := gocql.TimeUUID()
+	applied, err := execCapacityCAS(session.Query(
+		"INSERT INTO namespace_mappings (namespace,name,repository_id) VALUES (?,?,?) IF NOT EXISTS",
+		namespace, name, uid,
+	))
+	if err != nil {
+		return fmt.Errorf("reserve forward mapping: %w", err)
+	}
+	if !applied {
+		return errors.New("unexpected forward mapping conflict")
+	}
+	defer session.Query("DELETE FROM namespace_mappings WHERE namespace=? AND name=?", namespace, name).Exec()
+
+	applied, err = execCapacityCAS(session.Query(
+		"INSERT INTO namespace_mappings_by_repository (repository_id,namespace,name) VALUES (?,?,?) IF NOT EXISTS",
+		uid, namespace, name,
+	))
+	if err != nil {
+		return fmt.Errorf("reserve reverse mapping: %w", err)
+	}
+	if !applied {
+		return errors.New("unexpected reverse mapping conflict")
+	}
+	if err := session.Query("DELETE FROM namespace_mappings_by_repository WHERE repository_id=?", uid).Exec(); err != nil {
+		return fmt.Errorf("delete reverse mapping: %w", err)
+	}
+	if err := session.Query("DELETE FROM namespace_mappings WHERE namespace=? AND name=?", namespace, name).Exec(); err != nil {
+		return fmt.Errorf("delete forward mapping: %w", err)
+	}
+	return nil
+}
+
+func runSoak(t *testing.T, sessions []*gocql.Session, cfg capacityConfig) {
+	t.Helper()
+	deadline := time.Now().Add(cfg.SoakDuration)
+	cycles := 0
+	for time.Now().Before(deadline) {
+		runMutationLoad(t, sessions, cfg, cfg.Concurrency*10)
+		cycles++
+	}
+	if cycles == 0 {
+		t.Fatalf("soak duration %s completed no mutation cycles", cfg.SoakDuration)
+	}
+	t.Logf("soak completed %d batches over %s", cycles, cfg.SoakDuration)
+}
+
+func execCapacityCAS(query *gocql.Query) (bool, error) {
+	return query.MapScanCAS(make(map[string]any))
+}

--- a/gitstore-api/internal/datastore/scylla/failure_injection_test.go
+++ b/gitstore-api/internal/datastore/scylla/failure_injection_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package scylla
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testFailureInjector struct {
+	mu       sync.Mutex
+	failures map[failureKey]error
+}
+
+type failureKey struct {
+	step  string
+	point failurePoint
+}
+
+func newTestFailureInjector() *testFailureInjector {
+	return &testFailureInjector{failures: make(map[failureKey]error)}
+}
+
+func (i *testFailureInjector) fail(step string, point failurePoint) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.failures[failureKey{step: step, point: point}] = errors.New("injected failure")
+}
+
+func (i *testFailureInjector) Inject(step string, point failurePoint) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	key := failureKey{step: step, point: point}
+	err := i.failures[key]
+	delete(i.failures, key)
+	return err
+}
+
+func TestMutationExecutorCompensatesInReverseOrder(t *testing.T) {
+	injector := newTestFailureInjector()
+	injector.fail("second", failureAfter)
+	executor := newMutationExecutor(injector)
+	var calls []string
+
+	err := executor.execute(context.Background(),
+		mutationAction{
+			Step:       datastore.MutationStep{Action: "first"},
+			Apply:      func(context.Context) error { calls = append(calls, "apply-first"); return nil },
+			Compensate: func(context.Context) error { calls = append(calls, "undo-first"); return nil },
+		},
+		mutationAction{
+			Step:       datastore.MutationStep{Action: "second"},
+			Apply:      func(context.Context) error { calls = append(calls, "apply-second"); return nil },
+			Compensate: func(context.Context) error { calls = append(calls, "undo-second"); return nil },
+		},
+	)
+
+	require.Error(t, err)
+	assert.Equal(t, []string{"apply-first", "apply-second", "undo-second", "undo-first"}, calls)
+}
+
+func TestMutationExecutorReturnsRepairRequiredOnCompensationFailure(t *testing.T) {
+	injector := newTestFailureInjector()
+	injector.fail("second", failureBefore)
+	executor := newMutationExecutor(injector)
+
+	err := executor.execute(context.Background(),
+		mutationAction{
+			Step:       datastore.MutationStep{Operation: "create", ResourceKind: "Product", Projection: "products_by_name", Action: "first"},
+			Apply:      func(context.Context) error { return nil },
+			Compensate: func(context.Context) error { return errors.New("undo failed") },
+		},
+		mutationAction{
+			Step:  datastore.MutationStep{Operation: "create", ResourceKind: "Product", Projection: "products_by_uid", Action: "second"},
+			Apply: func(context.Context) error { return nil },
+		},
+	)
+
+	assert.ErrorIs(t, err, datastore.ErrRepairRequired)
+	var repair *datastore.RepairRequiredError
+	require.ErrorAs(t, err, &repair)
+	assert.Equal(t, "first", repair.Step.Action)
+}

--- a/gitstore-api/internal/datastore/scylla/migration_test.go
+++ b/gitstore-api/internal/datastore/scylla/migration_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"net"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gitstore-dev/gitstore/api/internal/datastore/scylla"
@@ -58,7 +59,17 @@ func TestRunMigrations_AppliesSchema(t *testing.T) {
 	assert.Equal(t, scyllaKeyspace, ksName)
 
 	// Verify representative lookup tables exist.
-	for _, expectedTable := range []string{"products_by_namespace", "products_by_name", "products_by_uid", "category_taxonomy_by_uid"} {
+	for _, expectedTable := range []string{
+		"products_by_namespace",
+		"products_by_name",
+		"products_by_uid",
+		"category_taxonomy_by_uid",
+		"namespaces_by_uid",
+		"repositories_by_uid",
+		"repositories_by_namespace",
+		"repositories_by_bucket",
+		"namespace_mappings_by_repository",
+	} {
 		var tblName string
 		err = session.Query(
 			`SELECT table_name FROM system_schema.tables WHERE keyspace_name = ? AND table_name = ?`,
@@ -76,10 +87,27 @@ func TestRunMigrations_RepositoryResourceContractColumns(t *testing.T) {
 	require.NoError(t, scylla.RunMigrations(context.Background(), session, scyllaKeyspace, uuid.New().String(), log))
 
 	expectedColumns := map[string]string{
+		"api_version":         "text",
+		"kind":                "text",
+		"namespace":           "text",
+		"uid":                 "uuid",
+		"name":                "text",
 		"creation_timestamp":  "timestamp",
 		"creation_actor":      "text",
 		"generation":          "bigint",
 		"resource_version":    "text",
+		"revision":            "text",
+		"labels":              "map<text, text>",
+		"annotations":         "map<text, text>",
+		"owner_references":    "text",
+		"finalizers":          "list<text>",
+		"deletion_timestamp":  "timestamp",
+		"repository_id":       "uuid",
+		"source_path":         "text",
+		"git_commit_sha":      "text",
+		"git_ref":             "text",
+		"spec":                "text",
+		"body":                "text",
 		"status":              "text",
 		"update_timestamp":    "timestamp",
 		"update_actor":        "text",
@@ -91,14 +119,110 @@ func TestRunMigrations_RepositoryResourceContractColumns(t *testing.T) {
 			var columnName, columnType string
 			err := session.Query(
 				`SELECT column_name, type FROM system_schema.columns
-				 WHERE keyspace_name = ? AND table_name = 'repositories' AND column_name = ?`,
+				 WHERE keyspace_name = ? AND table_name = 'repositories_by_uid' AND column_name = ?`,
 				scyllaKeyspace, column,
 			).Scan(&columnName, &columnType)
-			require.NoError(t, err, "expected repositories.%s to exist", column)
+			require.NoError(t, err, "expected repositories_by_uid.%s to exist", column)
 			assert.Equal(t, column, columnName)
 			assert.Equal(t, expectedType, columnType)
 		})
 	}
+}
+
+func TestRunMigrations_CanonicalEnvelopeColumnsMatch(t *testing.T) {
+	session := newRawSession(t)
+	require.NoError(t, scylla.RunMigrations(context.Background(), session, scyllaKeyspace, uuid.New().String(), zap.NewNop()))
+
+	tables := []string{
+		"products_by_namespace",
+		"product_variant_by_namespace",
+		"collection",
+		"category_taxonomy",
+		"repositories_by_uid",
+	}
+	columns := []string{
+		"api_version", "kind", "namespace", "uid", "name", "generation",
+		"resource_version", "revision", "creation_timestamp", "creation_actor",
+		"update_timestamp", "update_actor", "labels", "annotations",
+		"owner_references", "finalizers", "deletion_timestamp", "repository_id",
+		"source_path", "git_commit_sha", "git_ref", "spec", "body", "status",
+	}
+	for _, tableName := range tables {
+		for _, column := range columns {
+			t.Run(tableName+"/"+column, func(t *testing.T) {
+				var got string
+				err := session.Query(
+					`SELECT column_name FROM system_schema.columns
+					 WHERE keyspace_name = ? AND table_name = ? AND column_name = ?`,
+					scyllaKeyspace, tableName, column,
+				).Scan(&got)
+				require.NoError(t, err)
+				assert.Equal(t, column, got)
+			})
+		}
+	}
+}
+
+func TestRunMigrations_HasNoRepositorySecondaryIndexes(t *testing.T) {
+	session := newRawSession(t)
+	require.NoError(t, scylla.RunMigrations(context.Background(), session, scyllaKeyspace, uuid.New().String(), zap.NewNop()))
+
+	iter := session.Query(
+		`SELECT index_name FROM system_schema.indexes WHERE keyspace_name = ?`,
+		scyllaKeyspace,
+	).Iter()
+	var index string
+	for iter.Scan(&index) {
+		assert.NotContains(t, index, "repositories")
+		assert.NotContains(t, index, "mappings")
+	}
+	require.NoError(t, iter.Close())
+}
+
+func TestRunMigrations_DoesNotMaterializeProductLabelSelectors(t *testing.T) {
+	session := newRawSession(t)
+	require.NoError(t, scylla.RunMigrations(context.Background(), session, scyllaKeyspace, uuid.New().String(), zap.NewNop()))
+
+	iter := session.Query(
+		`SELECT table_name FROM system_schema.tables WHERE keyspace_name = ?`,
+		scyllaKeyspace,
+	).Iter()
+	var tableName string
+	for iter.Scan(&tableName) {
+		assert.NotContains(t, tableName, "product_label")
+		assert.NotContains(t, tableName, "product_selector")
+	}
+	require.NoError(t, iter.Close())
+
+	iter = session.Query(
+		`SELECT index_name FROM system_schema.indexes WHERE keyspace_name = ?`,
+		scyllaKeyspace,
+	).Iter()
+	var indexName string
+	for iter.Scan(&indexName) {
+		assert.NotContains(t, indexName, "product_label")
+		assert.NotContains(t, indexName, "product_selector")
+	}
+	require.NoError(t, iter.Close())
+}
+
+func TestRunMigrations_UsesTenDayGCGrace(t *testing.T) {
+	session := newRawSession(t)
+	require.NoError(t, scylla.RunMigrations(context.Background(), session, scyllaKeyspace, uuid.New().String(), zap.NewNop()))
+
+	iter := session.Query(
+		`SELECT table_name, gc_grace_seconds FROM system_schema.tables WHERE keyspace_name = ?`,
+		scyllaKeyspace,
+	).Iter()
+	var tableName string
+	var gcGraceSeconds int
+	for iter.Scan(&tableName, &gcGraceSeconds) {
+		if strings.HasSuffix(tableName, "$paxos") || strings.HasPrefix(tableName, "schema_migrations") {
+			continue
+		}
+		assert.Equalf(t, 864000, gcGraceSeconds, "table %s", tableName)
+	}
+	require.NoError(t, iter.Close())
 }
 
 func TestRunMigrations_Idempotent(t *testing.T) {

--- a/gitstore-api/internal/datastore/scylla/migrations/001_initial_schema.cql
+++ b/gitstore-api/internal/datastore/scylla/migrations/001_initial_schema.cql
@@ -1,25 +1,31 @@
 CREATE TABLE IF NOT EXISTS products_by_namespace (
-    namespace          text,
-    creation_timestamp timestamp,
-    uid                uuid,
-    name               text,
-    api_version        text,
-    kind               text,
-    generation         bigint,
-    resource_version   text,
-    revision           text,
-    labels             map<text, text>,
-    annotations        map<text, text>,
-    owner_references   text,
-    git_commit_sha     text,
-    git_ref            text,
-    spec               text,
-    body               text,
-    status             text,
-    repository_id      text,
-    source_path        text,
+    namespace            text,
+    creation_timestamp   timestamp,
+    uid                  uuid,
+    name                 text,
+    api_version          text,
+    kind                 text,
+    generation           bigint,
+    resource_version     text,
+    revision             text,
+    creation_actor       text,
+    update_timestamp     timestamp,
+    update_actor         text,
+    labels               map<text, text>,
+    annotations          map<text, text>,
+    owner_references     text,
+    finalizers           list<text>,
+    deletion_timestamp   timestamp,
+    repository_id        uuid,
+    source_path          text,
+    git_commit_sha       text,
+    git_ref              text,
+    spec                 text,
+    body                 text,
+    status               text,
     PRIMARY KEY ((namespace), creation_timestamp, uid)
-) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC);
+) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC)
+  AND gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS products_by_name (
     namespace          text,
@@ -27,36 +33,43 @@ CREATE TABLE IF NOT EXISTS products_by_name (
     uid                uuid,
     creation_timestamp timestamp,
     PRIMARY KEY ((namespace), name)
-);
+) WITH gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS products_by_uid (
     uid                uuid,
     namespace          text,
     creation_timestamp timestamp,
     PRIMARY KEY (uid)
-);
+) WITH gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS collection (
-    namespace          text,
-    creation_timestamp timestamp,
-    uid                uuid,
-    name               text,
-    api_version        text,
-    kind               text,
-    generation         bigint,
-    resource_version   text,
-    revision           text,
-    labels             map<text, text>,
-    annotations        map<text, text>,
-    git_commit_sha     text,
-    git_ref            text,
-    spec               text,
-    body               text,
-    status             text,
-    repository_id      text,
-    source_path        text,
+    namespace            text,
+    creation_timestamp   timestamp,
+    uid                  uuid,
+    name                 text,
+    api_version          text,
+    kind                 text,
+    generation           bigint,
+    resource_version     text,
+    revision             text,
+    creation_actor       text,
+    update_timestamp     timestamp,
+    update_actor         text,
+    labels               map<text, text>,
+    annotations          map<text, text>,
+    owner_references     text,
+    finalizers           list<text>,
+    deletion_timestamp   timestamp,
+    repository_id        uuid,
+    source_path          text,
+    git_commit_sha       text,
+    git_ref              text,
+    spec                 text,
+    body                 text,
+    status               text,
     PRIMARY KEY ((namespace), creation_timestamp, uid)
-) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC);
+) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC)
+  AND gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS collection_by_name (
     namespace          text,
@@ -64,93 +77,146 @@ CREATE TABLE IF NOT EXISTS collection_by_name (
     uid                uuid,
     creation_timestamp timestamp,
     PRIMARY KEY ((namespace), name)
-);
+) WITH gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS collection_by_uid (
     uid                uuid,
     namespace          text,
     creation_timestamp timestamp,
     PRIMARY KEY (uid)
-);
+) WITH gc_grace_seconds = 864000;
 
-CREATE TABLE IF NOT EXISTS namespaces_by_id (
-    id                   uuid PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS namespaces_by_uid (
+    uid                  uuid PRIMARY KEY,
     name                 text,
-    title                text,
-    tier                 text,
-    spec                 text,
+    api_version          text,
+    kind                 text,
     generation           bigint,
     resource_version     text,
-    status               text,
-    deletion_timestamp   timestamp,
-    finalizers           list<text>,
+    revision             text,
     creation_timestamp   timestamp,
     creation_actor       text,
     update_timestamp     timestamp,
-    update_actor         text
-);
+    update_actor         text,
+    labels               map<text, text>,
+    annotations          map<text, text>,
+    owner_references     text,
+    finalizers           list<text>,
+    deletion_timestamp   timestamp,
+    source_path          text,
+    git_commit_sha       text,
+    git_ref              text,
+    spec                 text,
+    body                 text,
+    status               text,
+    title                text,
+    tier                 text
+) WITH gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS namespaces_by_name (
     name text PRIMARY KEY,
-    id   uuid
-);
+    uid  uuid
+) WITH gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS namespaces_by_bucket (
     bucket               text,
     creation_timestamp   timestamp,
-    id                   uuid,
-    PRIMARY KEY ((bucket), creation_timestamp, id)
-) WITH CLUSTERING ORDER BY (creation_timestamp DESC, id DESC);
+    uid                  uuid,
+    PRIMARY KEY ((bucket), creation_timestamp, uid)
+) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC)
+  AND gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS namespace_mappings (
-    namespace_id uuid,
-    name         text,
-    repo_id      uuid,
-    PRIMARY KEY  (namespace_id, name)
-);
+    namespace      text,
+    name           text,
+    repository_id  uuid,
+    PRIMARY KEY ((namespace), name)
+) WITH gc_grace_seconds = 864000;
 
-CREATE TABLE IF NOT EXISTS repositories (
-    bucket              text,
-    creation_timestamp  timestamp,
-    id                  uuid,
-    namespace_id        uuid,
-    name                text,
-    default_branch      text,
-    storage_class       text,
-    generation          bigint,
-    resource_version    text,
-    status              text,
-    creation_actor      text,
-    max_pack_size_bytes bigint,
-    max_file_size_bytes bigint,
-    update_timestamp    timestamp,
-    update_actor        text,
-    PRIMARY KEY ((bucket), creation_timestamp, id)
-) WITH CLUSTERING ORDER BY (creation_timestamp DESC, id DESC);
+CREATE TABLE IF NOT EXISTS namespace_mappings_by_repository (
+    repository_id uuid PRIMARY KEY,
+    namespace     text,
+    name          text
+) WITH gc_grace_seconds = 864000;
 
-CREATE TABLE IF NOT EXISTS category_taxonomy (
+CREATE TABLE IF NOT EXISTS repositories_by_uid (
+    uid                  uuid PRIMARY KEY,
+    namespace            text,
+    name                 text,
+    api_version          text,
+    kind                 text,
+    generation           bigint,
+    resource_version     text,
+    revision             text,
+    creation_timestamp   timestamp,
+    creation_actor       text,
+    update_timestamp     timestamp,
+    update_actor         text,
+    labels               map<text, text>,
+    annotations          map<text, text>,
+    owner_references     text,
+    finalizers           list<text>,
+    deletion_timestamp   timestamp,
+    repository_id        uuid,
+    source_path          text,
+    git_commit_sha       text,
+    git_ref              text,
+    spec                 text,
+    body                 text,
+    status               text,
+    default_branch       text,
+    storage_class        text,
+    max_pack_size_bytes  bigint,
+    max_file_size_bytes  bigint
+) WITH gc_grace_seconds = 864000;
+
+CREATE TABLE IF NOT EXISTS repositories_by_namespace (
     namespace          text,
+    bucket             text,
     creation_timestamp timestamp,
     uid                uuid,
-    name               text,
-    api_version        text,
-    kind               text,
-    generation         bigint,
-    resource_version   text,
-    revision           text,
-    labels             map<text, text>,
-    annotations        map<text, text>,
-    parent_name        text,
-    ancestor_path      text,
-    git_commit_sha     text,
-    git_ref            text,
-    spec               text,
-    body               text,
-    status             text,
-    repository_id      text,
-    source_path        text,
+    PRIMARY KEY ((namespace, bucket), creation_timestamp, uid)
+) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC)
+  AND gc_grace_seconds = 864000;
+
+CREATE TABLE IF NOT EXISTS repositories_by_bucket (
+    bucket             text,
+    creation_timestamp timestamp,
+    uid                uuid,
+    PRIMARY KEY ((bucket), creation_timestamp, uid)
+) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC)
+  AND gc_grace_seconds = 864000;
+
+CREATE TABLE IF NOT EXISTS category_taxonomy (
+    namespace            text,
+    creation_timestamp   timestamp,
+    uid                  uuid,
+    name                 text,
+    api_version          text,
+    kind                 text,
+    generation           bigint,
+    resource_version     text,
+    revision             text,
+    creation_actor       text,
+    update_timestamp     timestamp,
+    update_actor         text,
+    labels               map<text, text>,
+    annotations          map<text, text>,
+    owner_references     text,
+    finalizers           list<text>,
+    deletion_timestamp   timestamp,
+    repository_id        uuid,
+    source_path          text,
+    git_commit_sha       text,
+    git_ref              text,
+    spec                 text,
+    body                 text,
+    status               text,
+    parent_name          text,
+    ancestor_path        text,
     PRIMARY KEY ((namespace), creation_timestamp, uid)
-) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC);
+) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC)
+  AND gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS category_taxonomy_by_name (
     namespace          text,
@@ -158,39 +224,45 @@ CREATE TABLE IF NOT EXISTS category_taxonomy_by_name (
     uid                uuid,
     creation_timestamp timestamp,
     PRIMARY KEY ((namespace), name)
-);
+) WITH gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS category_taxonomy_by_uid (
     uid                uuid,
     namespace          text,
     creation_timestamp timestamp,
     PRIMARY KEY (uid)
-);
+) WITH gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS product_variant_by_namespace (
-    namespace          text,
-    creation_timestamp timestamp,
-    uid                uuid,
-    name               text,
-    api_version        text,
-    kind               text,
-    generation         bigint,
-    resource_version   text,
-    revision           text,
-    labels             map<text, text>,
-    annotations        map<text, text>,
-    owner_references   text,
-    sku                text,
-    product_ref_name   text,
-    git_commit_sha     text,
-    git_ref            text,
-    spec               text,
-    body               text,
-    status             text,
-    repository_id      text,
-    source_path        text,
+    namespace            text,
+    creation_timestamp   timestamp,
+    uid                  uuid,
+    name                 text,
+    api_version          text,
+    kind                 text,
+    generation           bigint,
+    resource_version     text,
+    revision             text,
+    creation_actor       text,
+    update_timestamp     timestamp,
+    update_actor         text,
+    labels               map<text, text>,
+    annotations          map<text, text>,
+    owner_references     text,
+    finalizers           list<text>,
+    deletion_timestamp   timestamp,
+    repository_id        uuid,
+    source_path          text,
+    git_commit_sha       text,
+    git_ref              text,
+    spec                 text,
+    body                 text,
+    status               text,
+    sku                  text,
+    product_ref_name     text,
     PRIMARY KEY ((namespace), creation_timestamp, uid)
-) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC);
+) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC)
+  AND gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS product_variant_by_name (
     namespace          text,
@@ -198,14 +270,14 @@ CREATE TABLE IF NOT EXISTS product_variant_by_name (
     uid                uuid,
     creation_timestamp timestamp,
     PRIMARY KEY ((namespace), name)
-);
+) WITH gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS product_variant_by_uid (
     uid                uuid,
     namespace          text,
     creation_timestamp timestamp,
     PRIMARY KEY (uid)
-);
+) WITH gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS product_variant_by_sku (
     namespace          text,
@@ -213,7 +285,7 @@ CREATE TABLE IF NOT EXISTS product_variant_by_sku (
     uid                uuid,
     creation_timestamp timestamp,
     PRIMARY KEY ((namespace), sku)
-);
+) WITH gc_grace_seconds = 864000;
 
 CREATE TABLE IF NOT EXISTS product_variant_by_product_ref (
     namespace          text,
@@ -221,4 +293,5 @@ CREATE TABLE IF NOT EXISTS product_variant_by_product_ref (
     uid                uuid,
     creation_timestamp timestamp,
     PRIMARY KEY ((namespace, product_ref_name), creation_timestamp, uid)
-) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC);
+) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC)
+  AND gc_grace_seconds = 864000;

--- a/gitstore-api/internal/datastore/scylla/migrations/002_secondary_indexes.cql
+++ b/gitstore-api/internal/datastore/scylla/migrations/002_secondary_indexes.cql
@@ -1,4 +1,2 @@
-CREATE INDEX IF NOT EXISTS repositories_by_id         ON repositories       (id);
-CREATE INDEX IF NOT EXISTS repositories_by_namespace  ON repositories       (namespace_id);
-
-CREATE INDEX IF NOT EXISTS mappings_by_repo_id        ON namespace_mappings (repo_id);
+-- Query-first tables in 001_initial_schema.cql cover every supported access
+-- pattern. Secondary indexes are intentionally absent from the alpha baseline.

--- a/gitstore-api/internal/datastore/scylla/models.go
+++ b/gitstore-api/internal/datastore/scylla/models.go
@@ -5,319 +5,163 @@ package scylla
 
 import "github.com/scylladb/gocqlx/v3/table"
 
-// BucketAll is the sentinel partition key for global listing tables.
-const BucketAll = "all"
+func resourceColumns(includeNamespace, includeRepository bool) []string {
+	columns := []string{"api_version", "kind"}
+	if includeNamespace {
+		columns = append(columns, "namespace")
+	}
+	columns = append(columns,
+		"uid",
+		"name",
+		"generation",
+		"resource_version",
+		"revision",
+		"creation_timestamp",
+		"creation_actor",
+		"update_timestamp",
+		"update_actor",
+		"labels",
+		"annotations",
+		"owner_references",
+		"finalizers",
+		"deletion_timestamp",
+	)
+	if includeRepository {
+		columns = append(columns, "repository_id")
+	}
+	return append(columns,
+		"source_path",
+		"git_commit_sha",
+		"git_ref",
+		"spec",
+		"body",
+		"status",
+	)
+}
 
-// Table models
+func authoritativeColumns(includeNamespace, includeRepository bool, specific ...string) []string {
+	columns := resourceColumns(includeNamespace, includeRepository)
+	return append(columns, specific...)
+}
+
 var (
-	// ProductByNamespace is the primary paginated read table (newest-first per namespace).
 	ProductByNamespace = table.New(table.Metadata{
-		Name: "products_by_namespace",
-		Columns: []string{
-			"namespace",
-			"creation_timestamp",
-			"uid",
-			"name",
-			"api_version",
-			"kind",
-			"generation",
-			"resource_version",
-			"revision",
-			"labels",
-			"annotations",
-			"owner_references",
-			"repository_id",
-			"source_path",
-			"git_commit_sha",
-			"git_ref",
-			"spec",
-			"body",
-			"status",
-		},
-		PartKey: []string{
-			"namespace",
-		},
-		SortKey: []string{
-			"creation_timestamp",
-			"uid",
-		},
+		Name:    "products_by_namespace",
+		Columns: authoritativeColumns(true, true),
+		PartKey: []string{"namespace"},
+		SortKey: []string{"creation_timestamp", "uid"},
 	})
-
-	// ProductByName is the lookup table for GetProductByName(namespace, name).
 	ProductByName = table.New(table.Metadata{
-		Name: "products_by_name",
-		Columns: []string{
-			"namespace",
-			"name",
-			"uid",
-			"creation_timestamp",
-		},
-		PartKey: []string{
-			"namespace",
-		},
-		SortKey: []string{
-			"name",
-		},
+		Name:    "products_by_name",
+		Columns: []string{"namespace", "name", "uid", "creation_timestamp"},
+		PartKey: []string{"namespace"},
+		SortKey: []string{"name"},
 	})
-
-	// ProductByUID is the lookup table for GetProduct(uid).
 	ProductByUID = table.New(table.Metadata{
-		Name: "products_by_uid",
-		Columns: []string{
-			"uid",
-			"namespace",
-			"creation_timestamp",
-		},
-		PartKey: []string{
-			"uid",
-		},
-		SortKey: []string{},
+		Name:    "products_by_uid",
+		Columns: []string{"uid", "namespace", "creation_timestamp"},
+		PartKey: []string{"uid"},
 	})
 
 	CategoryTaxonomy = table.New(table.Metadata{
-		Name: "category_taxonomy",
-		Columns: []string{
-			"namespace",
-			"creation_timestamp",
-			"uid",
-			"name",
-			"api_version",
-			"kind",
-			"generation",
-			"resource_version",
-			"revision",
-			"labels",
-			"annotations",
-			"parent_name",
-			"ancestor_path",
-			"repository_id",
-			"source_path",
-			"git_commit_sha",
-			"git_ref",
-			"spec",
-			"body",
-			"status",
-		},
-		PartKey: []string{
-			"namespace",
-		},
-		SortKey: []string{
-			"creation_timestamp",
-			"uid",
-		},
+		Name:    "category_taxonomy",
+		Columns: authoritativeColumns(true, true, "parent_name", "ancestor_path"),
+		PartKey: []string{"namespace"},
+		SortKey: []string{"creation_timestamp", "uid"},
 	})
-
-	// CategoryTaxonomyByName is the lookup table for GetCategoryTaxonomyByName(namespace, name).
 	CategoryTaxonomyByName = table.New(table.Metadata{
-		Name: "category_taxonomy_by_name",
-		Columns: []string{
-			"namespace",
-			"name",
-			"uid",
-			"creation_timestamp",
-		},
-		PartKey: []string{
-			"namespace",
-		},
-		SortKey: []string{
-			"name",
-		},
+		Name:    "category_taxonomy_by_name",
+		Columns: []string{"namespace", "name", "uid", "creation_timestamp"},
+		PartKey: []string{"namespace"},
+		SortKey: []string{"name"},
 	})
-
-	// CategoryTaxonomyByUID is the lookup table for GetCategoryTaxonomy(uid).
 	CategoryTaxonomyByUID = table.New(table.Metadata{
-		Name: "category_taxonomy_by_uid",
-		Columns: []string{
-			"uid",
-			"namespace",
-			"creation_timestamp",
-		},
-		PartKey: []string{
-			"uid",
-		},
-		SortKey: []string{},
+		Name:    "category_taxonomy_by_uid",
+		Columns: []string{"uid", "namespace", "creation_timestamp"},
+		PartKey: []string{"uid"},
 	})
 
-	// Collection is the primary paginated read table (newest-first per namespace).
 	Collection = table.New(table.Metadata{
-		Name: "collection",
-		Columns: []string{
-			"namespace",
-			"creation_timestamp",
-			"uid",
-			"name",
-			"api_version",
-			"kind",
-			"generation",
-			"resource_version",
-			"revision",
-			"labels",
-			"annotations",
-			"repository_id",
-			"source_path",
-			"git_commit_sha",
-			"git_ref",
-			"spec",
-			"body",
-			"status",
-		},
-		PartKey: []string{
-			"namespace",
-		},
-		SortKey: []string{
-			"creation_timestamp",
-			"uid",
-		},
+		Name:    "collection",
+		Columns: authoritativeColumns(true, true),
+		PartKey: []string{"namespace"},
+		SortKey: []string{"creation_timestamp", "uid"},
 	})
-
-	// CollectionByName is the lookup table for GetCollectionByName(namespace, name).
 	CollectionByName = table.New(table.Metadata{
-		Name: "collection_by_name",
-		Columns: []string{
-			"namespace",
-			"name",
-			"uid",
-			"creation_timestamp",
-		},
-		PartKey: []string{
-			"namespace",
-		},
-		SortKey: []string{
-			"name",
-		},
+		Name:    "collection_by_name",
+		Columns: []string{"namespace", "name", "uid", "creation_timestamp"},
+		PartKey: []string{"namespace"},
+		SortKey: []string{"name"},
 	})
-
-	// CollectionByUID is the lookup table for GetCollection(uid).
 	CollectionByUID = table.New(table.Metadata{
-		Name: "collection_by_uid",
-		Columns: []string{
-			"uid",
-			"namespace",
-			"creation_timestamp",
-		},
-		PartKey: []string{
-			"uid",
-		},
-		SortKey: []string{},
+		Name:    "collection_by_uid",
+		Columns: []string{"uid", "namespace", "creation_timestamp"},
+		PartKey: []string{"uid"},
 	})
 
-	NamespaceByID = table.New(table.Metadata{
-		Name: "namespaces_by_id",
-		Columns: []string{
-			"id",
-			"name",
-			"title",
-			"tier",
-			"spec",
-			"generation",
-			"resource_version",
-			"status",
-			"deletion_timestamp",
-			"finalizers",
-			"creation_timestamp",
-			"creation_actor",
-			"update_timestamp",
-			"update_actor",
-		},
-		PartKey: []string{
-			"id",
-		},
-		SortKey: []string{},
+	NamespaceByUID = table.New(table.Metadata{
+		Name:    "namespaces_by_uid",
+		Columns: authoritativeColumns(false, false, "title", "tier"),
+		PartKey: []string{"uid"},
 	})
-
 	NamespaceByName = table.New(table.Metadata{
 		Name:    "namespaces_by_name",
-		Columns: []string{"name", "id"},
+		Columns: []string{"name", "uid"},
 		PartKey: []string{"name"},
-		SortKey: []string{},
 	})
-
 	NamespaceByBucket = table.New(table.Metadata{
 		Name:    "namespaces_by_bucket",
-		Columns: []string{"bucket", "creation_timestamp", "id"},
+		Columns: []string{"bucket", "creation_timestamp", "uid"},
 		PartKey: []string{"bucket"},
-		SortKey: []string{"creation_timestamp", "id"},
+		SortKey: []string{"creation_timestamp", "uid"},
 	})
 
-	Repository = table.New(table.Metadata{
-		Name: "repositories",
-		Columns: []string{
-			"bucket",
-			"creation_timestamp",
-			"id",
-			"namespace_id",
-			"name",
+	RepositoryByUID = table.New(table.Metadata{
+		Name: "repositories_by_uid",
+		Columns: authoritativeColumns(true, true,
 			"default_branch",
 			"storage_class",
 			"max_pack_size_bytes",
 			"max_file_size_bytes",
-			"generation",
-			"resource_version",
-			"status",
-			"creation_actor",
-			"update_timestamp",
-			"update_actor",
-		},
-		PartKey: []string{
-			"bucket",
-		},
-		SortKey: []string{
-			"creation_timestamp",
-			"id",
-		},
+		),
+		PartKey: []string{"uid"},
 	})
-
-	ProductVariantByNamespace = table.New(table.Metadata{
-		Name: "product_variant_by_namespace",
-		Columns: []string{
-			"namespace",
-			"creation_timestamp",
-			"uid",
-			"name",
-			"api_version",
-			"kind",
-			"generation",
-			"resource_version",
-			"revision",
-			"labels",
-			"annotations",
-			"owner_references",
-			"sku",
-			"product_ref_name",
-			"repository_id",
-			"source_path",
-			"git_commit_sha",
-			"git_ref",
-			"spec",
-			"body",
-			"status",
-		},
-		PartKey: []string{"namespace"},
+	RepositoryByNamespace = table.New(table.Metadata{
+		Name:    "repositories_by_namespace",
+		Columns: []string{"namespace", "bucket", "creation_timestamp", "uid"},
+		PartKey: []string{"namespace", "bucket"},
+		SortKey: []string{"creation_timestamp", "uid"},
+	})
+	RepositoryByBucket = table.New(table.Metadata{
+		Name:    "repositories_by_bucket",
+		Columns: []string{"bucket", "creation_timestamp", "uid"},
+		PartKey: []string{"bucket"},
 		SortKey: []string{"creation_timestamp", "uid"},
 	})
 
+	ProductVariantByNamespace = table.New(table.Metadata{
+		Name:    "product_variant_by_namespace",
+		Columns: authoritativeColumns(true, true, "sku", "product_ref_name"),
+		PartKey: []string{"namespace"},
+		SortKey: []string{"creation_timestamp", "uid"},
+	})
 	ProductVariantByName = table.New(table.Metadata{
 		Name:    "product_variant_by_name",
 		Columns: []string{"namespace", "name", "uid", "creation_timestamp"},
 		PartKey: []string{"namespace"},
 		SortKey: []string{"name"},
 	})
-
 	ProductVariantByUID = table.New(table.Metadata{
 		Name:    "product_variant_by_uid",
 		Columns: []string{"uid", "namespace", "creation_timestamp"},
 		PartKey: []string{"uid"},
-		SortKey: []string{},
 	})
-
 	ProductVariantBySKU = table.New(table.Metadata{
 		Name:    "product_variant_by_sku",
 		Columns: []string{"namespace", "sku", "uid", "creation_timestamp"},
 		PartKey: []string{"namespace"},
 		SortKey: []string{"sku"},
 	})
-
-	// ProductVariantByProductRef is the lookup table for ListProductVariantsByProductRef(namespace, productRefName).
 	ProductVariantByProductRef = table.New(table.Metadata{
 		Name:    "product_variant_by_product_ref",
 		Columns: []string{"namespace", "product_ref_name", "uid", "creation_timestamp"},
@@ -326,17 +170,14 @@ var (
 	})
 
 	NamespaceMapping = table.New(table.Metadata{
-		Name: "namespace_mappings",
-		Columns: []string{
-			"namespace_id",
-			"name",
-			"repo_id",
-		},
-		PartKey: []string{
-			"namespace_id",
-		},
-		SortKey: []string{
-			"name",
-		},
+		Name:    "namespace_mappings",
+		Columns: []string{"namespace", "name", "repository_id"},
+		PartKey: []string{"namespace"},
+		SortKey: []string{"name"},
+	})
+	NamespaceMappingByRepository = table.New(table.Metadata{
+		Name:    "namespace_mappings_by_repository",
+		Columns: []string{"repository_id", "namespace", "name"},
+		PartKey: []string{"repository_id"},
 	})
 )

--- a/gitstore-api/internal/datastore/scylla/namespace_mapping.go
+++ b/gitstore-api/internal/datastore/scylla/namespace_mapping.go
@@ -11,113 +11,979 @@ import (
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gocql/gocql"
 	"github.com/scylladb/gocqlx/v3/qb"
+	"go.uber.org/zap"
+)
+
+const (
+	repositorySagaReserveTarget       = "reserve_target"
+	repositorySagaUpdateAuthoritative = "update_authoritative"
+	repositorySagaUpdateReverse       = "update_reverse_mapping"
+	repositorySagaCleanupOldPath      = "cleanup_old_path"
 )
 
 type namespaceMappingRow struct {
-	NamespaceID gocql.UUID `db:"namespace_id"`
-	Name        string     `db:"name"`
-	RepoID      gocql.UUID `db:"repo_id"`
+	Namespace    string     `db:"namespace"`
+	Name         string     `db:"name"`
+	RepositoryID gocql.UUID `db:"repository_id"`
 }
 
-func toMappingRow(m *datastore.NamespaceMapping) *namespaceMappingRow {
-	return &namespaceMappingRow{
-		NamespaceID: mustParseUUID(m.NamespaceID),
-		Name:        m.Name,
-		RepoID:      mustParseUUID(m.RepoID),
+type repositoryPath struct {
+	namespace string
+	name      string
+}
+
+func (p repositoryPath) key() string {
+	return p.namespace + "/" + p.name
+}
+
+type repositorySagaVersion int
+
+const (
+	repositorySagaSpecVersion repositorySagaVersion = iota
+	repositorySagaSystemVersion
+)
+
+type repositorySagaOperations struct {
+	injector      failureInjector
+	reserve       func(context.Context, repositoryPath, string) error
+	release       func(context.Context, repositoryPath, string) error
+	commit        func(context.Context, *datastore.Repository, repositoryPath, repositoryPath, repositorySagaVersion) (bool, error)
+	updateReverse func(context.Context, repositoryPath, repositoryPath, string) error
+	cleanup       func(context.Context, repositoryPath, string) error
+	emit          func(datastore.ProjectionFinding)
+}
+
+func executeRepositoryMappingSaga(
+	ctx context.Context,
+	operations repositorySagaOperations,
+	repository *datastore.Repository,
+	source, target repositoryPath,
+	version repositorySagaVersion,
+) error {
+	if operations.injector == nil {
+		operations.injector = noopFailureInjector{}
 	}
-}
+	authoritativeCommitted := repository.Namespace == target.namespace && repository.Name == target.name
 
-func fromMappingRow(r *namespaceMappingRow) *datastore.NamespaceMapping {
-	return &datastore.NamespaceMapping{
-		NamespaceID: r.NamespaceID.String(),
-		Name:        r.Name,
-		RepoID:      r.RepoID.String(),
+	if err := operations.injector.Inject(repositorySagaReserveTarget, failureBefore); err != nil {
+		return err
 	}
-}
+	if err := operations.reserve(ctx, target, repository.UID); err != nil {
+		return err
+	}
+	if err := operations.injector.Inject(repositorySagaReserveTarget, failureAfter); err != nil {
+		if authoritativeCommitted {
+			return err
+		}
+		return compensateRepositoryTarget(ctx, operations, repository, target, err)
+	}
 
-func (s *scyllaDatastore) CreateNamespaceMapping(_ context.Context, m *datastore.NamespaceMapping) error {
-	row := toMappingRow(m)
-	// LWT: INSERT IF NOT EXISTS so a duplicate (namespace_id, name) returns
-	// ErrAlreadyExists instead of silently overwriting another repo's mapping.
-	stmt, names := qb.Insert("namespace_mappings").
-		Columns(s.namespaceMappingTable.Metadata().Columns...).
-		Unique().
-		ToCql()
-	applied, err := s.session.Query(stmt, names).BindStruct(row).ExecCASRelease()
+	if err := operations.injector.Inject(repositorySagaUpdateAuthoritative, failureBefore); err != nil {
+		if authoritativeCommitted {
+			return err
+		}
+		return compensateRepositoryTarget(ctx, operations, repository, target, err)
+	}
+	committed, err := operations.commit(ctx, repository, source, target, version)
 	if err != nil {
-		return fmt.Errorf("scylla: create namespace_mapping: %w", err)
+		if committed {
+			return repositorySagaRollForwardRequired(
+				operations, repository, target, "namespace_mappings_by_repository",
+				repositorySagaUpdateAuthoritative, datastore.FindingStale, err,
+			)
+		}
+		return compensateRepositoryTarget(ctx, operations, repository, target, err)
 	}
-	if !applied {
-		return fmt.Errorf("%w: namespace_mapping (%s, %s)", datastore.ErrAlreadyExists, m.NamespaceID, m.Name)
+	if !committed {
+		return compensateRepositoryTarget(
+			ctx,
+			operations,
+			repository,
+			target,
+			fmt.Errorf("authoritative repository update did not commit"),
+		)
+	}
+	if err := operations.injector.Inject(repositorySagaUpdateAuthoritative, failureAfter); err != nil {
+		return repositorySagaRollForwardRequired(
+			operations, repository, target, "namespace_mappings_by_repository",
+			repositorySagaUpdateAuthoritative, datastore.FindingStale, err,
+		)
+	}
+
+	if err := operations.injector.Inject(repositorySagaUpdateReverse, failureBefore); err != nil {
+		return repositorySagaRollForwardRequired(
+			operations, repository, target, "namespace_mappings_by_repository",
+			repositorySagaUpdateReverse, datastore.FindingStale, err,
+		)
+	}
+	if err := operations.updateReverse(ctx, source, target, repository.UID); err != nil {
+		return repositorySagaRollForwardRequired(
+			operations, repository, target, "namespace_mappings_by_repository",
+			repositorySagaUpdateReverse, datastore.FindingStale, err,
+		)
+	}
+	if err := operations.injector.Inject(repositorySagaUpdateReverse, failureAfter); err != nil {
+		return repositorySagaRollForwardRequired(
+			operations, repository, target, "namespace_mappings_by_repository",
+			repositorySagaUpdateReverse, datastore.FindingStale, err,
+		)
+	}
+
+	if err := operations.injector.Inject(repositorySagaCleanupOldPath, failureBefore); err != nil {
+		return repositorySagaRollForwardRequired(
+			operations, repository, source, "namespace_mappings",
+			repositorySagaCleanupOldPath, datastore.FindingStale, err,
+		)
+	}
+	if source != target {
+		if err := operations.cleanup(ctx, source, repository.UID); err != nil {
+			return repositorySagaRollForwardRequired(
+				operations, repository, source, "namespace_mappings",
+				repositorySagaCleanupOldPath, datastore.FindingStale, err,
+			)
+		}
+	}
+	if err := operations.injector.Inject(repositorySagaCleanupOldPath, failureAfter); err != nil {
+		return repositorySagaRollForwardRequired(
+			operations, repository, source, "namespace_mappings",
+			repositorySagaCleanupOldPath, datastore.FindingStale, err,
+		)
 	}
 	return nil
 }
 
-func (s *scyllaDatastore) LookupRepository(_ context.Context, namespaceID, name string) (*datastore.NamespaceMapping, error) {
-	var row namespaceMappingRow
+func repositorySagaRollForwardRequired(
+	operations repositorySagaOperations,
+	repository *datastore.Repository,
+	path repositoryPath,
+	projection, action string,
+	findingType datastore.FindingType,
+	primary error,
+) error {
+	if operations.emit != nil {
+		operations.emit(datastore.ProjectionFinding{
+			ResourceKind: "Repository",
+			ResourceUID:  repository.UID,
+			Projection:   projection,
+			LookupKey:    path.key(),
+			Operation:    "repository_mapping_saga",
+			Type:         findingType,
+		})
+	}
+	return datastore.NewRepairRequiredError(
+		datastore.MutationStep{
+			Operation:    "repository_mapping_saga",
+			ResourceKind: "Repository",
+			ResourceUID:  repository.UID,
+			Projection:   projection,
+			LookupKey:    path.key(),
+			Action:       action,
+		},
+		primary,
+		fmt.Errorf("authoritative repository version is committed; projections require roll-forward"),
+	)
+}
+
+func compensateRepositoryTarget(
+	ctx context.Context,
+	operations repositorySagaOperations,
+	repository *datastore.Repository,
+	target repositoryPath,
+	primary error,
+) error {
+	if err := operations.release(ctx, target, repository.UID); err != nil {
+		return datastore.NewRepairRequiredError(
+			datastore.MutationStep{
+				Operation:    "repository_mapping_saga",
+				ResourceKind: "Repository",
+				ResourceUID:  repository.UID,
+				Projection:   "namespace_mappings",
+				LookupKey:    target.key(),
+				Action:       repositorySagaReserveTarget,
+			},
+			primary,
+			err,
+		)
+	}
+	return primary
+}
+
+func (s *scyllaDatastore) CreateNamespaceMapping(ctx context.Context, mapping *datastore.NamespaceMapping) error {
+	if mapping == nil {
+		return fmt.Errorf("%w: namespace mapping is nil", datastore.ErrInvalidArgument)
+	}
+	datastore.NormalizeNamespaceMappingContract(mapping)
+	if mapping.Namespace == "" || mapping.Name == "" || mapping.RepositoryID == "" {
+		return fmt.Errorf("%w: namespace mapping fields are required", datastore.ErrInvalidArgument)
+	}
+	if _, err := gocql.ParseUUID(mapping.RepositoryID); err != nil {
+		return fmt.Errorf("%w: invalid repository id %s", datastore.ErrInvalidArgument, mapping.RepositoryID)
+	}
+
+	path := repositoryPath{namespace: mapping.Namespace, name: mapping.Name}
+	created, err := s.reserveRepositoryPathOwned(ctx, path, mapping.RepositoryID)
+	if err != nil {
+		return err
+	}
+	if err := s.reserveRepositoryReverseMapping(ctx, path, mapping.RepositoryID); err != nil {
+		if !created {
+			return err
+		}
+		if compensationErr := s.releaseRepositoryPath(ctx, path, mapping.RepositoryID); compensationErr != nil {
+			return datastore.NewRepairRequiredError(
+				datastore.MutationStep{
+					Operation:    "create_namespace_mapping",
+					ResourceKind: "Repository",
+					ResourceUID:  mapping.RepositoryID,
+					Projection:   "namespace_mappings_by_repository",
+					LookupKey:    path.key(),
+					Action:       "reserve",
+				},
+				err,
+				compensationErr,
+			)
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) LookupRepository(ctx context.Context, namespace, name string) (*datastore.NamespaceMapping, error) {
+	path := repositoryPath{namespace: namespace, name: name}
+	mapping, err := s.lookupRepositoryPath(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	repository, err := s.GetRepository(ctx, mapping.RepositoryID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		reverse, reverseErr := s.lookupRepositoryReverseMapping(ctx, mapping.RepositoryID)
+		if reverseErr != nil {
+			return nil, reverseErr
+		}
+		if reverse.Namespace != namespace || reverse.Name != name {
+			return nil, s.repositoryMappingRepairError(
+				"lookup_repository", mapping.RepositoryID, "namespace_mappings_by_repository", path, datastore.FindingStale,
+				fmt.Errorf("reverse mapping points to %s/%s", reverse.Namespace, reverse.Name),
+			)
+		}
+		return mapping, nil
+	}
+	if err != nil {
+		return nil, s.repositoryMappingRepairError(
+			"lookup_repository", mapping.RepositoryID, "namespace_mappings", path, datastore.FindingStale, err,
+		)
+	}
+	if repository.Namespace != namespace || repository.Name != name {
+		return nil, s.repositoryMappingRepairError(
+			"lookup_repository", mapping.RepositoryID, "namespace_mappings", path, datastore.FindingStale,
+			fmt.Errorf("authoritative repository path is %s/%s", repository.Namespace, repository.Name),
+		)
+	}
+	reverse, err := s.lookupRepositoryReverseMapping(ctx, mapping.RepositoryID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		return nil, s.repositoryMappingRepairError(
+			"lookup_repository", mapping.RepositoryID, "namespace_mappings_by_repository", path, datastore.FindingMissing, err,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if reverse.Namespace != namespace || reverse.Name != name {
+		return nil, s.repositoryMappingRepairError(
+			"lookup_repository", mapping.RepositoryID, "namespace_mappings_by_repository", path, datastore.FindingStale,
+			fmt.Errorf("reverse mapping points to %s/%s", reverse.Namespace, reverse.Name),
+		)
+	}
+	return mapping, nil
+}
+
+func (s *scyllaDatastore) LookupNamespaceByRepoID(ctx context.Context, repositoryID string) (*datastore.NamespaceMapping, error) {
+	mapping, err := s.lookupRepositoryReverseMapping(ctx, repositoryID)
+	if err != nil {
+		return nil, err
+	}
+	repository, err := s.GetRepository(ctx, repositoryID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		path := repositoryPath{namespace: mapping.Namespace, name: mapping.Name}
+		forward, forwardErr := s.lookupRepositoryPath(ctx, path)
+		if forwardErr != nil {
+			return nil, forwardErr
+		}
+		if forward.RepositoryID != repositoryID {
+			return nil, s.repositoryMappingRepairError(
+				"lookup_namespace_by_repository", repositoryID, "namespace_mappings", path, datastore.FindingDuplicate,
+				fmt.Errorf("path is owned by repository %s", forward.RepositoryID),
+			)
+		}
+		return mapping, nil
+	}
+	if err != nil {
+		return nil, s.repositoryMappingRepairError(
+			"lookup_namespace_by_repository", repositoryID, "namespace_mappings_by_repository",
+			repositoryPath{namespace: mapping.Namespace, name: mapping.Name}, datastore.FindingStale, err,
+		)
+	}
+	authoritative := repositoryPath{namespace: repository.Namespace, name: repository.Name}
+	if mapping.Namespace != authoritative.namespace || mapping.Name != authoritative.name {
+		return nil, s.repositoryMappingRepairError(
+			"lookup_namespace_by_repository", repositoryID, "namespace_mappings_by_repository",
+			authoritative, datastore.FindingStale,
+			fmt.Errorf("reverse mapping points to %s/%s", mapping.Namespace, mapping.Name),
+		)
+	}
+	forward, err := s.lookupRepositoryPath(ctx, authoritative)
+	if errors.Is(err, datastore.ErrNotFound) {
+		return nil, s.repositoryMappingRepairError(
+			"lookup_namespace_by_repository", repositoryID, "namespace_mappings",
+			authoritative, datastore.FindingMissing, err,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if forward.RepositoryID != repositoryID {
+		return nil, s.repositoryMappingRepairError(
+			"lookup_namespace_by_repository", repositoryID, "namespace_mappings",
+			authoritative, datastore.FindingDuplicate,
+			fmt.Errorf("path is owned by repository %s", forward.RepositoryID),
+		)
+	}
+	return mapping, nil
+}
+
+func (s *scyllaDatastore) LookupNamespaceByRepositoryID(ctx context.Context, repositoryID string) (*datastore.NamespaceMapping, error) {
+	return s.LookupNamespaceByRepoID(ctx, repositoryID)
+}
+
+func (s *scyllaDatastore) RenameRepository(ctx context.Context, namespace, oldName, newName string) error {
+	if namespace == "" || oldName == "" || newName == "" {
+		return fmt.Errorf("%w: namespace, old name, and new name are required", datastore.ErrInvalidArgument)
+	}
+	if oldName == newName {
+		_, err := s.LookupRepository(ctx, namespace, oldName)
+		return err
+	}
+
+	source := repositoryPath{namespace: namespace, name: oldName}
+	target := repositoryPath{namespace: namespace, name: newName}
+	sourceMapping, sourceErr := s.lookupRepositoryPath(ctx, source)
+	targetMapping, targetErr := s.lookupRepositoryPath(ctx, target)
+	if sourceErr != nil && !errors.Is(sourceErr, datastore.ErrNotFound) {
+		return sourceErr
+	}
+	if targetErr != nil && !errors.Is(targetErr, datastore.ErrNotFound) {
+		return targetErr
+	}
+	if sourceMapping == nil && targetMapping == nil {
+		return fmt.Errorf("%w: namespace mapping %s", datastore.ErrNotFound, source.key())
+	}
+
+	repositoryID := ""
+	if sourceMapping != nil {
+		repositoryID = sourceMapping.RepositoryID
+	}
+	if targetMapping != nil {
+		if repositoryID != "" && targetMapping.RepositoryID != repositoryID {
+			s.emitRepositoryMappingFinding(datastore.ProjectionFinding{
+				ResourceKind: "Repository",
+				ResourceUID:  targetMapping.RepositoryID,
+				Projection:   "namespace_mappings",
+				LookupKey:    target.key(),
+				Operation:    "rename_repository",
+				Type:         datastore.FindingDuplicate,
+			})
+			return fmt.Errorf("%w: namespace mapping %s", datastore.ErrAlreadyExists, target.key())
+		}
+		if sourceMapping != nil {
+			s.emitRepositoryMappingFinding(datastore.ProjectionFinding{
+				ResourceKind: "Repository",
+				ResourceUID:  targetMapping.RepositoryID,
+				Projection:   "namespace_mappings",
+				LookupKey:    source.key(),
+				Operation:    "rename_repository",
+				Type:         datastore.FindingStale,
+			})
+		}
+		repositoryID = targetMapping.RepositoryID
+	}
+	repository, err := s.GetRepository(ctx, repositoryID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		return s.moveRepositoryMappingWithoutAuthoritative(ctx, repositoryID, source, target)
+	}
+	if err != nil {
+		return s.repositoryMappingRepairError(
+			"rename_repository", repositoryID, "namespace_mappings", source, datastore.FindingDangling, err,
+		)
+	}
+	if !repositoryHasPath(repository, source) && !repositoryHasPath(repository, target) {
+		return s.repositoryMappingRepairError(
+			"rename_repository", repositoryID, "repositories_by_uid", target, datastore.FindingStale,
+			fmt.Errorf("authoritative repository path is %s/%s", repository.Namespace, repository.Name),
+		)
+	}
+
+	return executeRepositoryMappingSaga(
+		ctx,
+		s.repositorySagaOperations(),
+		repository,
+		source,
+		target,
+		repositorySagaSpecVersion,
+	)
+}
+
+func (s *scyllaDatastore) TransferRepository(ctx context.Context, repositoryID, fromNamespace, toNamespace string) error {
+	if repositoryID == "" || fromNamespace == "" || toNamespace == "" {
+		return fmt.Errorf("%w: repository id, source namespace, and target namespace are required", datastore.ErrInvalidArgument)
+	}
+	if _, err := gocql.ParseUUID(repositoryID); err != nil {
+		return fmt.Errorf("%w: invalid repository id %s", datastore.ErrInvalidArgument, repositoryID)
+	}
+	repository, err := s.GetRepository(ctx, repositoryID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		return s.transferRepositoryMappingWithoutAuthoritative(ctx, repositoryID, fromNamespace, toNamespace)
+	}
+	if err != nil {
+		return err
+	}
+	namespace, err := s.GetNamespaceByName(ctx, toNamespace)
+	if err != nil {
+		return fmt.Errorf("scylla: validate target namespace %s: %w", toNamespace, err)
+	}
+	if namespace.Name != toNamespace {
+		return fmt.Errorf("%w: target namespace lookup returned %s", datastore.ErrConflict, namespace.Name)
+	}
+	source := repositoryPath{namespace: fromNamespace, name: repository.Name}
+	target := repositoryPath{namespace: toNamespace, name: repository.Name}
+	if fromNamespace == toNamespace {
+		_, err := s.LookupNamespaceByRepoID(ctx, repositoryID)
+		return err
+	}
+	if !repositoryHasPath(repository, source) && !repositoryHasPath(repository, target) {
+		return fmt.Errorf(
+			"%w: repository %s authoritative namespace is %s",
+			datastore.ErrConflict,
+			repositoryID,
+			repository.Namespace,
+		)
+	}
+
+	reverse, reverseErr := s.lookupRepositoryReverseMapping(ctx, repositoryID)
+	if reverseErr != nil && !errors.Is(reverseErr, datastore.ErrNotFound) {
+		return reverseErr
+	}
+	if reverse != nil &&
+		(reverse.Namespace != source.namespace || reverse.Name != source.name) &&
+		(reverse.Namespace != target.namespace || reverse.Name != target.name) {
+		return s.repositoryMappingRepairError(
+			"transfer_repository", repositoryID, "namespace_mappings_by_repository", target, datastore.FindingStale,
+			fmt.Errorf("reverse mapping points to %s/%s", reverse.Namespace, reverse.Name),
+		)
+	}
+
+	sourceMapping, sourceErr := s.lookupRepositoryPath(ctx, source)
+	if sourceErr != nil && !errors.Is(sourceErr, datastore.ErrNotFound) {
+		return sourceErr
+	}
+	if sourceMapping != nil && sourceMapping.RepositoryID != repositoryID {
+		return s.repositoryMappingRepairError(
+			"transfer_repository", repositoryID, "namespace_mappings", source, datastore.FindingDuplicate,
+			fmt.Errorf("source path is owned by repository %s", sourceMapping.RepositoryID),
+		)
+	}
+	targetMapping, targetErr := s.lookupRepositoryPath(ctx, target)
+	if targetErr != nil && !errors.Is(targetErr, datastore.ErrNotFound) {
+		return targetErr
+	}
+	if targetMapping != nil && targetMapping.RepositoryID != repositoryID {
+		s.emitRepositoryMappingFinding(datastore.ProjectionFinding{
+			ResourceKind: "Repository",
+			ResourceUID:  targetMapping.RepositoryID,
+			Projection:   "namespace_mappings",
+			LookupKey:    target.key(),
+			Operation:    "transfer_repository",
+			Type:         datastore.FindingDuplicate,
+		})
+		return fmt.Errorf("%w: namespace mapping %s", datastore.ErrAlreadyExists, target.key())
+	}
+	if sourceMapping != nil && targetMapping != nil {
+		s.emitRepositoryMappingFinding(datastore.ProjectionFinding{
+			ResourceKind: "Repository",
+			ResourceUID:  repositoryID,
+			Projection:   "namespace_mappings",
+			LookupKey:    source.key(),
+			Operation:    "transfer_repository",
+			Type:         datastore.FindingStale,
+		})
+	}
+
+	return executeRepositoryMappingSaga(
+		ctx,
+		s.repositorySagaOperations(),
+		repository,
+		source,
+		target,
+		repositorySagaSystemVersion,
+	)
+}
+
+func (s *scyllaDatastore) transferRepositoryMappingWithoutAuthoritative(
+	ctx context.Context,
+	repositoryID, fromNamespace, toNamespace string,
+) error {
+	reverse, err := s.lookupRepositoryReverseMapping(ctx, repositoryID)
+	if err != nil {
+		return err
+	}
+	if reverse.Namespace != fromNamespace && reverse.Namespace != toNamespace {
+		return fmt.Errorf(
+			"%w: repository mapping %s is in namespace %s",
+			datastore.ErrNotFound,
+			repositoryID,
+			reverse.Namespace,
+		)
+	}
+	source := repositoryPath{namespace: fromNamespace, name: reverse.Name}
+	target := repositoryPath{namespace: toNamespace, name: reverse.Name}
+	if source == target {
+		return nil
+	}
+	return s.moveRepositoryMappingWithoutAuthoritative(ctx, repositoryID, source, target)
+}
+
+func (s *scyllaDatastore) moveRepositoryMappingWithoutAuthoritative(
+	ctx context.Context,
+	repositoryID string,
+	source, target repositoryPath,
+) error {
+	created, err := s.reserveRepositoryPathOwned(ctx, target, repositoryID)
+	if err != nil {
+		return err
+	}
+	if err := s.setRepositoryReverseMapping(ctx, source, target, repositoryID); err != nil {
+		if !created {
+			return err
+		}
+		if compensationErr := s.releaseRepositoryPath(ctx, target, repositoryID); compensationErr != nil {
+			return datastore.NewRepairRequiredError(
+				datastore.MutationStep{
+					Operation:    "move_repository_mapping",
+					ResourceKind: "Repository",
+					ResourceUID:  repositoryID,
+					Projection:   "namespace_mappings_by_repository",
+					LookupKey:    target.key(),
+					Action:       repositorySagaUpdateReverse,
+				},
+				err,
+				compensationErr,
+			)
+		}
+		return err
+	}
+	if err := s.deleteRepositoryPath(ctx, source, repositoryID); err != nil {
+		s.emitRepositoryMappingFinding(datastore.ProjectionFinding{
+			ResourceKind: "Repository",
+			ResourceUID:  repositoryID,
+			Projection:   "namespace_mappings",
+			LookupKey:    source.key(),
+			Operation:    "move_repository_mapping",
+			Type:         datastore.FindingStale,
+		})
+		return datastore.NewRepairRequiredError(
+			datastore.MutationStep{
+				Operation:    "move_repository_mapping",
+				ResourceKind: "Repository",
+				ResourceUID:  repositoryID,
+				Projection:   "namespace_mappings",
+				LookupKey:    source.key(),
+				Action:       repositorySagaCleanupOldPath,
+			},
+			err,
+			fmt.Errorf("target mapping is committed; old path requires cleanup"),
+		)
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) DeleteNamespaceMapping(ctx context.Context, namespace, name string) error {
+	path := repositoryPath{namespace: namespace, name: name}
+	mapping, err := s.lookupRepositoryPath(ctx, path)
+	if err != nil {
+		return err
+	}
+	if err := s.deleteRepositoryPath(ctx, path, mapping.RepositoryID); err != nil {
+		return err
+	}
+	if err := s.deleteRepositoryReverseMapping(ctx, path, mapping.RepositoryID); err != nil {
+		if restoreErr := s.reserveRepositoryPath(ctx, path, mapping.RepositoryID); restoreErr != nil {
+			return datastore.NewRepairRequiredError(
+				datastore.MutationStep{
+					Operation:    "delete_namespace_mapping",
+					ResourceKind: "Repository",
+					ResourceUID:  mapping.RepositoryID,
+					Projection:   "namespace_mappings_by_repository",
+					LookupKey:    path.key(),
+					Action:       "delete",
+				},
+				err,
+				restoreErr,
+			)
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) repositorySagaOperations() repositorySagaOperations {
+	injector := failureInjector(noopFailureInjector{})
+	if s.mutations != nil && s.mutations.injector != nil {
+		injector = s.mutations.injector
+	}
+	return repositorySagaOperations{
+		injector: injector,
+		reserve:  s.reserveRepositoryPath,
+		release:  s.releaseRepositoryPath,
+		commit:   s.commitRepositorySaga,
+		updateReverse: func(ctx context.Context, source, target repositoryPath, repositoryID string) error {
+			return s.setRepositoryReverseMapping(ctx, source, target, repositoryID)
+		},
+		cleanup: s.deleteRepositoryPath,
+		emit:    s.emitRepositoryMappingFinding,
+	}
+}
+
+func (s *scyllaDatastore) commitRepositorySaga(
+	ctx context.Context,
+	initial *datastore.Repository,
+	source, target repositoryPath,
+	version repositorySagaVersion,
+) (bool, error) {
+	targetMapping, err := s.lookupRepositoryPath(ctx, target)
+	if err != nil {
+		return false, err
+	}
+	if targetMapping.RepositoryID != initial.UID {
+		return false, s.repositoryMappingRepairError(
+			"repository_mapping_saga", initial.UID, "namespace_mappings", target, datastore.FindingDuplicate,
+			fmt.Errorf("target path is owned by repository %s", targetMapping.RepositoryID),
+		)
+	}
+	repository, err := s.GetRepository(ctx, initial.UID)
+	if err != nil {
+		return false, err
+	}
+	if repositoryHasPath(repository, target) {
+		if version == repositorySagaSystemVersion {
+			previous := *repository
+			previous.Namespace = source.namespace
+			if err := s.syncRepositoryNamespaceProjection(ctx, &previous, repository); err != nil {
+				return true, err
+			}
+		}
+		return true, nil
+	}
+	if !repositoryHasPath(repository, source) {
+		return false, s.repositoryMappingRepairError(
+			"repository_mapping_saga", repository.UID, "repositories_by_uid", target, datastore.FindingStale,
+			fmt.Errorf("authoritative repository path is %s/%s", repository.Namespace, repository.Name),
+		)
+	}
+	if repository.ResourceVersion != initial.ResourceVersion {
+		return false, datastore.ErrConflict
+	}
+
+	updated := *repository
+	updated.Namespace = target.namespace
+	updated.Name = target.name
+	if version == repositorySagaSystemVersion {
+		datastore.AdvanceRepositorySystemVersion(&updated)
+	} else {
+		datastore.AdvanceRepositorySpecVersion(&updated)
+	}
+	err = s.updateRepositoryAuthoritative(ctx, &updated, repository.CreationTimestamp, repository.ResourceVersion)
+	if err != nil {
+		current, readErr := s.GetRepository(ctx, repository.UID)
+		if readErr == nil && repositoryHasPath(current, target) {
+			if version == repositorySagaSystemVersion {
+				if projectionErr := s.syncRepositoryNamespaceProjection(ctx, repository, current); projectionErr != nil {
+					return true, projectionErr
+				}
+			}
+			return true, nil
+		}
+		return false, err
+	}
+	if version == repositorySagaSystemVersion {
+		if err := s.syncRepositoryNamespaceProjection(ctx, repository, &updated); err != nil {
+			return true, err
+		}
+	}
+	return true, nil
+}
+
+func repositoryHasPath(repository *datastore.Repository, path repositoryPath) bool {
+	return repository != nil && repository.Namespace == path.namespace && repository.Name == path.name
+}
+
+func (s *scyllaDatastore) reserveRepositoryPath(ctx context.Context, path repositoryPath, repositoryID string) error {
+	_, err := s.reserveRepositoryPathOwned(ctx, path, repositoryID)
+	return err
+}
+
+func (s *scyllaDatastore) reserveRepositoryPathOwned(
+	ctx context.Context,
+	path repositoryPath,
+	repositoryID string,
+) (bool, error) {
+	uid, err := gocql.ParseUUID(repositoryID)
+	if err != nil {
+		return false, fmt.Errorf("%w: invalid repository id %s", datastore.ErrInvalidArgument, repositoryID)
+	}
+	const statement = "INSERT INTO namespace_mappings (namespace, name, repository_id) VALUES (?, ?, ?) IF NOT EXISTS"
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).
+		Bind(path.namespace, path.name, uid).ExecCASRelease()
+	if err != nil {
+		return false, fmt.Errorf("scylla: reserve namespace mapping %s: %w", path.key(), err)
+	}
+	if applied {
+		return true, nil
+	}
+	existing, lookupErr := s.lookupRepositoryPath(ctx, path)
+	if lookupErr != nil {
+		return false, fmt.Errorf("scylla: inspect namespace mapping reservation %s: %w", path.key(), lookupErr)
+	}
+	if existing.RepositoryID == repositoryID {
+		return false, nil
+	}
+	s.emitRepositoryMappingFinding(datastore.ProjectionFinding{
+		ResourceKind: "Repository",
+		ResourceUID:  existing.RepositoryID,
+		Projection:   "namespace_mappings",
+		LookupKey:    path.key(),
+		Operation:    "reserve_repository_path",
+		Type:         datastore.FindingDuplicate,
+	})
+	return false, fmt.Errorf("%w: namespace mapping %s", datastore.ErrAlreadyExists, path.key())
+}
+
+func (s *scyllaDatastore) reserveRepositoryReverseMapping(ctx context.Context, path repositoryPath, repositoryID string) error {
+	_, err := s.reserveRepositoryReverseMappingOwned(ctx, path, repositoryID)
+	return err
+}
+
+func (s *scyllaDatastore) reserveRepositoryReverseMappingOwned(
+	ctx context.Context,
+	path repositoryPath,
+	repositoryID string,
+) (bool, error) {
+	uid := mustParseUUID(repositoryID)
+	const statement = "INSERT INTO namespace_mappings_by_repository (repository_id, namespace, name) VALUES (?, ?, ?) IF NOT EXISTS"
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).
+		Bind(uid, path.namespace, path.name).ExecCASRelease()
+	if err != nil {
+		return false, fmt.Errorf("scylla: reserve reverse namespace mapping: %w", err)
+	}
+	if applied {
+		return true, nil
+	}
+	existing, lookupErr := s.lookupRepositoryReverseMapping(ctx, repositoryID)
+	if lookupErr != nil {
+		return false, fmt.Errorf("scylla: inspect reverse namespace mapping reservation: %w", lookupErr)
+	}
+	if existing.Namespace == path.namespace && existing.Name == path.name {
+		return false, nil
+	}
+	return false, s.repositoryMappingRepairError(
+		"create_namespace_mapping", repositoryID, "namespace_mappings_by_repository", path, datastore.FindingDuplicate,
+		fmt.Errorf("repository already maps to %s/%s", existing.Namespace, existing.Name),
+	)
+}
+
+func (s *scyllaDatastore) setRepositoryReverseMapping(
+	ctx context.Context,
+	source, target repositoryPath,
+	repositoryID string,
+) error {
+	existing, err := s.lookupRepositoryReverseMapping(ctx, repositoryID)
+	if errors.Is(err, datastore.ErrNotFound) {
+		s.emitRepositoryMappingFinding(datastore.ProjectionFinding{
+			ResourceKind: "Repository",
+			ResourceUID:  repositoryID,
+			Projection:   "namespace_mappings_by_repository",
+			LookupKey:    target.key(),
+			Operation:    "repository_mapping_saga",
+			Type:         datastore.FindingMissing,
+		})
+		return s.reserveRepositoryReverseMapping(ctx, target, repositoryID)
+	}
+	if err != nil {
+		return err
+	}
+	current := repositoryPath{namespace: existing.Namespace, name: existing.Name}
+	if current == target {
+		return nil
+	}
+	if current != source {
+		return s.repositoryMappingRepairError(
+			"repository_mapping_saga", repositoryID, "namespace_mappings_by_repository", target, datastore.FindingStale,
+			fmt.Errorf("reverse mapping points to %s", current.key()),
+		)
+	}
+
+	const statement = "UPDATE namespace_mappings_by_repository SET namespace=?, name=? WHERE repository_id=? IF namespace=? AND name=?"
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).
+		Bind(target.namespace, target.name, mustParseUUID(repositoryID), source.namespace, source.name).ExecCASRelease()
+	if err != nil {
+		return fmt.Errorf("scylla: update reverse namespace mapping: %w", err)
+	}
+	if applied {
+		return nil
+	}
+	currentMapping, lookupErr := s.lookupRepositoryReverseMapping(ctx, repositoryID)
+	if lookupErr == nil && currentMapping.Namespace == target.namespace && currentMapping.Name == target.name {
+		return nil
+	}
+	if lookupErr != nil {
+		return lookupErr
+	}
+	return s.repositoryMappingRepairError(
+		"repository_mapping_saga", repositoryID, "namespace_mappings_by_repository", target, datastore.FindingStale,
+		fmt.Errorf("reverse mapping changed concurrently to %s/%s", currentMapping.Namespace, currentMapping.Name),
+	)
+}
+
+func (s *scyllaDatastore) releaseRepositoryPath(ctx context.Context, path repositoryPath, repositoryID string) error {
+	return s.deleteRepositoryPath(ctx, path, repositoryID)
+}
+
+func (s *scyllaDatastore) deleteRepositoryPath(ctx context.Context, path repositoryPath, repositoryID string) error {
+	const statement = "DELETE FROM namespace_mappings WHERE namespace=? AND name=? IF repository_id=?"
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).
+		Bind(path.namespace, path.name, mustParseUUID(repositoryID)).ExecCASRelease()
+	if err != nil {
+		return fmt.Errorf("scylla: conditionally delete namespace mapping %s: %w", path.key(), err)
+	}
+	if applied {
+		return nil
+	}
+	existing, lookupErr := s.lookupRepositoryPath(ctx, path)
+	if errors.Is(lookupErr, datastore.ErrNotFound) {
+		return nil
+	}
+	if lookupErr != nil {
+		return lookupErr
+	}
+	return s.repositoryMappingRepairError(
+		"delete_repository_path", repositoryID, "namespace_mappings", path, datastore.FindingDuplicate,
+		fmt.Errorf("path is owned by repository %s", existing.RepositoryID),
+	)
+}
+
+func (s *scyllaDatastore) deleteRepositoryReverseMapping(
+	ctx context.Context,
+	path repositoryPath,
+	repositoryID string,
+) error {
+	const statement = "DELETE FROM namespace_mappings_by_repository WHERE repository_id=? IF namespace=? AND name=?"
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).
+		Bind(mustParseUUID(repositoryID), path.namespace, path.name).ExecCASRelease()
+	if err != nil {
+		return fmt.Errorf("scylla: conditionally delete reverse namespace mapping: %w", err)
+	}
+	if applied {
+		return nil
+	}
+	existing, lookupErr := s.lookupRepositoryReverseMapping(ctx, repositoryID)
+	if errors.Is(lookupErr, datastore.ErrNotFound) {
+		return nil
+	}
+	if lookupErr != nil {
+		return lookupErr
+	}
+	return s.repositoryMappingRepairError(
+		"delete_namespace_mapping", repositoryID, "namespace_mappings_by_repository", path, datastore.FindingStale,
+		fmt.Errorf("reverse mapping points to %s/%s", existing.Namespace, existing.Name),
+	)
+}
+
+func (s *scyllaDatastore) lookupRepositoryPath(ctx context.Context, path repositoryPath) (*datastore.NamespaceMapping, error) {
 	stmt, names := s.namespaceMappingTable.Get()
-	if err := s.session.Query(stmt, names).BindMap(qb.M{"namespace_id": namespaceID, "name": name}).GetRelease(&row); err != nil {
-		if errors.Is(err, gocql.ErrNotFound) {
-			return nil, fmt.Errorf("%w: namespace_mapping (%s, %s)", datastore.ErrNotFound, namespaceID, name)
-		}
-		return nil, fmt.Errorf("scylla: lookup repository: %w", err)
-	}
-	return fromMappingRow(&row), nil
-}
-
-func (s *scyllaDatastore) LookupNamespaceByRepoID(_ context.Context, repoID string) (*datastore.NamespaceMapping, error) {
-	stmt, names := qb.Select("namespace_mappings").
-		Columns(s.namespaceMappingTable.Metadata().Columns...).
-		Where(qb.Eq("repo_id")).
-		ToCql()
 	var row namespaceMappingRow
-	if err := s.session.Query(stmt, names).BindMap(qb.M{"repo_id": repoID}).GetRelease(&row); err != nil {
+	if err := s.session.Query(stmt, names).WithContext(ctx).
+		BindMap(qb.M{"namespace": path.namespace, "name": path.name}).GetRelease(&row); err != nil {
 		if errors.Is(err, gocql.ErrNotFound) {
-			return nil, fmt.Errorf("%w: namespace_mapping repo_id %s", datastore.ErrNotFound, repoID)
+			return nil, fmt.Errorf("%w: namespace mapping %s", datastore.ErrNotFound, path.key())
 		}
-		return nil, fmt.Errorf("scylla: lookup namespace by repo_id: %w", err)
+		return nil, fmt.Errorf("scylla: lookup repository path %s: %w", path.key(), err)
 	}
-	return fromMappingRow(&row), nil
+	return fromNamespaceMappingRow(&row), nil
 }
 
-func (s *scyllaDatastore) RenameRepository(ctx context.Context, namespaceID, oldName, newName string) error {
-	old, err := s.LookupRepository(ctx, namespaceID, oldName)
+func (s *scyllaDatastore) lookupRepositoryReverseMapping(ctx context.Context, repositoryID string) (*datastore.NamespaceMapping, error) {
+	repositoryUUID, err := gocql.ParseUUID(repositoryID)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("%w: invalid repository id %s", datastore.ErrNotFound, repositoryID)
 	}
-	// Insert the new name first via LWT; if the target name is already taken,
-	// CreateNamespaceMapping returns ErrAlreadyExists and the old mapping stays intact.
-	if err := s.CreateNamespaceMapping(ctx, &datastore.NamespaceMapping{
-		NamespaceID: namespaceID,
-		Name:        newName,
-		RepoID:      old.RepoID,
-	}); err != nil {
-		return err
+	stmt, names := s.namespaceMappingByRepositoryTable.Get()
+	var row namespaceMappingRow
+	if err := s.session.Query(stmt, names).WithContext(ctx).
+		BindMap(qb.M{"repository_id": repositoryUUID}).GetRelease(&row); err != nil {
+		if errors.Is(err, gocql.ErrNotFound) {
+			return nil, fmt.Errorf("%w: repository mapping %s", datastore.ErrNotFound, repositoryID)
+		}
+		return nil, fmt.Errorf("scylla: reverse lookup namespace mapping: %w", err)
 	}
-	return s.DeleteNamespaceMapping(ctx, namespaceID, oldName)
+	return fromNamespaceMappingRow(&row), nil
 }
 
-func (s *scyllaDatastore) TransferRepository(ctx context.Context, repoID, fromNamespaceID, toNamespaceID string) error {
-	old, err := s.LookupNamespaceByRepoID(ctx, repoID)
-	if err != nil {
-		return err
-	}
-	// Insert the destination mapping first via LWT so we don't clobber an
-	// existing repo with the same name in the target namespace.
-	if err := s.CreateNamespaceMapping(ctx, &datastore.NamespaceMapping{
-		NamespaceID: toNamespaceID,
-		Name:        old.Name,
-		RepoID:      repoID,
-	}); err != nil {
-		return err
-	}
-	return s.DeleteNamespaceMapping(ctx, fromNamespaceID, old.Name)
+func (s *scyllaDatastore) repositoryMappingRepairError(
+	operation, repositoryID, projection string,
+	path repositoryPath,
+	findingType datastore.FindingType,
+	primary error,
+) error {
+	s.emitRepositoryMappingFinding(datastore.ProjectionFinding{
+		ResourceKind: "Repository",
+		ResourceUID:  repositoryID,
+		Projection:   projection,
+		LookupKey:    path.key(),
+		Operation:    operation,
+		Type:         findingType,
+	})
+	return datastore.NewRepairRequiredError(
+		datastore.MutationStep{
+			Operation:    operation,
+			ResourceKind: "Repository",
+			ResourceUID:  repositoryID,
+			Projection:   projection,
+			LookupKey:    path.key(),
+			Action:       string(findingType),
+		},
+		primary,
+		fmt.Errorf("repository mapping projections require repair"),
+	)
 }
 
-func (s *scyllaDatastore) DeleteNamespaceMapping(_ context.Context, namespaceID, name string) error {
-	stmt, names := s.namespaceMappingTable.Delete()
-	if err := s.session.Query(stmt, names).BindMap(qb.M{"namespace_id": namespaceID, "name": name}).ExecRelease(); err != nil {
-		return fmt.Errorf("scylla: delete namespace_mapping: %w", err)
+func (s *scyllaDatastore) emitRepositoryMappingFinding(finding datastore.ProjectionFinding) {
+	if s.log == nil {
+		return
 	}
-	return nil
+	s.log.Warn("datastore projection inconsistency",
+		zap.String("operation", finding.Operation),
+		zap.String("resource_kind", finding.ResourceKind),
+		zap.String("resource_uid", finding.ResourceUID),
+		zap.String("projection", finding.Projection),
+		zap.String("lookup_key", finding.LookupKey),
+		zap.String("finding_type", string(finding.Type)),
+	)
+}
+
+func fromNamespaceMappingRow(row *namespaceMappingRow) *datastore.NamespaceMapping {
+	mapping := &datastore.NamespaceMapping{
+		Namespace:    row.Namespace,
+		Name:         row.Name,
+		RepositoryID: row.RepositoryID.String(),
+	}
+	datastore.NormalizeNamespaceMappingContract(mapping)
+	return mapping
 }

--- a/gitstore-api/internal/datastore/scylla/namespace_model_test.go
+++ b/gitstore-api/internal/datastore/scylla/namespace_model_test.go
@@ -4,6 +4,7 @@
 package scylla
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -14,12 +15,63 @@ import (
 )
 
 func TestNamespaceTablesMatchQueryAccessPatterns(t *testing.T) {
-	assert.Equal(t, []string{"id"}, NamespaceByID.Metadata().PartKey)
-	assert.Empty(t, NamespaceByID.Metadata().SortKey)
+	assert.Equal(t, []string{"uid"}, NamespaceByUID.Metadata().PartKey)
+	assert.Empty(t, NamespaceByUID.Metadata().SortKey)
 	assert.Equal(t, []string{"name"}, NamespaceByName.Metadata().PartKey)
 	assert.Equal(t, []string{"bucket"}, NamespaceByBucket.Metadata().PartKey)
-	assert.Equal(t, []string{"creation_timestamp", "id"}, NamespaceByBucket.Metadata().SortKey)
-	assert.Equal(t, []string{"creation_timestamp", "id"}, Repository.Metadata().SortKey)
+	assert.Equal(t, []string{"creation_timestamp", "uid"}, NamespaceByBucket.Metadata().SortKey)
+	assert.Equal(t, []string{"uid"}, RepositoryByUID.Metadata().PartKey)
+	assert.Equal(t, []string{"namespace", "bucket"}, RepositoryByNamespace.Metadata().PartKey)
+	assert.Equal(t, []string{"creation_timestamp", "uid"}, RepositoryByNamespace.Metadata().SortKey)
+	assert.Equal(t, []string{"bucket"}, RepositoryByBucket.Metadata().PartKey)
+	assert.Equal(t, []string{"creation_timestamp", "uid"}, RepositoryByBucket.Metadata().SortKey)
+}
+
+func TestAuthoritativeTablesUseCanonicalResourceEnvelope(t *testing.T) {
+	required := []string{
+		"api_version",
+		"kind",
+		"uid",
+		"name",
+		"generation",
+		"resource_version",
+		"revision",
+		"creation_timestamp",
+		"creation_actor",
+		"update_timestamp",
+		"update_actor",
+		"labels",
+		"annotations",
+		"owner_references",
+		"finalizers",
+		"deletion_timestamp",
+		"source_path",
+		"git_commit_sha",
+		"git_ref",
+		"spec",
+		"body",
+		"status",
+	}
+
+	for name, metadata := range map[string][]string{
+		"Namespace":        NamespaceByUID.Metadata().Columns,
+		"Repository":       RepositoryByUID.Metadata().Columns,
+		"Product":          ProductByNamespace.Metadata().Columns,
+		"ProductVariant":   ProductVariantByNamespace.Metadata().Columns,
+		"Collection":       Collection.Metadata().Columns,
+		"CategoryTaxonomy": CategoryTaxonomy.Metadata().Columns,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Subset(t, metadata, required)
+			if name != "Namespace" {
+				assert.Contains(t, metadata, "namespace")
+				assert.Contains(t, metadata, "repository_id")
+			} else {
+				assert.NotContains(t, metadata, "namespace")
+				assert.NotContains(t, metadata, "repository_id")
+			}
+		})
+	}
 }
 
 func TestNamespaceBucketsForPage(t *testing.T) {
@@ -42,17 +94,24 @@ func TestInitialSchemaUsesQueryFirstNamespaceTables(t *testing.T) {
 	require.NoError(t, err)
 	schema := string(content)
 
-	assert.Contains(t, schema, "CREATE TABLE IF NOT EXISTS namespaces_by_id")
+	assert.Contains(t, schema, "CREATE TABLE IF NOT EXISTS namespaces_by_uid")
 	assert.Contains(t, schema, "CREATE TABLE IF NOT EXISTS namespaces_by_name")
 	assert.Contains(t, schema, "CREATE TABLE IF NOT EXISTS namespaces_by_bucket")
-	assert.Contains(t, schema, "creation_actor      text")
-	assert.Contains(t, schema, "update_timestamp    timestamp")
-	assert.Contains(t, schema, "update_actor        text")
-	assert.Contains(t, schema, "PRIMARY KEY ((bucket), creation_timestamp, id)")
+	assert.Contains(t, schema, "api_version          text")
+	assert.Contains(t, schema, "owner_references     text")
+	assert.Contains(t, schema, "body                 text")
+	assert.Contains(t, schema, "creation_actor       text")
+	assert.Contains(t, schema, "update_timestamp     timestamp")
+	assert.Contains(t, schema, "update_actor         text")
+	assert.Contains(t, schema, "PRIMARY KEY ((bucket), creation_timestamp, uid)")
 	assert.NotContains(t, schema, "CREATE TABLE IF NOT EXISTS namespaces (")
+	assert.NotContains(t, schema, "namespaces_by_id")
 	assert.NotContains(t, schema, "ALTER TABLE")
 	assert.NotContains(t, schema, "identifier")
 	assert.NotContains(t, schema, "display_name")
+	assert.NotContains(t, schema, "'all'")
+	assert.Equal(t, strings.Count(schema, "CREATE TABLE IF NOT EXISTS"), strings.Count(schema, "gc_grace_seconds = 864000"))
+	assert.NotContains(t, schema, "TimeWindowCompactionStrategy")
 }
 
 func TestScyllaSchemaUsesTwoAlphaBaselineMigrations(t *testing.T) {
@@ -70,4 +129,14 @@ func TestScyllaSchemaUsesTwoAlphaBaselineMigrations(t *testing.T) {
 		"001_initial_schema.cql",
 		"002_secondary_indexes.cql",
 	}, names)
+}
+
+func TestSecondaryIndexMigrationIsIntentionallyEmpty(t *testing.T) {
+	content, err := migrations.Files.ReadFile("002_secondary_indexes.cql")
+	require.NoError(t, err)
+	schema := string(content)
+
+	assert.NotContains(t, schema, "CREATE INDEX")
+	assert.NotContains(t, schema, "CREATE CUSTOM INDEX")
+	assert.Contains(t, schema, "Query-first tables")
 }

--- a/gitstore-api/internal/datastore/scylla/pagination.go
+++ b/gitstore-api/internal/datastore/scylla/pagination.go
@@ -54,7 +54,7 @@ type clusterKeys struct {
 	IDCol        string
 }
 
-var namespaceClusterKeys = clusterKeys{TimestampCol: "creation_timestamp", IDCol: "id"}
+var namespaceClusterKeys = clusterKeys{TimestampCol: "creation_timestamp", IDCol: "uid"}
 var productClusterKeys = clusterKeys{TimestampCol: "creation_timestamp", IDCol: "uid"}
 var collectionClusterKeys = clusterKeys{TimestampCol: "creation_timestamp", IDCol: "uid"}
 
@@ -205,70 +205,5 @@ func buildPageResult[T any](items []*T, limit int, page datastore.PageParams) *d
 		HasNext:     hasNext,
 		HasPrevious: hasPrevious,
 		TotalCount:  -1, // expensive to compute in ScyllaDB
-	}
-}
-
-// paginateInMemory applies cursor-based keyset pagination to a pre-sorted slice
-// (sorted by creation timestamp DESC, id DESC). Used when ORDER BY is not supported in CQL
-// (e.g., secondary index queries).
-func paginateInMemory(items []*datastore.Repository, page datastore.PageParams) *datastore.PageResult[datastore.Repository] {
-	total := len(items)
-	limit := page.Limit()
-
-	// Apply cursor filtering
-	if page.After != "" {
-		cursor, err := parsePageCursor(page.After)
-		if err == nil {
-			idx := -1
-			for i, item := range items {
-				if item.CreationTimestamp.Equal(cursor.CreatedAt) && item.ID == cursor.ID {
-					idx = i
-					break
-				}
-			}
-			if idx >= 0 {
-				items = items[idx+1:]
-			}
-		}
-	} else if page.Before != "" {
-		cursor, err := parsePageCursor(page.Before)
-		if err == nil {
-			idx := -1
-			for i, item := range items {
-				if item.CreationTimestamp.Equal(cursor.CreatedAt) && item.ID == cursor.ID {
-					idx = i
-					break
-				}
-			}
-			if idx >= 0 {
-				items = items[:idx]
-			}
-		}
-	}
-
-	hasNext := false
-	hasPrevious := false
-
-	if page.Last > 0 {
-		// Take the last N items
-		if len(items) > limit {
-			items = items[len(items)-limit:]
-			hasPrevious = true
-		}
-		hasNext = page.Before != ""
-	} else {
-		// Take the first N items
-		if len(items) > limit {
-			items = items[:limit]
-			hasNext = true
-		}
-		hasPrevious = page.After != ""
-	}
-
-	return &datastore.PageResult[datastore.Repository]{
-		Items:       items,
-		HasNext:     hasNext,
-		HasPrevious: hasPrevious,
-		TotalCount:  int32(total),
 	}
 }

--- a/gitstore-api/internal/datastore/scylla/recovery.go
+++ b/gitstore-api/internal/datastore/scylla/recovery.go
@@ -1,0 +1,551 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package scylla
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/gocql/gocql"
+	"go.uber.org/zap"
+)
+
+type failurePoint string
+
+const (
+	failureBefore failurePoint = "before"
+	failureAfter  failurePoint = "after"
+)
+
+type failureInjector interface {
+	Inject(step string, point failurePoint) error
+}
+
+type noopFailureInjector struct{}
+
+func (noopFailureInjector) Inject(string, failurePoint) error { return nil }
+
+type mutationAction struct {
+	Step       datastore.MutationStep
+	Apply      func(context.Context) error
+	Compensate func(context.Context) error
+}
+
+type mutationExecutor struct {
+	injector failureInjector
+}
+
+func newMutationExecutor(injector failureInjector) *mutationExecutor {
+	if injector == nil {
+		injector = noopFailureInjector{}
+	}
+	return &mutationExecutor{injector: injector}
+}
+
+func (e *mutationExecutor) execute(ctx context.Context, actions ...mutationAction) error {
+	completed := make([]mutationAction, 0, len(actions))
+	for _, action := range actions {
+		if err := e.injector.Inject(action.Step.Action, failureBefore); err != nil {
+			return e.compensate(ctx, completed, action.Step, err)
+		}
+		if action.Apply == nil {
+			return e.compensate(ctx, completed, action.Step, errors.New("mutation action has no apply function"))
+		}
+		if err := action.Apply(ctx); err != nil {
+			return e.compensate(ctx, completed, action.Step, err)
+		}
+		completed = append(completed, action)
+		if err := e.injector.Inject(action.Step.Action, failureAfter); err != nil {
+			return e.compensate(ctx, completed, action.Step, err)
+		}
+	}
+	return nil
+}
+
+func (e *mutationExecutor) executeUpdate(
+	ctx context.Context,
+	committedResourceVersion string,
+	authoritative mutationAction,
+	projections ...mutationAction,
+) error {
+	if err := e.injector.Inject(authoritative.Step.Action, failureBefore); err != nil {
+		return err
+	}
+	if authoritative.Apply == nil {
+		return errors.New("authoritative mutation action has no apply function")
+	}
+	if err := authoritative.Apply(ctx); err != nil {
+		return err
+	}
+	authoritativeAfterErr := e.injector.Inject(authoritative.Step.Action, failureAfter)
+
+	var unresolved []error
+	var firstStep datastore.MutationStep
+	for _, action := range projections {
+		if action.Apply == nil {
+			if firstStep.Action == "" {
+				firstStep = action.Step
+			}
+			unresolved = append(unresolved, errors.New("projection mutation action has no apply function"))
+			continue
+		}
+
+		var err error
+		for attempt := 0; attempt < 2; attempt++ {
+			if injected := e.injector.Inject(action.Step.Action, failureBefore); injected != nil {
+				err = injected
+			} else {
+				err = action.Apply(ctx)
+				if err == nil {
+					err = e.injector.Inject(action.Step.Action, failureAfter)
+				}
+			}
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			if firstStep.Action == "" {
+				firstStep = action.Step
+			}
+			unresolved = append(unresolved, fmt.Errorf("%s: %w", action.Step.Projection, err))
+		}
+	}
+	if len(unresolved) == 0 {
+		return authoritativeAfterErr
+	}
+	primary := errors.Join(unresolved...)
+	if authoritativeAfterErr != nil {
+		primary = errors.Join(authoritativeAfterErr, primary)
+	}
+	return datastore.NewRepairRequiredError(
+		firstStep,
+		primary,
+		fmt.Errorf("authoritative resource version %s committed; projections require roll-forward", committedResourceVersion),
+	)
+}
+
+func (e *mutationExecutor) executeDelete(
+	ctx context.Context,
+	authoritative mutationAction,
+	projections ...mutationAction,
+) error {
+	completed := make([]mutationAction, 0, len(projections))
+	for _, action := range projections {
+		if err := e.injector.Inject(action.Step.Action, failureBefore); err != nil {
+			return e.compensate(ctx, completed, action.Step, err)
+		}
+		if action.Apply == nil {
+			return e.compensate(ctx, completed, action.Step, errors.New("mutation action has no apply function"))
+		}
+		if err := action.Apply(ctx); err != nil {
+			return e.compensate(ctx, completed, action.Step, err)
+		}
+		completed = append(completed, action)
+		if err := e.injector.Inject(action.Step.Action, failureAfter); err != nil {
+			return e.compensate(ctx, completed, action.Step, err)
+		}
+	}
+
+	if err := e.injector.Inject(authoritative.Step.Action, failureBefore); err != nil {
+		return e.compensate(ctx, completed, authoritative.Step, err)
+	}
+	if authoritative.Apply == nil {
+		return e.compensate(ctx, completed, authoritative.Step, errors.New("authoritative mutation action has no apply function"))
+	}
+	if err := authoritative.Apply(ctx); err != nil {
+		return e.compensate(ctx, completed, authoritative.Step, err)
+	}
+	return e.injector.Inject(authoritative.Step.Action, failureAfter)
+}
+
+func (e *mutationExecutor) compensate(
+	ctx context.Context,
+	completed []mutationAction,
+	failedStep datastore.MutationStep,
+	primary error,
+) error {
+	var compensationErrors []error
+	compensationStep := failedStep
+	for i := len(completed) - 1; i >= 0; i-- {
+		if completed[i].Compensate == nil {
+			continue
+		}
+		if err := completed[i].Compensate(ctx); err != nil {
+			if len(compensationErrors) == 0 {
+				compensationStep = completed[i].Step
+			}
+			compensationErrors = append(compensationErrors, err)
+		}
+	}
+	if len(compensationErrors) > 0 {
+		return datastore.NewRepairRequiredError(compensationStep, primary, errors.Join(compensationErrors...))
+	}
+	return primary
+}
+
+func (s *scyllaDatastore) reportFinding(ctx context.Context, finding datastore.ProjectionFinding) {
+	datastore.ReportProjectionFinding(ctx, finding)
+	s.log.Warn("scylla catalogue projection inconsistency",
+		zap.String("operation", finding.Operation),
+		zap.String("resource_kind", finding.ResourceKind),
+		zap.String("resource_uid", finding.ResourceUID),
+		zap.String("projection", finding.Projection),
+		zap.String("lookup_key", finding.LookupKey),
+		zap.String("finding_type", string(finding.Type)),
+	)
+}
+
+func (s *scyllaDatastore) reserveName(
+	ctx context.Context,
+	resourceKind, tableName, namespace, name string,
+	owner gocql.UUID,
+	createdAt time.Time,
+) error {
+	_, err := s.reserveNameWithMode(ctx, resourceKind, tableName, namespace, name, owner, createdAt, true)
+	return err
+}
+
+func (s *scyllaDatastore) reserveNameOwned(
+	ctx context.Context,
+	resourceKind, tableName, namespace, name string,
+	owner gocql.UUID,
+	createdAt time.Time,
+) (bool, error) {
+	return s.reserveNameWithMode(ctx, resourceKind, tableName, namespace, name, owner, createdAt, false)
+}
+
+func (s *scyllaDatastore) reserveNameWithMode(
+	ctx context.Context,
+	resourceKind, tableName, namespace, name string,
+	owner gocql.UUID,
+	createdAt time.Time,
+	repairSameOwner bool,
+) (bool, error) {
+	statement := fmt.Sprintf(
+		"INSERT INTO %s (namespace,name,uid,creation_timestamp) VALUES (?,?,?,?) IF NOT EXISTS",
+		tableName,
+	)
+	return s.reserveOwned(ctx, datastore.MutationStep{
+		Operation:    "reserve",
+		ResourceKind: resourceKind,
+		ResourceUID:  owner.String(),
+		Projection:   tableName,
+		LookupKey:    namespace + "/" + name,
+		Action:       "reserve-name",
+	}, statement, []any{namespace, name, owner, createdAt}, owner, func(existing map[string]any) error {
+		existingCreated, _ := existing["creation_timestamp"].(time.Time)
+		if scyllaTimestampEqual(existingCreated, createdAt) {
+			return nil
+		}
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: resourceKind,
+			ResourceUID:  owner.String(),
+			Projection:   tableName,
+			LookupKey:    namespace + "/" + name,
+			Operation:    "reserve",
+			Type:         datastore.FindingStale,
+		})
+		if !repairSameOwner {
+			return fmt.Errorf("%w: %s %s/%s has stale identity metadata", datastore.ErrConflict, tableName, namespace, name)
+		}
+		applied, err := s.session.Query(
+			fmt.Sprintf("UPDATE %s SET creation_timestamp=? WHERE namespace=? AND name=? IF uid=?", tableName),
+			nil,
+		).WithContext(ctx).Bind(createdAt, namespace, name, owner).ExecCASRelease()
+		if err != nil {
+			return err
+		}
+		if !applied {
+			return fmt.Errorf("%w: %s %s/%s changed owner during repair", datastore.ErrAlreadyExists, tableName, namespace, name)
+		}
+		return nil
+	})
+}
+
+func (s *scyllaDatastore) reserveUID(
+	ctx context.Context,
+	resourceKind, tableName, namespace string,
+	owner gocql.UUID,
+	createdAt time.Time,
+) error {
+	_, err := s.reserveUIDWithMode(ctx, resourceKind, tableName, namespace, owner, createdAt, true)
+	return err
+}
+
+func (s *scyllaDatastore) reserveUIDOwned(
+	ctx context.Context,
+	resourceKind, tableName, namespace string,
+	owner gocql.UUID,
+	createdAt time.Time,
+) (bool, error) {
+	return s.reserveUIDWithMode(ctx, resourceKind, tableName, namespace, owner, createdAt, false)
+}
+
+func (s *scyllaDatastore) reserveUIDWithMode(
+	ctx context.Context,
+	resourceKind, tableName, namespace string,
+	owner gocql.UUID,
+	createdAt time.Time,
+	repairSameOwner bool,
+) (bool, error) {
+	statement := fmt.Sprintf(
+		"INSERT INTO %s (uid,namespace,creation_timestamp) VALUES (?,?,?) IF NOT EXISTS",
+		tableName,
+	)
+	return s.reserveOwned(ctx, datastore.MutationStep{
+		Operation:    "reserve",
+		ResourceKind: resourceKind,
+		ResourceUID:  owner.String(),
+		Projection:   tableName,
+		LookupKey:    owner.String(),
+		Action:       "reserve-uid",
+	}, statement, []any{owner, namespace, createdAt}, owner, func(existing map[string]any) error {
+		existingNamespace, _ := existing["namespace"].(string)
+		existingCreated, _ := existing["creation_timestamp"].(time.Time)
+		if existingNamespace == namespace && scyllaTimestampEqual(existingCreated, createdAt) {
+			return nil
+		}
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: resourceKind,
+			ResourceUID:  owner.String(),
+			Projection:   tableName,
+			LookupKey:    owner.String(),
+			Operation:    "reserve",
+			Type:         datastore.FindingStale,
+		})
+		if !repairSameOwner {
+			return fmt.Errorf("%w: %s uid %s has stale identity metadata", datastore.ErrConflict, tableName, owner)
+		}
+		applied, err := s.session.Query(
+			fmt.Sprintf("UPDATE %s SET namespace=?,creation_timestamp=? WHERE uid=? IF namespace=? AND creation_timestamp=?", tableName),
+			nil,
+		).WithContext(ctx).Bind(namespace, createdAt, owner, existingNamespace, existingCreated).ExecCASRelease()
+		if err != nil {
+			return err
+		}
+		if !applied {
+			return fmt.Errorf("%w: %s uid %s changed during repair", datastore.ErrConflict, tableName, owner)
+		}
+		return nil
+	})
+}
+
+func (s *scyllaDatastore) reserveSKU(
+	ctx context.Context,
+	namespace, sku string,
+	owner gocql.UUID,
+	createdAt time.Time,
+) error {
+	_, err := s.reserveSKUWithMode(ctx, namespace, sku, owner, createdAt, true)
+	return err
+}
+
+func (s *scyllaDatastore) reserveSKUOwned(
+	ctx context.Context,
+	namespace, sku string,
+	owner gocql.UUID,
+	createdAt time.Time,
+) (bool, error) {
+	return s.reserveSKUWithMode(ctx, namespace, sku, owner, createdAt, false)
+}
+
+func (s *scyllaDatastore) reserveSKUWithMode(
+	ctx context.Context,
+	namespace, sku string,
+	owner gocql.UUID,
+	createdAt time.Time,
+	repairSameOwner bool,
+) (bool, error) {
+	const tableName = "product_variant_by_sku"
+	statement := "INSERT INTO product_variant_by_sku (namespace,sku,uid,creation_timestamp) VALUES (?,?,?,?) IF NOT EXISTS"
+	return s.reserveOwned(ctx, datastore.MutationStep{
+		Operation:    "reserve",
+		ResourceKind: "ProductVariant",
+		ResourceUID:  owner.String(),
+		Projection:   tableName,
+		LookupKey:    namespace + "/" + sku,
+		Action:       "reserve-sku",
+	}, statement, []any{namespace, sku, owner, createdAt}, owner, func(existing map[string]any) error {
+		existingCreated, _ := existing["creation_timestamp"].(time.Time)
+		if scyllaTimestampEqual(existingCreated, createdAt) {
+			return nil
+		}
+
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: "ProductVariant",
+			ResourceUID:  owner.String(),
+			Projection:   tableName,
+			LookupKey:    namespace + "/" + sku,
+			Operation:    "reserve",
+			Type:         datastore.FindingStale,
+		})
+		if !repairSameOwner {
+			return fmt.Errorf("%w: sku %s/%s has stale identity metadata", datastore.ErrConflict, namespace, sku)
+		}
+		applied, err := s.session.Query(
+			"UPDATE product_variant_by_sku SET creation_timestamp=? WHERE namespace=? AND sku=? IF uid=?",
+			nil,
+		).WithContext(ctx).Bind(createdAt, namespace, sku, owner).ExecCASRelease()
+		if err != nil {
+			return err
+		}
+		if !applied {
+			return fmt.Errorf("%w: sku %s/%s changed owner during repair", datastore.ErrAlreadyExists, namespace, sku)
+		}
+		return nil
+	})
+}
+
+func scyllaTimestampEqual(left, right time.Time) bool {
+	return left.UnixMilli() == right.UnixMilli()
+}
+
+func (s *scyllaDatastore) reserveOwned(
+	ctx context.Context,
+	step datastore.MutationStep,
+	statement string,
+	args []any,
+	owner gocql.UUID,
+	sameOwner func(map[string]any) error,
+) (bool, error) {
+	return s.reserveOwnedColumn(ctx, step, statement, args, "uid", owner, sameOwner)
+}
+
+func (s *scyllaDatastore) reserveOwnedColumn(
+	ctx context.Context,
+	step datastore.MutationStep,
+	statement string,
+	args []any,
+	ownerColumn string,
+	owner gocql.UUID,
+	sameOwner func(map[string]any) error,
+) (bool, error) {
+	existing := make(map[string]any)
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).Bind(args...).MapScanCAS(existing)
+	if err != nil {
+		return false, fmt.Errorf("scylla: reserve %s: %w", step.Projection, err)
+	}
+	if applied {
+		return true, nil
+	}
+	actualOwner, ok := asUUID(existing[ownerColumn])
+	if !ok || actualOwner != owner {
+		s.reportFinding(ctx, datastore.ProjectionFinding{
+			ResourceKind: step.ResourceKind,
+			ResourceUID:  owner.String(),
+			Projection:   step.Projection,
+			LookupKey:    step.LookupKey,
+			Operation:    step.Operation,
+			Type:         datastore.FindingDuplicate,
+		})
+		return false, fmt.Errorf("%w: %s %s is owned by %v", datastore.ErrAlreadyExists, step.Projection, step.LookupKey, existing[ownerColumn])
+	}
+	if sameOwner != nil {
+		return false, sameOwner(existing)
+	}
+	return false, nil
+}
+
+func (s *scyllaDatastore) releaseName(
+	ctx context.Context,
+	tableName, namespace, name string,
+	owner gocql.UUID,
+) error {
+	return s.releaseOwned(ctx,
+		fmt.Sprintf("DELETE FROM %s WHERE namespace=? AND name=? IF uid=?", tableName),
+		[]any{namespace, name, owner},
+		datastore.ProjectionFinding{
+			ResourceKind: resourceKindForProjection(tableName), ResourceUID: owner.String(), Projection: tableName, LookupKey: namespace + "/" + name,
+			Operation: "release", Type: datastore.FindingStale,
+		},
+	)
+}
+
+func (s *scyllaDatastore) releaseUID(
+	ctx context.Context,
+	tableName, namespace string,
+	owner gocql.UUID,
+	createdAt time.Time,
+) error {
+	return s.releaseOwned(ctx,
+		fmt.Sprintf("DELETE FROM %s WHERE uid=? IF namespace=? AND creation_timestamp=?", tableName),
+		[]any{owner, namespace, createdAt},
+		datastore.ProjectionFinding{
+			ResourceKind: resourceKindForProjection(tableName), ResourceUID: owner.String(), Projection: tableName, LookupKey: owner.String(),
+			Operation: "release", Type: datastore.FindingStale,
+		},
+	)
+}
+
+func (s *scyllaDatastore) releaseSKU(
+	ctx context.Context,
+	namespace, sku string,
+	owner gocql.UUID,
+) error {
+	return s.releaseOwned(ctx,
+		"DELETE FROM product_variant_by_sku WHERE namespace=? AND sku=? IF uid=?",
+		[]any{namespace, sku, owner},
+		datastore.ProjectionFinding{
+			ResourceKind: "ProductVariant", ResourceUID: owner.String(), Projection: "product_variant_by_sku",
+			LookupKey: namespace + "/" + sku, Operation: "release", Type: datastore.FindingStale,
+		},
+	)
+}
+
+func (s *scyllaDatastore) releaseOwned(
+	ctx context.Context,
+	statement string,
+	args []any,
+	finding datastore.ProjectionFinding,
+) error {
+	existing := make(map[string]any)
+	applied, err := s.session.Query(statement, nil).WithContext(ctx).Bind(args...).MapScanCAS(existing)
+	if err != nil {
+		return err
+	}
+	if !applied {
+		s.reportFinding(ctx, finding)
+	}
+	return nil
+}
+
+func resourceKindForProjection(tableName string) string {
+	switch tableName {
+	case "products_by_name", "products_by_uid", "products_by_namespace":
+		return "Product"
+	case "category_taxonomy_by_name", "category_taxonomy_by_uid", "category_taxonomy":
+		return "CategoryTaxonomy"
+	case "collection_by_name", "collection_by_uid", "collection":
+		return "Collection"
+	case "product_variant_by_name", "product_variant_by_uid", "product_variant_by_sku",
+		"product_variant_by_product_ref", "product_variant_by_namespace":
+		return "ProductVariant"
+	case "namespace_mappings":
+		return "Repository"
+	default:
+		return "Unknown"
+	}
+}
+
+func asUUID(value any) (gocql.UUID, bool) {
+	switch typed := value.(type) {
+	case gocql.UUID:
+		return typed, true
+	case *gocql.UUID:
+		if typed != nil {
+			return *typed, true
+		}
+	case string:
+		parsed, err := gocql.ParseUUID(typed)
+		return parsed, err == nil
+	case []byte:
+		parsed, err := gocql.UUIDFromBytes(typed)
+		return parsed, err == nil
+	}
+	return gocql.UUID{}, false
+}

--- a/gitstore-api/internal/datastore/scylla/repair.go
+++ b/gitstore-api/internal/datastore/scylla/repair.go
@@ -1,0 +1,945 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package scylla
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/config"
+	"github.com/gocql/gocql"
+	"github.com/scylladb/gocqlx/v3"
+)
+
+type FindingType string
+
+const (
+	FindingMissing   FindingType = "missing"
+	FindingDangling  FindingType = "dangling"
+	FindingStale     FindingType = "stale"
+	FindingDuplicate FindingType = "duplicate"
+)
+
+type RepairActionType string
+
+const (
+	RepairInsert RepairActionType = "insert"
+	RepairUpdate RepairActionType = "update"
+	RepairDelete RepairActionType = "delete"
+)
+
+type AuthoritativeResource struct {
+	Kind              string    `json:"kind"`
+	UID               string    `json:"uid"`
+	Namespace         string    `json:"namespace,omitempty"`
+	Name              string    `json:"name"`
+	ResourceVersion   string    `json:"resourceVersion"`
+	CreationTimestamp time.Time `json:"creationTimestamp"`
+	SKU               string    `json:"sku,omitempty"`
+	ProductRefName    string    `json:"productRefName,omitempty"`
+}
+
+type ProjectionRecord struct {
+	Table             string    `json:"table"`
+	UID               string    `json:"uid"`
+	Namespace         string    `json:"namespace,omitempty"`
+	Name              string    `json:"name,omitempty"`
+	Bucket            string    `json:"bucket,omitempty"`
+	CreationTimestamp time.Time `json:"creationTimestamp,omitempty"`
+	SKU               string    `json:"sku,omitempty"`
+	ProductRefName    string    `json:"productRefName,omitempty"`
+}
+
+type ProjectionSnapshot struct {
+	Authoritative []AuthoritativeResource `json:"authoritative"`
+	Projections   []ProjectionRecord      `json:"projections"`
+}
+
+type ProjectionFinding struct {
+	Type       FindingType       `json:"type"`
+	Kind       string            `json:"kind"`
+	UID        string            `json:"uid"`
+	Table      string            `json:"table"`
+	Key        string            `json:"key"`
+	Expected   *ProjectionRecord `json:"expected,omitempty"`
+	Actual     *ProjectionRecord `json:"actual,omitempty"`
+	Repairable bool              `json:"repairable"`
+	Reason     string            `json:"reason,omitempty"`
+}
+
+type RepairAction struct {
+	Type                    RepairActionType  `json:"type"`
+	Kind                    string            `json:"kind"`
+	UID                     string            `json:"uid"`
+	ResourceNamespace       string            `json:"resourceNamespace,omitempty"`
+	ExpectedResourceVersion string            `json:"expectedResourceVersion,omitempty"`
+	RequireAbsentResource   bool              `json:"requireAbsentResource,omitempty"`
+	Before                  *ProjectionRecord `json:"before,omitempty"`
+	After                   *ProjectionRecord `json:"after,omitempty"`
+}
+
+type RepairPlan struct {
+	Findings []ProjectionFinding `json:"findings"`
+	Actions  []RepairAction      `json:"actions"`
+}
+
+type RepairResult struct {
+	PlannedActions int        `json:"plannedActions"`
+	AppliedActions int        `json:"appliedActions"`
+	Verification   RepairPlan `json:"verification"`
+}
+
+type projectionRepairStore interface {
+	Snapshot(context.Context) (ProjectionSnapshot, error)
+	LookupResource(context.Context, RepairAction) (*AuthoritativeResource, error)
+	ApplyAction(context.Context, RepairAction) (bool, error)
+	Close()
+}
+
+type ProjectionRepairService struct {
+	store projectionRepairStore
+}
+
+func OpenProjectionRepairService(cfg config.ScyllaConfig) (*ProjectionRepairService, error) {
+	hosts, port := parseRepairHosts(cfg.Hosts)
+	cluster := gocql.NewCluster(hosts...)
+	cluster.Keyspace = cfg.Keyspace
+	cluster.Consistency = gocql.Quorum
+	cluster.DisableShardAwarePort = cfg.DisableShardAwarePort
+	cluster.IgnorePeerAddr = cfg.IgnorePeerAddr
+	if port > 0 {
+		cluster.Port = port
+	}
+	if cfg.Username != "" {
+		cluster.Authenticator = gocql.PasswordAuthenticator{Username: cfg.Username, Password: cfg.Password}
+	}
+	if cfg.TLS {
+		cluster.SslOpts = &gocql.SslOptions{EnableHostVerification: true}
+	}
+	raw, err := cluster.CreateSession()
+	if err != nil {
+		return nil, fmt.Errorf("scylla projection repair: open session: %w", err)
+	}
+	return &ProjectionRepairService{store: &scyllaProjectionRepairStore{
+		session: gocqlx.NewSession(raw),
+		raw:     raw,
+	}}, nil
+}
+
+func parseRepairHosts(hosts []string) ([]string, int) {
+	parsed := make([]string, 0, len(hosts))
+	port := 0
+	for _, address := range hosts {
+		address = strings.TrimSpace(address)
+		host, rawPort, err := net.SplitHostPort(address)
+		if err != nil {
+			parsed = append(parsed, address)
+			continue
+		}
+		parsed = append(parsed, host)
+		if value, parseErr := strconv.Atoi(rawPort); parseErr == nil && value > 0 {
+			port = value
+		}
+	}
+	return parsed, port
+}
+
+func (s *ProjectionRepairService) Close() {
+	if s != nil && s.store != nil {
+		s.store.Close()
+	}
+}
+
+func (s *ProjectionRepairService) Audit(ctx context.Context) (RepairPlan, error) {
+	if s == nil || s.store == nil {
+		return RepairPlan{}, errors.New("projection repair service is not initialized")
+	}
+	snapshot, err := s.store.Snapshot(ctx)
+	if err != nil {
+		return RepairPlan{}, err
+	}
+	return BuildRepairPlan(snapshot)
+}
+
+func (s *ProjectionRepairService) Apply(ctx context.Context, plan RepairPlan) (RepairResult, error) {
+	if s == nil || s.store == nil {
+		return RepairResult{}, errors.New("projection repair service is not initialized")
+	}
+	if err := ValidateRepairPlan(plan); err != nil {
+		return RepairResult{}, err
+	}
+	result := RepairResult{PlannedActions: len(plan.Actions)}
+	for _, action := range plan.Actions {
+		resource, err := s.store.LookupResource(ctx, action)
+		if err != nil {
+			return result, fmt.Errorf("guard %s %s/%s: %w", action.Type, action.Kind, action.UID, err)
+		}
+		if action.RequireAbsentResource {
+			if resource != nil {
+				return result, fmt.Errorf("guard %s %s/%s: authoritative resource appeared concurrently", action.Type, action.Kind, action.UID)
+			}
+		} else {
+			if resource == nil {
+				return result, fmt.Errorf("guard %s %s/%s: authoritative resource disappeared concurrently", action.Type, action.Kind, action.UID)
+			}
+			if resource.ResourceVersion != action.ExpectedResourceVersion {
+				return result, fmt.Errorf(
+					"guard %s %s/%s: resource version changed from %q to %q",
+					action.Type, action.Kind, action.UID, action.ExpectedResourceVersion, resource.ResourceVersion,
+				)
+			}
+		}
+		applied, err := s.store.ApplyAction(ctx, action)
+		if err != nil {
+			return result, fmt.Errorf("apply %s to %s: %w", action.Type, actionTable(action), err)
+		}
+		if !applied {
+			return result, fmt.Errorf("apply %s to %s: conditional mutation was not applied", action.Type, actionTable(action))
+		}
+		result.AppliedActions++
+	}
+
+	verification, err := s.Audit(ctx)
+	if err != nil {
+		return result, fmt.Errorf("post-repair audit: %w", err)
+	}
+	result.Verification = verification
+	if len(verification.Findings) != 0 {
+		return result, fmt.Errorf("post-repair verification found %d projection inconsistencies", len(verification.Findings))
+	}
+	return result, nil
+}
+
+func BuildRepairPlan(snapshot ProjectionSnapshot) (RepairPlan, error) {
+	if err := validateSnapshot(snapshot); err != nil {
+		return RepairPlan{}, err
+	}
+
+	resources := make(map[string]AuthoritativeResource, len(snapshot.Authoritative))
+	expectedByKey := make(map[string]ProjectionRecord)
+	expectedByOwner := make(map[string][]ProjectionRecord)
+	for _, resource := range snapshot.Authoritative {
+		resources[resourceKey(resource.Kind, resource.UID)] = resource
+		for _, projection := range expectedProjections(resource) {
+			key := projectionMapKey(projection)
+			if owner, exists := expectedByKey[key]; exists && owner.UID != projection.UID {
+				return RepairPlan{}, fmt.Errorf(
+					"authoritative conflict: %s key %q is claimed by %s and %s",
+					projection.Table, projection.Key(), owner.UID, projection.UID,
+				)
+			}
+			expectedByKey[key] = projection
+			ownerKey := projectionOwnerKey(resource.Kind, projection.Table, projection.UID)
+			expectedByOwner[ownerKey] = append(expectedByOwner[ownerKey], projection)
+		}
+	}
+
+	actualByKey := make(map[string]ProjectionRecord, len(snapshot.Projections))
+	for _, projection := range snapshot.Projections {
+		key := projectionMapKey(projection)
+		if _, exists := actualByKey[key]; exists {
+			return RepairPlan{}, fmt.Errorf("snapshot contains duplicate physical projection key %s/%s", projection.Table, projection.Key())
+		}
+		actualByKey[key] = projection
+	}
+
+	plan := RepairPlan{}
+	for key, expected := range expectedByKey {
+		resource := resources[resourceKey(projectionKind(expected.Table), expected.UID)]
+		actual, exists := actualByKey[key]
+		switch {
+		case !exists:
+			plan.Findings = append(plan.Findings, finding(FindingMissing, resource.Kind, expected.UID, expected, ProjectionRecord{}, true, "projection row is absent"))
+			plan.Actions = append(plan.Actions, insertAction(resource, expected))
+		case actual.UID == expected.UID && !actual.Equal(expected):
+			plan.Findings = append(plan.Findings, finding(FindingStale, resource.Kind, expected.UID, expected, actual, true, "projection values do not match the authoritative row"))
+			plan.Actions = append(plan.Actions, updateAction(resource, actual, expected))
+		case actual.UID != expected.UID:
+			competingKind := projectionKind(actual.Table)
+			competing, competingExists := resources[resourceKey(competingKind, actual.UID)]
+			competingClaimsKey := false
+			if competingExists {
+				for _, candidate := range expectedByOwner[projectionOwnerKey(competing.Kind, actual.Table, actual.UID)] {
+					if projectionMapKey(candidate) == key {
+						competingClaimsKey = true
+						break
+					}
+				}
+			}
+			repairable := !competingClaimsKey
+			reason := "projection key points to a different resource"
+			if competingClaimsKey {
+				reason = "a valid competing authoritative resource claims this unique key"
+			}
+			plan.Findings = append(plan.Findings, finding(FindingStale, resource.Kind, expected.UID, expected, actual, repairable, reason))
+			if repairable {
+				if !competingExists {
+					competing = AuthoritativeResource{Kind: competingKind, UID: actual.UID, Namespace: actual.Namespace}
+				}
+				plan.Actions = append(plan.Actions, deleteAction(competing, competingExists, actual))
+				plan.Actions = append(plan.Actions, insertAction(resource, expected))
+			}
+		}
+	}
+
+	for key, actual := range actualByKey {
+		expectedAtKey, expectedKeyExists := expectedByKey[key]
+		if expectedKeyExists {
+			if expectedAtKey.UID == actual.UID {
+				continue
+			}
+			continue
+		}
+		kind := projectionKind(actual.Table)
+		resource, exists := resources[resourceKey(kind, actual.UID)]
+		if !exists {
+			plan.Findings = append(plan.Findings, finding(FindingDangling, kind, actual.UID, ProjectionRecord{}, actual, true, "projection owner has no authoritative row"))
+			plan.Actions = append(plan.Actions, deleteAction(AuthoritativeResource{Kind: kind, UID: actual.UID}, false, actual))
+			continue
+		}
+		owned := expectedByOwner[projectionOwnerKey(kind, actual.Table, actual.UID)]
+		findingType := FindingStale
+		reason := "projection key does not match the authoritative row"
+		for _, expected := range owned {
+			if candidate, ok := actualByKey[projectionMapKey(expected)]; ok && candidate.Equal(expected) {
+				findingType = FindingDuplicate
+				reason = "a valid projection exists at the authoritative key"
+				break
+			}
+		}
+		plan.Findings = append(plan.Findings, finding(findingType, kind, actual.UID, firstProjection(owned), actual, true, reason))
+		plan.Actions = append(plan.Actions, deleteAction(resource, true, actual))
+	}
+
+	sort.Slice(plan.Findings, func(i, j int) bool {
+		left, right := plan.Findings[i], plan.Findings[j]
+		return strings.Join([]string{left.Table, left.Key, string(left.Type), left.UID}, "\x00") <
+			strings.Join([]string{right.Table, right.Key, string(right.Type), right.UID}, "\x00")
+	})
+	sort.SliceStable(plan.Actions, func(i, j int) bool {
+		left, right := plan.Actions[i], plan.Actions[j]
+		leftOrder, rightOrder := actionOrder(left.Type), actionOrder(right.Type)
+		if leftOrder != rightOrder {
+			return leftOrder < rightOrder
+		}
+		return strings.Join([]string{actionTable(left), actionKey(left), left.UID}, "\x00") <
+			strings.Join([]string{actionTable(right), actionKey(right), right.UID}, "\x00")
+	})
+	return plan, nil
+}
+
+func ValidateRepairPlan(plan RepairPlan) error {
+	for i, finding := range plan.Findings {
+		if !finding.Repairable {
+			return fmt.Errorf("finding %d for %s/%s is not automatically repairable: %s", i, finding.Table, finding.Key, finding.Reason)
+		}
+	}
+	for i, action := range plan.Actions {
+		if action.Type != RepairInsert && action.Type != RepairUpdate && action.Type != RepairDelete {
+			return fmt.Errorf("action %d has invalid type %q", i, action.Type)
+		}
+		if action.Kind == "" || action.UID == "" {
+			return fmt.Errorf("action %d requires kind and uid", i)
+		}
+		if _, err := gocql.ParseUUID(action.UID); err != nil {
+			return fmt.Errorf("action %d has invalid uid %q", i, action.UID)
+		}
+		if action.RequireAbsentResource && action.ExpectedResourceVersion != "" {
+			return fmt.Errorf("action %d cannot require both an absent resource and a resource version", i)
+		}
+		if !action.RequireAbsentResource && action.ExpectedResourceVersion == "" {
+			return fmt.Errorf("action %d requires an expected resource version", i)
+		}
+		switch action.Type {
+		case RepairInsert:
+			if action.After == nil || action.Before != nil {
+				return fmt.Errorf("action %d insert requires only an after projection", i)
+			}
+			if action.RequireAbsentResource {
+				return fmt.Errorf("action %d insert requires an authoritative resource", i)
+			}
+		case RepairUpdate:
+			if action.Before == nil || action.After == nil {
+				return fmt.Errorf("action %d update requires before and after projections", i)
+			}
+			if action.Before.Table != action.After.Table {
+				return fmt.Errorf("action %d update cannot change projection tables", i)
+			}
+		case RepairDelete:
+			if action.Before == nil || action.After != nil {
+				return fmt.Errorf("action %d delete requires only a before projection", i)
+			}
+		}
+		projection := action.Before
+		if projection == nil {
+			projection = action.After
+		}
+		if projection == nil || !knownProjectionTable(projection.Table) {
+			return fmt.Errorf("action %d has an invalid projection table", i)
+		}
+		if projection.UID != action.UID {
+			return fmt.Errorf("action %d uid does not match its projection owner", i)
+		}
+		if projectionKind(projection.Table) != action.Kind {
+			return fmt.Errorf("action %d kind does not match projection table %s", i, projection.Table)
+		}
+	}
+	return nil
+}
+
+func validateSnapshot(snapshot ProjectionSnapshot) error {
+	seenResources := make(map[string]struct{}, len(snapshot.Authoritative))
+	for i, resource := range snapshot.Authoritative {
+		if resource.Kind == "" || resource.UID == "" || resource.Name == "" || resource.ResourceVersion == "" || resource.CreationTimestamp.IsZero() {
+			return fmt.Errorf("authoritative resource %d is missing kind, uid, name, version, or creation timestamp", i)
+		}
+		if _, err := gocql.ParseUUID(resource.UID); err != nil {
+			return fmt.Errorf("authoritative resource %s has invalid uid %q", resource.Kind, resource.UID)
+		}
+		if resource.Kind != "Namespace" && resource.Namespace == "" {
+			return fmt.Errorf("authoritative resource %s/%s requires namespace", resource.Kind, resource.UID)
+		}
+		key := resourceKey(resource.Kind, resource.UID)
+		if _, exists := seenResources[key]; exists {
+			return fmt.Errorf("duplicate authoritative resource %s", key)
+		}
+		seenResources[key] = struct{}{}
+	}
+	for i, projection := range snapshot.Projections {
+		if projection.Table == "" || projection.UID == "" || !knownProjectionTable(projection.Table) {
+			return fmt.Errorf("projection %d has invalid table or uid", i)
+		}
+		if _, err := gocql.ParseUUID(projection.UID); err != nil {
+			return fmt.Errorf("projection %d has invalid uid %q", i, projection.UID)
+		}
+	}
+	return nil
+}
+
+func expectedProjections(resource AuthoritativeResource) []ProjectionRecord {
+	base := ProjectionRecord{
+		UID: resource.UID, Namespace: resource.Namespace, Name: resource.Name,
+		CreationTimestamp: resource.CreationTimestamp, Bucket: resource.CreationTimestamp.UTC().Format("2006-01"),
+		SKU: resource.SKU, ProductRefName: resource.ProductRefName,
+	}
+	switch resource.Kind {
+	case "Namespace":
+		name, bucket := base, base
+		name.Table = "namespaces_by_name"
+		bucket.Table = "namespaces_by_bucket"
+		return []ProjectionRecord{name, bucket}
+	case "Repository":
+		namespace, global, forward, reverse := base, base, base, base
+		namespace.Table = "repositories_by_namespace"
+		global.Table = "repositories_by_bucket"
+		forward.Table = "namespace_mappings"
+		reverse.Table = "namespace_mappings_by_repository"
+		return []ProjectionRecord{namespace, global, forward, reverse}
+	case "Product":
+		return catalogProjections(base, "products_by_name", "products_by_uid")
+	case "CategoryTaxonomy":
+		return catalogProjections(base, "category_taxonomy_by_name", "category_taxonomy_by_uid")
+	case "Collection":
+		return catalogProjections(base, "collection_by_name", "collection_by_uid")
+	case "ProductVariant":
+		result := catalogProjections(base, "product_variant_by_name", "product_variant_by_uid")
+		if resource.SKU != "" {
+			sku := base
+			sku.Table = "product_variant_by_sku"
+			result = append(result, sku)
+		}
+		if resource.ProductRefName != "" {
+			ref := base
+			ref.Table = "product_variant_by_product_ref"
+			result = append(result, ref)
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func catalogProjections(base ProjectionRecord, nameTable, uidTable string) []ProjectionRecord {
+	name, uid := base, base
+	name.Table = nameTable
+	uid.Table = uidTable
+	return []ProjectionRecord{name, uid}
+}
+
+func (p ProjectionRecord) Key() string {
+	ts := p.CreationTimestamp.UTC().Format(time.RFC3339Nano)
+	switch p.Table {
+	case "namespaces_by_name":
+		return p.Name
+	case "namespaces_by_bucket":
+		return strings.Join([]string{p.Bucket, ts, p.UID}, "/")
+	case "repositories_by_namespace":
+		return strings.Join([]string{p.Namespace, p.Bucket, ts, p.UID}, "/")
+	case "repositories_by_bucket":
+		return strings.Join([]string{p.Bucket, ts, p.UID}, "/")
+	case "namespace_mappings":
+		return p.Namespace + "/" + p.Name
+	case "namespace_mappings_by_repository":
+		return p.UID
+	case "products_by_name", "category_taxonomy_by_name", "collection_by_name", "product_variant_by_name":
+		return p.Namespace + "/" + p.Name
+	case "products_by_uid", "category_taxonomy_by_uid", "collection_by_uid", "product_variant_by_uid":
+		return p.UID
+	case "product_variant_by_sku":
+		return p.Namespace + "/" + p.SKU
+	case "product_variant_by_product_ref":
+		return strings.Join([]string{p.Namespace, p.ProductRefName, ts, p.UID}, "/")
+	default:
+		return ""
+	}
+}
+
+func (p ProjectionRecord) Equal(other ProjectionRecord) bool {
+	if p.Table != other.Table || p.UID != other.UID {
+		return false
+	}
+	switch p.Table {
+	case "namespaces_by_name":
+		return p.Name == other.Name
+	case "namespaces_by_bucket":
+		return p.Bucket == other.Bucket && p.CreationTimestamp.Equal(other.CreationTimestamp)
+	case "repositories_by_namespace":
+		return p.Namespace == other.Namespace && p.Bucket == other.Bucket && p.CreationTimestamp.Equal(other.CreationTimestamp)
+	case "repositories_by_bucket":
+		return p.Bucket == other.Bucket && p.CreationTimestamp.Equal(other.CreationTimestamp)
+	case "namespace_mappings", "namespace_mappings_by_repository":
+		return p.Namespace == other.Namespace && p.Name == other.Name
+	case "products_by_name", "category_taxonomy_by_name", "collection_by_name", "product_variant_by_name":
+		return p.Namespace == other.Namespace && p.Name == other.Name && p.CreationTimestamp.Equal(other.CreationTimestamp)
+	case "products_by_uid", "category_taxonomy_by_uid", "collection_by_uid", "product_variant_by_uid":
+		return p.Namespace == other.Namespace && p.CreationTimestamp.Equal(other.CreationTimestamp)
+	case "product_variant_by_sku":
+		return p.Namespace == other.Namespace && p.SKU == other.SKU && p.CreationTimestamp.Equal(other.CreationTimestamp)
+	case "product_variant_by_product_ref":
+		return p.Namespace == other.Namespace && p.ProductRefName == other.ProductRefName && p.CreationTimestamp.Equal(other.CreationTimestamp)
+	default:
+		return false
+	}
+}
+
+func projectionKind(table string) string {
+	switch {
+	case strings.HasPrefix(table, "namespaces_"):
+		return "Namespace"
+	case strings.HasPrefix(table, "repositories_"), strings.HasPrefix(table, "namespace_mappings"):
+		return "Repository"
+	case strings.HasPrefix(table, "products_"):
+		return "Product"
+	case strings.HasPrefix(table, "category_taxonomy_"):
+		return "CategoryTaxonomy"
+	case strings.HasPrefix(table, "collection_"):
+		return "Collection"
+	case strings.HasPrefix(table, "product_variant_"):
+		return "ProductVariant"
+	default:
+		return ""
+	}
+}
+
+func knownProjectionTable(table string) bool {
+	switch table {
+	case "namespaces_by_name",
+		"namespaces_by_bucket",
+		"repositories_by_namespace",
+		"repositories_by_bucket",
+		"namespace_mappings",
+		"namespace_mappings_by_repository",
+		"products_by_name",
+		"products_by_uid",
+		"category_taxonomy_by_name",
+		"category_taxonomy_by_uid",
+		"collection_by_name",
+		"collection_by_uid",
+		"product_variant_by_name",
+		"product_variant_by_uid",
+		"product_variant_by_sku",
+		"product_variant_by_product_ref":
+		return true
+	default:
+		return false
+	}
+}
+
+func resourceKey(kind, uid string) string {
+	return kind + "\x00" + uid
+}
+
+func projectionMapKey(projection ProjectionRecord) string {
+	return projection.Table + "\x00" + projection.Key()
+}
+
+func projectionOwnerKey(kind, table, uid string) string {
+	return strings.Join([]string{kind, table, uid}, "\x00")
+}
+
+func finding(kind FindingType, resourceKind, uid string, expected, actual ProjectionRecord, repairable bool, reason string) ProjectionFinding {
+	result := ProjectionFinding{
+		Type: kind, Kind: resourceKind, UID: uid, Repairable: repairable, Reason: reason,
+	}
+	if expected.Table != "" {
+		copy := expected
+		result.Expected = &copy
+		result.Table = expected.Table
+		result.Key = expected.Key()
+	}
+	if actual.Table != "" {
+		copy := actual
+		result.Actual = &copy
+		if result.Table == "" {
+			result.Table = actual.Table
+			result.Key = actual.Key()
+		}
+	}
+	return result
+}
+
+func insertAction(resource AuthoritativeResource, after ProjectionRecord) RepairAction {
+	return RepairAction{
+		Type: RepairInsert, Kind: resource.Kind, UID: resource.UID,
+		ResourceNamespace:       resource.Namespace,
+		ExpectedResourceVersion: resource.ResourceVersion, After: &after,
+	}
+}
+
+func updateAction(resource AuthoritativeResource, before, after ProjectionRecord) RepairAction {
+	return RepairAction{
+		Type: RepairUpdate, Kind: resource.Kind, UID: resource.UID,
+		ResourceNamespace:       resource.Namespace,
+		ExpectedResourceVersion: resource.ResourceVersion, Before: &before, After: &after,
+	}
+}
+
+func deleteAction(resource AuthoritativeResource, exists bool, before ProjectionRecord) RepairAction {
+	action := RepairAction{
+		Type: RepairDelete, Kind: resource.Kind, UID: resource.UID,
+		ResourceNamespace: resource.Namespace, Before: &before,
+	}
+	if exists {
+		action.ExpectedResourceVersion = resource.ResourceVersion
+	} else {
+		action.RequireAbsentResource = true
+	}
+	return action
+}
+
+func firstProjection(projections []ProjectionRecord) ProjectionRecord {
+	if len(projections) == 0 {
+		return ProjectionRecord{}
+	}
+	return projections[0]
+}
+
+func actionOrder(action RepairActionType) int {
+	switch action {
+	case RepairDelete:
+		return 0
+	case RepairUpdate:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func actionTable(action RepairAction) string {
+	if action.After != nil {
+		return action.After.Table
+	}
+	if action.Before != nil {
+		return action.Before.Table
+	}
+	return ""
+}
+
+func actionKey(action RepairAction) string {
+	if action.After != nil {
+		return action.After.Key()
+	}
+	if action.Before != nil {
+		return action.Before.Key()
+	}
+	return ""
+}
+
+type scyllaProjectionRepairStore struct {
+	session gocqlx.Session
+	raw     *gocql.Session
+}
+
+func (s *scyllaProjectionRepairStore) Close() {
+	s.raw.Close()
+}
+
+type auditRow struct {
+	UID               gocql.UUID `db:"uid"`
+	RepositoryID      gocql.UUID `db:"repository_id"`
+	Namespace         string     `db:"namespace"`
+	Name              string     `db:"name"`
+	ResourceVersion   string     `db:"resource_version"`
+	CreationTimestamp time.Time  `db:"creation_timestamp"`
+	Bucket            string     `db:"bucket"`
+	SKU               string     `db:"sku"`
+	ProductRefName    string     `db:"product_ref_name"`
+}
+
+func (s *scyllaProjectionRepairStore) Snapshot(ctx context.Context) (ProjectionSnapshot, error) {
+	var snapshot ProjectionSnapshot
+	authoritative := []struct {
+		kind      string
+		table     string
+		extraCols string
+	}{
+		{"Namespace", "namespaces_by_uid", ""},
+		{"Repository", "repositories_by_uid", "namespace,"},
+		{"Product", "products_by_namespace", "namespace,"},
+		{"CategoryTaxonomy", "category_taxonomy", "namespace,"},
+		{"Collection", "collection", "namespace,"},
+		{"ProductVariant", "product_variant_by_namespace", "namespace,sku,product_ref_name,"},
+	}
+	for _, source := range authoritative {
+		var rows []auditRow
+		statement := fmt.Sprintf(
+			"SELECT %s uid,name,resource_version,creation_timestamp FROM %s",
+			source.extraCols, source.table,
+		)
+		if err := s.session.Query(statement, nil).WithContext(ctx).SelectRelease(&rows); err != nil {
+			return ProjectionSnapshot{}, fmt.Errorf("audit authoritative table %s: %w", source.table, err)
+		}
+		for _, row := range rows {
+			snapshot.Authoritative = append(snapshot.Authoritative, AuthoritativeResource{
+				Kind: source.kind, UID: row.UID.String(), Namespace: row.Namespace, Name: row.Name,
+				ResourceVersion: row.ResourceVersion, CreationTimestamp: row.CreationTimestamp,
+				SKU: row.SKU, ProductRefName: row.ProductRefName,
+			})
+		}
+	}
+
+	projections := []struct {
+		table   string
+		columns string
+		uid     func(auditRow) gocql.UUID
+	}{
+		{"namespaces_by_name", "name,uid", rowUID},
+		{"namespaces_by_bucket", "bucket,creation_timestamp,uid", rowUID},
+		{"repositories_by_namespace", "namespace,bucket,creation_timestamp,uid", rowUID},
+		{"repositories_by_bucket", "bucket,creation_timestamp,uid", rowUID},
+		{"namespace_mappings", "namespace,name,repository_id", rowRepositoryID},
+		{"namespace_mappings_by_repository", "repository_id,namespace,name", rowRepositoryID},
+		{"products_by_name", "namespace,name,uid,creation_timestamp", rowUID},
+		{"products_by_uid", "uid,namespace,creation_timestamp", rowUID},
+		{"category_taxonomy_by_name", "namespace,name,uid,creation_timestamp", rowUID},
+		{"category_taxonomy_by_uid", "uid,namespace,creation_timestamp", rowUID},
+		{"collection_by_name", "namespace,name,uid,creation_timestamp", rowUID},
+		{"collection_by_uid", "uid,namespace,creation_timestamp", rowUID},
+		{"product_variant_by_name", "namespace,name,uid,creation_timestamp", rowUID},
+		{"product_variant_by_uid", "uid,namespace,creation_timestamp", rowUID},
+		{"product_variant_by_sku", "namespace,sku,uid,creation_timestamp", rowUID},
+		{"product_variant_by_product_ref", "namespace,product_ref_name,creation_timestamp,uid", rowUID},
+	}
+	for _, source := range projections {
+		var rows []auditRow
+		if err := s.session.Query("SELECT "+source.columns+" FROM "+source.table, nil).
+			WithContext(ctx).SelectRelease(&rows); err != nil {
+			return ProjectionSnapshot{}, fmt.Errorf("audit projection table %s: %w", source.table, err)
+		}
+		for _, row := range rows {
+			uid := source.uid(row)
+			snapshot.Projections = append(snapshot.Projections, ProjectionRecord{
+				Table: source.table, UID: uid.String(), Namespace: row.Namespace, Name: row.Name,
+				Bucket: row.Bucket, CreationTimestamp: row.CreationTimestamp,
+				SKU: row.SKU, ProductRefName: row.ProductRefName,
+			})
+		}
+	}
+	return snapshot, nil
+}
+
+func rowUID(row auditRow) gocql.UUID {
+	return row.UID
+}
+
+func rowRepositoryID(row auditRow) gocql.UUID {
+	return row.RepositoryID
+}
+
+func (s *scyllaProjectionRepairStore) LookupResource(ctx context.Context, action RepairAction) (*AuthoritativeResource, error) {
+	var rows []auditRow
+	var statement string
+	var args []any
+	switch action.Kind {
+	case "Namespace":
+		statement, args = "SELECT uid,name,resource_version,creation_timestamp FROM namespaces_by_uid WHERE uid=?", []any{mustRepairUUID(action.UID)}
+	case "Repository":
+		statement, args = "SELECT uid,namespace,name,resource_version,creation_timestamp FROM repositories_by_uid WHERE uid=?", []any{mustRepairUUID(action.UID)}
+	default:
+		table := authoritativeTable(action.Kind)
+		namespace := actionNamespace(action)
+		if table == "" || namespace == "" {
+			return nil, fmt.Errorf("cannot locate authoritative %s/%s", action.Kind, action.UID)
+		}
+		extras := ""
+		if action.Kind == "ProductVariant" {
+			extras = ",sku,product_ref_name"
+		}
+		statement = "SELECT uid,namespace,name,resource_version,creation_timestamp" + extras + " FROM " + table + " WHERE namespace=?"
+		args = []any{namespace}
+	}
+	if err := s.session.Query(statement, nil).WithContext(ctx).Bind(args...).SelectRelease(&rows); err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		if row.UID.String() == action.UID {
+			return &AuthoritativeResource{
+				Kind: action.Kind, UID: action.UID, Namespace: row.Namespace, Name: row.Name,
+				ResourceVersion: row.ResourceVersion, CreationTimestamp: row.CreationTimestamp,
+				SKU: row.SKU, ProductRefName: row.ProductRefName,
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+func authoritativeTable(kind string) string {
+	switch kind {
+	case "Product":
+		return "products_by_namespace"
+	case "CategoryTaxonomy":
+		return "category_taxonomy"
+	case "Collection":
+		return "collection"
+	case "ProductVariant":
+		return "product_variant_by_namespace"
+	default:
+		return ""
+	}
+}
+
+func actionNamespace(action RepairAction) string {
+	if action.ResourceNamespace != "" {
+		return action.ResourceNamespace
+	}
+	if action.After != nil && action.After.Namespace != "" {
+		return action.After.Namespace
+	}
+	if action.Before != nil {
+		return action.Before.Namespace
+	}
+	return ""
+}
+
+func mustRepairUUID(value string) gocql.UUID {
+	uid, _ := gocql.ParseUUID(value)
+	return uid
+}
+
+func (s *scyllaProjectionRepairStore) ApplyAction(ctx context.Context, action RepairAction) (bool, error) {
+	switch action.Type {
+	case RepairInsert:
+		return s.insertProjection(ctx, *action.After)
+	case RepairUpdate:
+		return s.updateProjection(ctx, *action.Before, *action.After)
+	case RepairDelete:
+		return s.deleteProjection(ctx, *action.Before)
+	default:
+		return false, fmt.Errorf("unsupported repair action %q", action.Type)
+	}
+}
+
+func (s *scyllaProjectionRepairStore) insertProjection(ctx context.Context, row ProjectionRecord) (bool, error) {
+	uid := mustRepairUUID(row.UID)
+	var statement string
+	var args []any
+	switch row.Table {
+	case "namespaces_by_name":
+		statement, args = "INSERT INTO namespaces_by_name (name,uid) VALUES (?,?) IF NOT EXISTS", []any{row.Name, uid}
+	case "namespaces_by_bucket":
+		statement, args = "INSERT INTO namespaces_by_bucket (bucket,creation_timestamp,uid) VALUES (?,?,?) IF NOT EXISTS", []any{row.Bucket, row.CreationTimestamp, uid}
+	case "repositories_by_namespace":
+		statement, args = "INSERT INTO repositories_by_namespace (namespace,bucket,creation_timestamp,uid) VALUES (?,?,?,?) IF NOT EXISTS", []any{row.Namespace, row.Bucket, row.CreationTimestamp, uid}
+	case "repositories_by_bucket":
+		statement, args = "INSERT INTO repositories_by_bucket (bucket,creation_timestamp,uid) VALUES (?,?,?) IF NOT EXISTS", []any{row.Bucket, row.CreationTimestamp, uid}
+	case "namespace_mappings":
+		statement, args = "INSERT INTO namespace_mappings (namespace,name,repository_id) VALUES (?,?,?) IF NOT EXISTS", []any{row.Namespace, row.Name, uid}
+	case "namespace_mappings_by_repository":
+		statement, args = "INSERT INTO namespace_mappings_by_repository (repository_id,namespace,name) VALUES (?,?,?) IF NOT EXISTS", []any{uid, row.Namespace, row.Name}
+	case "products_by_name", "category_taxonomy_by_name", "collection_by_name", "product_variant_by_name":
+		statement, args = fmt.Sprintf("INSERT INTO %s (namespace,name,uid,creation_timestamp) VALUES (?,?,?,?) IF NOT EXISTS", row.Table), []any{row.Namespace, row.Name, uid, row.CreationTimestamp}
+	case "products_by_uid", "category_taxonomy_by_uid", "collection_by_uid", "product_variant_by_uid":
+		statement, args = fmt.Sprintf("INSERT INTO %s (uid,namespace,creation_timestamp) VALUES (?,?,?) IF NOT EXISTS", row.Table), []any{uid, row.Namespace, row.CreationTimestamp}
+	case "product_variant_by_sku":
+		statement, args = "INSERT INTO product_variant_by_sku (namespace,sku,uid,creation_timestamp) VALUES (?,?,?,?) IF NOT EXISTS", []any{row.Namespace, row.SKU, uid, row.CreationTimestamp}
+	case "product_variant_by_product_ref":
+		statement, args = "INSERT INTO product_variant_by_product_ref (namespace,product_ref_name,creation_timestamp,uid) VALUES (?,?,?,?) IF NOT EXISTS", []any{row.Namespace, row.ProductRefName, row.CreationTimestamp, uid}
+	default:
+		return false, fmt.Errorf("unsupported projection table %q", row.Table)
+	}
+	return s.session.Query(statement, nil).WithContext(ctx).Bind(args...).ExecCASRelease()
+}
+
+func (s *scyllaProjectionRepairStore) updateProjection(ctx context.Context, before, after ProjectionRecord) (bool, error) {
+	uid := mustRepairUUID(after.UID)
+	var statement string
+	var args []any
+	switch after.Table {
+	case "namespaces_by_name":
+		statement, args = "UPDATE namespaces_by_name SET uid=? WHERE name=? IF uid=?", []any{uid, after.Name, mustRepairUUID(before.UID)}
+	case "namespace_mappings":
+		statement, args = "UPDATE namespace_mappings SET repository_id=? WHERE namespace=? AND name=? IF repository_id=?", []any{uid, after.Namespace, after.Name, mustRepairUUID(before.UID)}
+	case "namespace_mappings_by_repository":
+		statement, args = "UPDATE namespace_mappings_by_repository SET namespace=?,name=? WHERE repository_id=? IF namespace=? AND name=?", []any{after.Namespace, after.Name, uid, before.Namespace, before.Name}
+	case "products_by_name", "category_taxonomy_by_name", "collection_by_name", "product_variant_by_name":
+		statement = fmt.Sprintf("UPDATE %s SET uid=?,creation_timestamp=? WHERE namespace=? AND name=? IF uid=? AND creation_timestamp=?", after.Table)
+		args = []any{uid, after.CreationTimestamp, after.Namespace, after.Name, mustRepairUUID(before.UID), before.CreationTimestamp}
+	case "products_by_uid", "category_taxonomy_by_uid", "collection_by_uid", "product_variant_by_uid":
+		statement = fmt.Sprintf("UPDATE %s SET namespace=?,creation_timestamp=? WHERE uid=? IF namespace=? AND creation_timestamp=?", after.Table)
+		args = []any{after.Namespace, after.CreationTimestamp, uid, before.Namespace, before.CreationTimestamp}
+	case "product_variant_by_sku":
+		statement = "UPDATE product_variant_by_sku SET uid=?,creation_timestamp=? WHERE namespace=? AND sku=? IF uid=? AND creation_timestamp=?"
+		args = []any{uid, after.CreationTimestamp, after.Namespace, after.SKU, mustRepairUUID(before.UID), before.CreationTimestamp}
+	default:
+		return false, fmt.Errorf("projection %s cannot be updated in place", after.Table)
+	}
+	return s.session.Query(statement, nil).WithContext(ctx).Bind(args...).ExecCASRelease()
+}
+
+func (s *scyllaProjectionRepairStore) deleteProjection(ctx context.Context, row ProjectionRecord) (bool, error) {
+	uid := mustRepairUUID(row.UID)
+	var statement string
+	var args []any
+	switch row.Table {
+	case "namespaces_by_name":
+		statement, args = "DELETE FROM namespaces_by_name WHERE name=? IF uid=?", []any{row.Name, uid}
+	case "namespaces_by_bucket":
+		statement, args = "DELETE FROM namespaces_by_bucket WHERE bucket=? AND creation_timestamp=? AND uid=? IF EXISTS", []any{row.Bucket, row.CreationTimestamp, uid}
+	case "repositories_by_namespace":
+		statement, args = "DELETE FROM repositories_by_namespace WHERE namespace=? AND bucket=? AND creation_timestamp=? AND uid=? IF EXISTS", []any{row.Namespace, row.Bucket, row.CreationTimestamp, uid}
+	case "repositories_by_bucket":
+		statement, args = "DELETE FROM repositories_by_bucket WHERE bucket=? AND creation_timestamp=? AND uid=? IF EXISTS", []any{row.Bucket, row.CreationTimestamp, uid}
+	case "namespace_mappings":
+		statement, args = "DELETE FROM namespace_mappings WHERE namespace=? AND name=? IF repository_id=?", []any{row.Namespace, row.Name, uid}
+	case "namespace_mappings_by_repository":
+		statement, args = "DELETE FROM namespace_mappings_by_repository WHERE repository_id=? IF namespace=? AND name=?", []any{uid, row.Namespace, row.Name}
+	case "products_by_name", "category_taxonomy_by_name", "collection_by_name", "product_variant_by_name":
+		statement, args = fmt.Sprintf("DELETE FROM %s WHERE namespace=? AND name=? IF uid=?", row.Table), []any{row.Namespace, row.Name, uid}
+	case "products_by_uid", "category_taxonomy_by_uid", "collection_by_uid", "product_variant_by_uid":
+		statement, args = fmt.Sprintf("DELETE FROM %s WHERE uid=? IF namespace=? AND creation_timestamp=?", row.Table), []any{uid, row.Namespace, row.CreationTimestamp}
+	case "product_variant_by_sku":
+		statement, args = "DELETE FROM product_variant_by_sku WHERE namespace=? AND sku=? IF uid=?", []any{row.Namespace, row.SKU, uid}
+	case "product_variant_by_product_ref":
+		statement, args = "DELETE FROM product_variant_by_product_ref WHERE namespace=? AND product_ref_name=? AND creation_timestamp=? AND uid=? IF EXISTS", []any{row.Namespace, row.ProductRefName, row.CreationTimestamp, uid}
+	default:
+		return false, fmt.Errorf("unsupported projection table %q", row.Table)
+	}
+	return s.session.Query(statement, nil).WithContext(ctx).Bind(args...).ExecCASRelease()
+}

--- a/gitstore-api/internal/datastore/scylla/repair.go
+++ b/gitstore-api/internal/datastore/scylla/repair.go
@@ -273,10 +273,12 @@ func BuildRepairPlan(snapshot ProjectionSnapshot) (RepairPlan, error) {
 					}
 				}
 			}
-			repairable := !competingClaimsKey
+			repairable := !competingClaimsKey && projectionDeleteRepairable(actual.Table)
 			reason := "projection key points to a different resource"
 			if competingClaimsKey {
 				reason = "a valid competing authoritative resource claims this unique key"
+			} else if !projectionDeleteRepairable(actual.Table) {
+				reason = "projection participates in write reservation and cannot be deleted safely online"
 			}
 			plan.Findings = append(plan.Findings, finding(FindingStale, resource.Kind, expected.UID, expected, actual, repairable, reason))
 			if repairable {
@@ -300,8 +302,15 @@ func BuildRepairPlan(snapshot ProjectionSnapshot) (RepairPlan, error) {
 		kind := projectionKind(actual.Table)
 		resource, exists := resources[resourceKey(kind, actual.UID)]
 		if !exists {
-			plan.Findings = append(plan.Findings, finding(FindingDangling, kind, actual.UID, ProjectionRecord{}, actual, true, "projection owner has no authoritative row"))
-			plan.Actions = append(plan.Actions, deleteAction(AuthoritativeResource{Kind: kind, UID: actual.UID}, false, actual))
+			repairable := projectionDeleteRepairable(actual.Table)
+			reason := "projection owner has no authoritative row"
+			if !repairable {
+				reason = "projection may be an in-flight write reservation and cannot be deleted safely online"
+			}
+			plan.Findings = append(plan.Findings, finding(FindingDangling, kind, actual.UID, ProjectionRecord{}, actual, repairable, reason))
+			if repairable {
+				plan.Actions = append(plan.Actions, deleteAction(AuthoritativeResource{Kind: kind, UID: actual.UID}, false, actual))
+			}
 			continue
 		}
 		owned := expectedByOwner[projectionOwnerKey(kind, actual.Table, actual.UID)]
@@ -314,8 +323,14 @@ func BuildRepairPlan(snapshot ProjectionSnapshot) (RepairPlan, error) {
 				break
 			}
 		}
-		plan.Findings = append(plan.Findings, finding(findingType, kind, actual.UID, firstProjection(owned), actual, true, reason))
-		plan.Actions = append(plan.Actions, deleteAction(resource, true, actual))
+		repairable := projectionDeleteRepairable(actual.Table)
+		if !repairable {
+			reason = "projection participates in write reservation and cannot be deleted safely online"
+		}
+		plan.Findings = append(plan.Findings, finding(findingType, kind, actual.UID, firstProjection(owned), actual, repairable, reason))
+		if repairable {
+			plan.Actions = append(plan.Actions, deleteAction(resource, true, actual))
+		}
 	}
 
 	sort.Slice(plan.Findings, func(i, j int) bool {
@@ -672,6 +687,26 @@ func actionKey(action RepairAction) string {
 	return ""
 }
 
+func projectionDeleteRepairable(table string) bool {
+	switch table {
+	case "namespaces_by_name",
+		"namespace_mappings",
+		"namespace_mappings_by_repository",
+		"products_by_name",
+		"products_by_uid",
+		"category_taxonomy_by_name",
+		"category_taxonomy_by_uid",
+		"collection_by_name",
+		"collection_by_uid",
+		"product_variant_by_name",
+		"product_variant_by_uid",
+		"product_variant_by_sku":
+		return false
+	default:
+		return true
+	}
+}
+
 type scyllaProjectionRepairStore struct {
 	session gocqlx.Session
 	raw     *gocql.Session
@@ -708,12 +743,12 @@ func (s *scyllaProjectionRepairStore) Snapshot(ctx context.Context) (ProjectionS
 		{"ProductVariant", "product_variant_by_namespace", "namespace,sku,product_ref_name,"},
 	}
 	for _, source := range authoritative {
-		var rows []auditRow
 		statement := fmt.Sprintf(
 			"SELECT %s uid,name,resource_version,creation_timestamp FROM %s",
 			source.extraCols, source.table,
 		)
-		if err := s.session.Query(statement, nil).WithContext(ctx).SelectRelease(&rows); err != nil {
+		rows, err := s.scanAuditRows(ctx, statement)
+		if err != nil {
 			return ProjectionSnapshot{}, fmt.Errorf("audit authoritative table %s: %w", source.table, err)
 		}
 		for _, row := range rows {
@@ -748,9 +783,8 @@ func (s *scyllaProjectionRepairStore) Snapshot(ctx context.Context) (ProjectionS
 		{"product_variant_by_product_ref", "namespace,product_ref_name,creation_timestamp,uid", rowUID},
 	}
 	for _, source := range projections {
-		var rows []auditRow
-		if err := s.session.Query("SELECT "+source.columns+" FROM "+source.table, nil).
-			WithContext(ctx).SelectRelease(&rows); err != nil {
+		rows, err := s.scanAuditRows(ctx, "SELECT "+source.columns+" FROM "+source.table)
+		if err != nil {
 			return ProjectionSnapshot{}, fmt.Errorf("audit projection table %s: %w", source.table, err)
 		}
 		for _, row := range rows {
@@ -763,6 +797,20 @@ func (s *scyllaProjectionRepairStore) Snapshot(ctx context.Context) (ProjectionS
 		}
 	}
 	return snapshot, nil
+}
+
+func (s *scyllaProjectionRepairStore) scanAuditRows(ctx context.Context, statement string) ([]auditRow, error) {
+	iter := s.session.Query(statement, nil).WithContext(ctx).PageSize(1000).Iter()
+	rows := make([]auditRow, 0, 1000)
+	var row auditRow
+	for iter.StructScan(&row) {
+		rows = append(rows, row)
+		row = auditRow{}
+	}
+	if err := iter.Close(); err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func rowUID(row auditRow) gocql.UUID {
@@ -850,6 +898,13 @@ func (s *scyllaProjectionRepairStore) ApplyAction(ctx context.Context, action Re
 	case RepairUpdate:
 		return s.updateProjection(ctx, *action.Before, *action.After)
 	case RepairDelete:
+		resource, err := s.LookupResource(ctx, action)
+		if err != nil {
+			return false, err
+		}
+		if resource != nil {
+			return false, nil
+		}
 		return s.deleteProjection(ctx, *action.Before)
 	default:
 		return false, fmt.Errorf("unsupported repair action %q", action.Type)

--- a/gitstore-api/internal/datastore/scylla/repair_test.go
+++ b/gitstore-api/internal/datastore/scylla/repair_test.go
@@ -133,6 +133,33 @@ func TestBuildRepairPlanDoesNotOverwriteValidCompetingOwner(t *testing.T) {
 	}
 }
 
+func TestBuildRepairPlanDoesNotDeleteWriteReservation(t *testing.T) {
+	t.Parallel()
+	reservation := ProjectionRecord{
+		Table:             "products_by_name",
+		UID:               "99999999-9999-9999-9999-999999999999",
+		Namespace:         "shop",
+		Name:              "pending-product",
+		CreationTimestamp: time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC),
+	}
+
+	plan, err := BuildRepairPlan(ProjectionSnapshot{
+		Projections: []ProjectionRecord{reservation},
+	})
+	if err != nil {
+		t.Fatalf("BuildRepairPlan() error = %v", err)
+	}
+	if len(plan.Findings) != 1 {
+		t.Fatalf("findings = %#v, want one", plan.Findings)
+	}
+	if plan.Findings[0].Repairable {
+		t.Fatalf("reservation finding unexpectedly repairable: %#v", plan.Findings[0])
+	}
+	if len(plan.Actions) != 0 {
+		t.Fatalf("actions = %#v, want none", plan.Actions)
+	}
+}
+
 func TestValidateRepairPlanRejectsUnsafeAction(t *testing.T) {
 	t.Parallel()
 	err := ValidateRepairPlan(RepairPlan{Actions: []RepairAction{{

--- a/gitstore-api/internal/datastore/scylla/repair_test.go
+++ b/gitstore-api/internal/datastore/scylla/repair_test.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package scylla
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildRepairPlanDeterministicFindings(t *testing.T) {
+	t.Parallel()
+	created := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	namespace := AuthoritativeResource{
+		Kind: "Namespace", UID: "11111111-1111-1111-1111-111111111111", Name: "current",
+		ResourceVersion: "7", CreationTimestamp: created,
+	}
+	staleNamespace := AuthoritativeResource{
+		Kind: "Namespace", UID: "22222222-2222-2222-2222-222222222222", Name: "stale-current",
+		ResourceVersion: "3", CreationTimestamp: created.Add(time.Minute),
+	}
+	validName := expectedProjections(namespace)[0]
+	duplicateName := validName
+	duplicateName.Name = "old"
+	dangling := validName
+	dangling.Name = "orphan"
+	dangling.UID = "99999999-9999-9999-9999-999999999999"
+	staleName := expectedProjections(staleNamespace)[0]
+	staleName.Name = "stale-old"
+	staleBucket := expectedProjections(staleNamespace)[1]
+
+	snapshot := ProjectionSnapshot{
+		Authoritative: []AuthoritativeResource{namespace, staleNamespace},
+		Projections:   []ProjectionRecord{dangling, duplicateName, staleName, staleBucket, validName},
+	}
+	first, err := BuildRepairPlan(snapshot)
+	if err != nil {
+		t.Fatalf("BuildRepairPlan() error = %v", err)
+	}
+	second, err := BuildRepairPlan(snapshot)
+	if err != nil {
+		t.Fatalf("second BuildRepairPlan() error = %v", err)
+	}
+	if stringifyPlan(first) != stringifyPlan(second) {
+		t.Fatalf("plans are not deterministic:\nfirst:  %s\nsecond: %s", stringifyPlan(first), stringifyPlan(second))
+	}
+
+	gotTypes := make([]FindingType, 0, len(first.Findings))
+	for _, finding := range first.Findings {
+		gotTypes = append(gotTypes, finding.Type)
+	}
+	want := []FindingType{FindingMissing, FindingDuplicate, FindingDangling, FindingStale}
+	for _, findingType := range want {
+		if !containsFindingType(gotTypes, findingType) {
+			t.Fatalf("findings = %v, want %q", gotTypes, findingType)
+		}
+	}
+}
+
+func TestProjectionRepairServiceDryRunDoesNotMutate(t *testing.T) {
+	t.Parallel()
+	store := newFakeRepairStore(missingNamespaceBucketSnapshot())
+	service := &ProjectionRepairService{store: store}
+
+	plan, err := service.Audit(context.Background())
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+	if len(plan.Actions) != 1 || plan.Actions[0].Type != RepairInsert {
+		t.Fatalf("Audit() actions = %#v, want one insert", plan.Actions)
+	}
+	if store.applyCalls != 0 {
+		t.Fatalf("dry-run audit applied %d mutations", store.applyCalls)
+	}
+}
+
+func TestProjectionRepairServiceApplyAndVerify(t *testing.T) {
+	t.Parallel()
+	store := newFakeRepairStore(missingNamespaceBucketSnapshot())
+	service := &ProjectionRepairService{store: store}
+	plan, err := service.Audit(context.Background())
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+
+	result, err := service.Apply(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if result.AppliedActions != 1 {
+		t.Fatalf("AppliedActions = %d, want 1", result.AppliedActions)
+	}
+	if len(result.Verification.Findings) != 0 {
+		t.Fatalf("verification findings = %#v, want none", result.Verification.Findings)
+	}
+}
+
+func TestProjectionRepairServiceProtectsConcurrentWriter(t *testing.T) {
+	t.Parallel()
+	store := newFakeRepairStore(missingNamespaceBucketSnapshot())
+	service := &ProjectionRepairService{store: store}
+	plan, err := service.Audit(context.Background())
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+	store.concurrentVersion = "8"
+
+	_, err = service.Apply(context.Background(), plan)
+	if err == nil || !strings.Contains(err.Error(), "resource version changed") {
+		t.Fatalf("Apply() error = %v, want concurrent resource-version error", err)
+	}
+	if store.applyCalls != 0 {
+		t.Fatalf("concurrent writer protection applied %d mutations", store.applyCalls)
+	}
+}
+
+func TestBuildRepairPlanDoesNotOverwriteValidCompetingOwner(t *testing.T) {
+	t.Parallel()
+	created := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	left := AuthoritativeResource{
+		Kind: "Namespace", UID: "11111111-1111-1111-1111-111111111111", Name: "shared",
+		ResourceVersion: "1", CreationTimestamp: created,
+	}
+	right := AuthoritativeResource{
+		Kind: "Namespace", UID: "22222222-2222-2222-2222-222222222222", Name: "shared",
+		ResourceVersion: "1", CreationTimestamp: created.Add(time.Second),
+	}
+	_, err := BuildRepairPlan(ProjectionSnapshot{Authoritative: []AuthoritativeResource{left, right}})
+	if err == nil || !strings.Contains(err.Error(), "authoritative conflict") {
+		t.Fatalf("BuildRepairPlan() error = %v, want authoritative conflict", err)
+	}
+}
+
+func TestValidateRepairPlanRejectsUnsafeAction(t *testing.T) {
+	t.Parallel()
+	err := ValidateRepairPlan(RepairPlan{Actions: []RepairAction{{
+		Type: RepairDelete, Kind: "Namespace", UID: "11111111-1111-1111-1111-111111111111",
+		Before: &ProjectionRecord{
+			Table: "namespaces_by_name", UID: "11111111-1111-1111-1111-111111111111", Name: "name",
+		},
+	}}})
+	if err == nil || !strings.Contains(err.Error(), "expected resource version") {
+		t.Fatalf("ValidateRepairPlan() error = %v, want version validation error", err)
+	}
+}
+
+func missingNamespaceBucketSnapshot() ProjectionSnapshot {
+	created := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	resource := AuthoritativeResource{
+		Kind: "Namespace", UID: "11111111-1111-1111-1111-111111111111", Name: "demo",
+		ResourceVersion: "7", CreationTimestamp: created,
+	}
+	return ProjectionSnapshot{
+		Authoritative: []AuthoritativeResource{resource},
+		Projections:   []ProjectionRecord{expectedProjections(resource)[0]},
+	}
+}
+
+func containsFindingType(findings []FindingType, want FindingType) bool {
+	for _, finding := range findings {
+		if finding == want {
+			return true
+		}
+	}
+	return false
+}
+
+func stringifyPlan(plan RepairPlan) string {
+	var builder strings.Builder
+	for _, finding := range plan.Findings {
+		builder.WriteString(string(finding.Type))
+		builder.WriteByte(':')
+		builder.WriteString(finding.Table)
+		builder.WriteByte(':')
+		builder.WriteString(finding.Key)
+		builder.WriteByte('\n')
+	}
+	for _, action := range plan.Actions {
+		builder.WriteString(string(action.Type))
+		builder.WriteByte(':')
+		builder.WriteString(actionTable(action))
+		builder.WriteByte(':')
+		builder.WriteString(actionKey(action))
+		builder.WriteByte('\n')
+	}
+	return builder.String()
+}
+
+type fakeRepairStore struct {
+	snapshot          ProjectionSnapshot
+	applyCalls        int
+	concurrentVersion string
+}
+
+func newFakeRepairStore(snapshot ProjectionSnapshot) *fakeRepairStore {
+	return &fakeRepairStore{snapshot: snapshot}
+}
+
+func (f *fakeRepairStore) Snapshot(context.Context) (ProjectionSnapshot, error) {
+	return f.snapshot, nil
+}
+
+func (f *fakeRepairStore) LookupResource(_ context.Context, action RepairAction) (*AuthoritativeResource, error) {
+	for i := range f.snapshot.Authoritative {
+		resource := f.snapshot.Authoritative[i]
+		if resource.Kind == action.Kind && resource.UID == action.UID {
+			if f.concurrentVersion != "" {
+				resource.ResourceVersion = f.concurrentVersion
+			}
+			return &resource, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeRepairStore) ApplyAction(_ context.Context, action RepairAction) (bool, error) {
+	f.applyCalls++
+	switch action.Type {
+	case RepairInsert:
+		f.snapshot.Projections = append(f.snapshot.Projections, *action.After)
+	case RepairUpdate:
+		for i := range f.snapshot.Projections {
+			if f.snapshot.Projections[i].Equal(*action.Before) {
+				f.snapshot.Projections[i] = *action.After
+				return true, nil
+			}
+		}
+		return false, nil
+	case RepairDelete:
+		for i := range f.snapshot.Projections {
+			if f.snapshot.Projections[i].Equal(*action.Before) {
+				f.snapshot.Projections = append(f.snapshot.Projections[:i], f.snapshot.Projections[i+1:]...)
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+func (f *fakeRepairStore) Close() {}

--- a/gitstore-api/internal/datastore/scylla/repository.go
+++ b/gitstore-api/internal/datastore/scylla/repository.go
@@ -196,8 +196,46 @@ func (s *scyllaDatastore) ListRepositories(ctx context.Context, page datastore.P
 
 func (s *scyllaDatastore) listRepositories(ctx context.Context, namespace string, page datastore.PageParams) (*datastore.PageResult[datastore.Repository], error) {
 	limit := page.Limit()
-	rows := make([]repositoryIndexRow, 0, limit+1)
-	for _, bucket := range repositoryBucketsForPage(page, time.Now().UTC()) {
+	items, err := collectRepositoryPage(
+		ctx,
+		repositoryBucketsForPage(page, time.Now().UTC()),
+		page,
+		func(ctx context.Context, bucket string, bucketPage datastore.PageParams) ([]repositoryIndexRow, error) {
+			statement, args, err := repositoryIndexSelect(namespace, bucket, bucketPage)
+			if err != nil {
+				return nil, err
+			}
+			var rows []repositoryIndexRow
+			if err := s.session.Query(statement, nil).WithContext(ctx).Bind(args...).SelectRelease(&rows); err != nil {
+				return nil, fmt.Errorf("scylla: list repositories bucket %s: %w", bucket, err)
+			}
+			return rows, nil
+		},
+		func(ctx context.Context, uid string) (*datastore.Repository, error) {
+			return s.GetRepository(ctx, uid)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	result := buildPageResult(items, limit, page)
+	result.TotalCount = -1
+	return result, nil
+}
+
+type repositoryIndexFetcher func(context.Context, string, datastore.PageParams) ([]repositoryIndexRow, error)
+type repositoryHydrator func(context.Context, string) (*datastore.Repository, error)
+
+func collectRepositoryPage(
+	ctx context.Context,
+	buckets []string,
+	page datastore.PageParams,
+	fetch repositoryIndexFetcher,
+	hydrate repositoryHydrator,
+) ([]*datastore.Repository, error) {
+	limit := page.Limit()
+	items := make([]*datastore.Repository, 0, limit+1)
+	for _, bucket := range buckets {
 		bucketPage := page
 		if page.After != "" && !cursorInNamespaceBucket(page.After, bucket) {
 			bucketPage.After = ""
@@ -205,38 +243,52 @@ func (s *scyllaDatastore) listRepositories(ctx context.Context, namespace string
 		if page.Before != "" && !cursorInNamespaceBucket(page.Before, bucket) {
 			bucketPage.Before = ""
 		}
-		statement, args, err := repositoryIndexSelect(namespace, bucket, bucketPage)
-		if err != nil {
-			return nil, err
+
+		for len(items) < limit+1 {
+			rows, err := fetch(ctx, bucket, bucketPage)
+			if err != nil {
+				return nil, err
+			}
+			if len(rows) == 0 {
+				break
+			}
+			for _, index := range rows {
+				repository, err := hydrate(ctx, index.UID.String())
+				if errors.Is(err, datastore.ErrNotFound) {
+					continue
+				}
+				if err != nil {
+					return nil, fmt.Errorf("scylla: hydrate listed repository: %w", err)
+				}
+				items = append(items, repository)
+				if len(items) >= limit+1 {
+					break
+				}
+			}
+			if len(items) >= limit+1 || len(rows) < limit+1 {
+				break
+			}
+
+			last := rows[len(rows)-1]
+			cursor := encodeKeysetCursor(last.CreationTimestamp, last.UID.String())
+			if page.Last > 0 {
+				bucketPage.Before = cursor
+				bucketPage.After = ""
+			} else {
+				bucketPage.After = cursor
+				bucketPage.Before = ""
+			}
 		}
-		var bucketRows []repositoryIndexRow
-		if err := s.session.Query(statement, nil).WithContext(ctx).Bind(args...).SelectRelease(&bucketRows); err != nil {
-			return nil, fmt.Errorf("scylla: list repositories bucket %s: %w", bucket, err)
-		}
-		rows = append(rows, bucketRows...)
-		if len(rows) >= limit+1 {
-			rows = rows[:limit+1]
+		if len(items) >= limit+1 {
 			break
 		}
 	}
 	if page.Last > 0 {
-		reverseRows(rows)
-	}
-
-	items := make([]*datastore.Repository, 0, len(rows))
-	for _, index := range rows {
-		repository, err := s.GetRepository(ctx, index.UID.String())
-		if errors.Is(err, datastore.ErrNotFound) {
-			continue
+		for left, right := 0, len(items)-1; left < right; left, right = left+1, right-1 {
+			items[left], items[right] = items[right], items[left]
 		}
-		if err != nil {
-			return nil, fmt.Errorf("scylla: hydrate listed repository: %w", err)
-		}
-		items = append(items, repository)
 	}
-	result := buildPageResult(items, limit, page)
-	result.TotalCount = -1
-	return result, nil
+	return items, nil
 }
 
 func repositoryBucketsForPage(page datastore.PageParams, now time.Time) []string {

--- a/gitstore-api/internal/datastore/scylla/repository.go
+++ b/gitstore-api/internal/datastore/scylla/repository.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"strings"
 	"time"
 
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
@@ -16,143 +16,324 @@ import (
 )
 
 type repositoryRow struct {
+	APIVersion        string            `db:"api_version"`
+	Kind              string            `db:"kind"`
+	Namespace         string            `db:"namespace"`
+	UID               gocql.UUID        `db:"uid"`
+	Name              string            `db:"name"`
+	Generation        int64             `db:"generation"`
+	ResourceVersion   string            `db:"resource_version"`
+	Revision          string            `db:"revision"`
+	CreationTimestamp time.Time         `db:"creation_timestamp"`
+	CreationActor     string            `db:"creation_actor"`
+	UpdateTimestamp   time.Time         `db:"update_timestamp"`
+	UpdateActor       string            `db:"update_actor"`
+	Labels            map[string]string `db:"labels"`
+	Annotations       map[string]string `db:"annotations"`
+	OwnerReferences   string            `db:"owner_references"`
+	Finalizers        []string          `db:"finalizers"`
+	DeletionTimestamp *time.Time        `db:"deletion_timestamp"`
+	RepositoryID      *gocql.UUID       `db:"repository_id"`
+	SourcePath        string            `db:"source_path"`
+	GitCommitSHA      string            `db:"git_commit_sha"`
+	GitRef            string            `db:"git_ref"`
+	Spec              string            `db:"spec"`
+	Body              string            `db:"body"`
+	Status            string            `db:"status"`
+	DefaultBranch     string            `db:"default_branch"`
+	StorageClass      string            `db:"storage_class"`
+	MaxPackSizeBytes  int64             `db:"max_pack_size_bytes"`
+	MaxFileSizeBytes  int64             `db:"max_file_size_bytes"`
+}
+
+type repositoryIndexRow struct {
+	Namespace         string     `db:"namespace"`
 	Bucket            string     `db:"bucket"`
 	CreationTimestamp time.Time  `db:"creation_timestamp"`
-	ID                gocql.UUID `db:"id"`
-	NamespaceID       gocql.UUID `db:"namespace_id"`
-	Name              string     `db:"name"`
-	DefaultBranch     string     `db:"default_branch"`
-	StorageClass      string     `db:"storage_class"`
-	MaxPackSizeBytes  int64      `db:"max_pack_size_bytes"`
-	MaxFileSizeBytes  int64      `db:"max_file_size_bytes"`
-	Generation        int64      `db:"generation"`
-	ResourceVersion   string     `db:"resource_version"`
-	Status            string     `db:"status"`
-	CreationActor     string     `db:"creation_actor"`
-	UpdateTimestamp   time.Time  `db:"update_timestamp"`
-	UpdateActor       string     `db:"update_actor"`
+	UID               gocql.UUID `db:"uid"`
 }
 
-func toRepositoryRow(r *datastore.Repository) *repositoryRow {
-	datastore.NormalizeRepositoryContract(r)
-	return &repositoryRow{
-		Bucket:            BucketAll,
-		CreationTimestamp: r.CreationTimestamp,
-		ID:                mustParseUUID(r.ID),
-		NamespaceID:       mustParseUUID(r.NamespaceID),
-		Name:              r.Name,
-		DefaultBranch:     r.DefaultBranch,
-		StorageClass:      r.StorageClass,
-		MaxPackSizeBytes:  r.MaxPackSizeBytes,
-		MaxFileSizeBytes:  r.MaxFileSizeBytes,
-		Generation:        r.Generation,
-		ResourceVersion:   r.ResourceVersion,
-		Status:            string(r.Status),
-		CreationActor:     r.CreationActor,
-		UpdateTimestamp:   r.UpdateTimestamp,
-		UpdateActor:       r.UpdateActor,
+func (s *scyllaDatastore) CreateRepository(ctx context.Context, repository *datastore.Repository) error {
+	if repository == nil {
+		return fmt.Errorf("%w: repository is nil", datastore.ErrInvalidArgument)
 	}
-}
-
-func fromRepositoryRow(r *repositoryRow) *datastore.Repository {
-	repository := &datastore.Repository{
-		ID:                r.ID.String(),
-		NamespaceID:       r.NamespaceID.String(),
-		Name:              r.Name,
-		DefaultBranch:     r.DefaultBranch,
-		StorageClass:      r.StorageClass,
-		MaxPackSizeBytes:  r.MaxPackSizeBytes,
-		MaxFileSizeBytes:  r.MaxFileSizeBytes,
-		Generation:        r.Generation,
-		ResourceVersion:   r.ResourceVersion,
-		Status:            []byte(r.Status),
-		CreationTimestamp: r.CreationTimestamp,
-		CreationActor:     r.CreationActor,
-		UpdateTimestamp:   r.UpdateTimestamp,
-		UpdateActor:       r.UpdateActor,
+	if repository.UID == "" || repository.Namespace == "" || repository.Name == "" {
+		return fmt.Errorf("%w: repository uid, namespace, and name are required", datastore.ErrInvalidArgument)
+	}
+	if _, err := gocql.ParseUUID(repository.UID); err != nil {
+		return fmt.Errorf("%w: invalid repository uid %s", datastore.ErrInvalidArgument, repository.UID)
 	}
 	datastore.NormalizeRepositoryContract(repository)
-	return repository
-}
-
-func (s *scyllaDatastore) CreateRepository(ctx context.Context, r *datastore.Repository) error {
-	if _, err := s.GetRepository(ctx, r.ID); err == nil {
-		return fmt.Errorf("%w: repository id %s", datastore.ErrAlreadyExists, r.ID)
+	row := toRepositoryRow(repository)
+	path := repositoryPath{namespace: repository.Namespace, name: repository.Name}
+	pathCreated, err := s.reserveRepositoryPathOwned(ctx, path, repository.UID)
+	if err != nil {
+		return err
 	}
-	row := toRepositoryRow(r)
-	stmt, names := s.repositoryTable.Insert()
-	if err := s.session.Query(stmt, names).BindStruct(row).ExecRelease(); err != nil {
-		return fmt.Errorf("scylla: create repository: %w", err)
+
+	insert, names := s.repositoryByUIDTable.Insert()
+	applied, err := s.session.Query(insert+" IF NOT EXISTS", names).WithContext(ctx).
+		BindStruct(row).ExecCASRelease()
+	if err != nil {
+		if pathCreated {
+			if compensationErr := s.releaseRepositoryPath(ctx, path, repository.UID); compensationErr != nil {
+				return datastore.NewRepairRequiredError(
+					datastore.MutationStep{
+						Operation:    "create_repository",
+						ResourceKind: "Repository",
+						ResourceUID:  repository.UID,
+						Projection:   "namespace_mappings",
+						LookupKey:    path.key(),
+						Action:       "reserve",
+					},
+					fmt.Errorf("scylla: create repository authoritative row: %w", err),
+					compensationErr,
+				)
+			}
+		}
+		return fmt.Errorf("scylla: create repository authoritative row: %w", err)
+	}
+	if !applied {
+		if pathCreated {
+			if compensationErr := s.releaseRepositoryPath(ctx, path, repository.UID); compensationErr != nil {
+				return datastore.NewRepairRequiredError(
+					datastore.MutationStep{
+						Operation:    "create_repository",
+						ResourceKind: "Repository",
+						ResourceUID:  repository.UID,
+						Projection:   "namespace_mappings",
+						LookupKey:    path.key(),
+						Action:       "reserve",
+					},
+					fmt.Errorf("%w: repository uid %s", datastore.ErrAlreadyExists, repository.UID),
+					compensationErr,
+				)
+			}
+		}
+		return fmt.Errorf("%w: repository uid %s", datastore.ErrAlreadyExists, repository.UID)
+	}
+
+	reverseCreated, err := s.reserveRepositoryReverseMappingOwned(ctx, path, repository.UID)
+	if err != nil {
+		return s.failRepositoryCreate(ctx, repository, path, pathCreated, false, err)
+	}
+	bucket := namespaceBucket(repository.CreationTimestamp)
+	if err := s.insertRepositoryProjections(ctx, repository.Namespace, bucket, repository.CreationTimestamp, row.UID); err != nil {
+		return s.failRepositoryCreate(ctx, repository, path, pathCreated, reverseCreated, err)
 	}
 	return nil
 }
 
-func (s *scyllaDatastore) GetRepository(_ context.Context, id string) (*datastore.Repository, error) {
-	uid, err := gocql.ParseUUID(id)
+func (s *scyllaDatastore) failRepositoryCreate(
+	ctx context.Context,
+	repository *datastore.Repository,
+	path repositoryPath,
+	pathCreated, reverseCreated bool,
+	primary error,
+) error {
+	var compensationErr error
+	uid := mustParseUUID(repository.UID)
+	applied, err := s.session.Query(
+		"DELETE FROM repositories_by_uid WHERE uid=? IF resource_version=?",
+		nil,
+	).WithContext(ctx).Bind(uid, repository.ResourceVersion).ExecCASRelease()
 	if err != nil {
-		return nil, fmt.Errorf("%w: invalid repository id %s", datastore.ErrNotFound, id)
+		compensationErr = errors.Join(compensationErr, fmt.Errorf("delete authoritative repository: %w", err))
+	} else if !applied {
+		compensationErr = errors.Join(compensationErr, fmt.Errorf("authoritative repository changed during compensation"))
 	}
-	// Use secondary index on id
-	stmt, names := qb.Select("repositories").
-		Columns(s.repositoryTable.Metadata().Columns...).
-		Where(qb.Eq("id")).
-		Limit(1).
-		ToCql()
+	if reverseCreated {
+		if err := s.deleteRepositoryReverseMapping(ctx, path, repository.UID); err != nil {
+			compensationErr = errors.Join(compensationErr, err)
+		}
+	}
+	if pathCreated {
+		if err := s.releaseRepositoryPath(ctx, path, repository.UID); err != nil {
+			compensationErr = errors.Join(compensationErr, err)
+		}
+	}
+	if compensationErr != nil {
+		return datastore.NewRepairRequiredError(
+			datastore.MutationStep{
+				Operation:    "create_repository",
+				ResourceKind: "Repository",
+				ResourceUID:  repository.UID,
+				Projection:   "repository_projections",
+				LookupKey:    path.key(),
+				Action:       "compensate",
+			},
+			primary,
+			compensationErr,
+		)
+	}
+	return primary
+}
+
+func (s *scyllaDatastore) GetRepository(ctx context.Context, uidString string) (*datastore.Repository, error) {
+	uid, err := gocql.ParseUUID(uidString)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid repository uid %s", datastore.ErrNotFound, uidString)
+	}
+	stmt, names := s.repositoryByUIDTable.Get()
 	var row repositoryRow
-	if err := s.session.Query(stmt, names).BindMap(qb.M{"id": uid}).GetRelease(&row); err != nil {
+	if err := s.session.Query(stmt, names).WithContext(ctx).
+		BindMap(qb.M{"uid": uid}).GetRelease(&row); err != nil {
 		if errors.Is(err, gocql.ErrNotFound) {
-			return nil, fmt.Errorf("%w: repository id %s", datastore.ErrNotFound, id)
+			return nil, fmt.Errorf("%w: repository uid %s", datastore.ErrNotFound, uidString)
 		}
 		return nil, fmt.Errorf("scylla: get repository: %w", err)
 	}
 	return fromRepositoryRow(&row), nil
 }
 
-func (s *scyllaDatastore) ListRepositoriesByNamespace(_ context.Context, namespaceID string, page datastore.PageParams) (*datastore.PageResult[datastore.Repository], error) {
-	nsUUID, err := gocql.ParseUUID(namespaceID)
-	if err != nil {
-		return nil, fmt.Errorf("%w: invalid namespace_id", datastore.ErrInvalidArgument)
-	}
-
-	// Secondary index query — ORDER BY is not supported, so fetch all and paginate in-memory.
-	cols := s.repositoryTable.Metadata().Columns
-	stmt, names := qb.Select("repositories").
-		Columns(cols...).
-		Where(qb.Eq("namespace_id")).
-		ToCql()
-
-	var rows []repositoryRow
-	if err := s.session.Query(stmt, names).BindMap(qb.M{"namespace_id": nsUUID}).SelectRelease(&rows); err != nil {
-		return nil, fmt.Errorf("scylla: list repositories by namespace: %w", err)
-	}
-
-	// Sort descending by (creation_timestamp, id) — matching partition table ordering.
-	sort.Slice(rows, func(i, j int) bool {
-		if rows[i].CreationTimestamp.Equal(rows[j].CreationTimestamp) {
-			return rows[i].ID.String() > rows[j].ID.String()
-		}
-		return rows[i].CreationTimestamp.After(rows[j].CreationTimestamp)
-	})
-
-	repos := make([]*datastore.Repository, len(rows))
-	for i := range rows {
-		repos[i] = fromRepositoryRow(&rows[i])
-	}
-
-	return paginateInMemory(repos, page), nil
+func (s *scyllaDatastore) ListRepositoriesByNamespace(ctx context.Context, namespace string, page datastore.PageParams) (*datastore.PageResult[datastore.Repository], error) {
+	return s.listRepositories(ctx, namespace, page)
 }
 
-func (s *scyllaDatastore) UpdateRepository(ctx context.Context, r *datastore.Repository, expectedResourceVersion string) error {
-	row := toRepositoryRow(r)
-	const statement = "UPDATE repositories SET namespace_id=?, name=?, default_branch=?, storage_class=?, " +
-		"max_pack_size_bytes=?, max_file_size_bytes=?, generation=?, resource_version=?, status=?, " +
-		"creation_actor=?, update_timestamp=?, update_actor=? WHERE bucket=? AND creation_timestamp=? AND id=? " +
-		"IF resource_version=?"
+func (s *scyllaDatastore) ListRepositories(ctx context.Context, page datastore.PageParams) (*datastore.PageResult[datastore.Repository], error) {
+	return s.listRepositories(ctx, "", page)
+}
+
+func (s *scyllaDatastore) listRepositories(ctx context.Context, namespace string, page datastore.PageParams) (*datastore.PageResult[datastore.Repository], error) {
+	limit := page.Limit()
+	rows := make([]repositoryIndexRow, 0, limit+1)
+	for _, bucket := range repositoryBucketsForPage(page, time.Now().UTC()) {
+		bucketPage := page
+		if page.After != "" && !cursorInNamespaceBucket(page.After, bucket) {
+			bucketPage.After = ""
+		}
+		if page.Before != "" && !cursorInNamespaceBucket(page.Before, bucket) {
+			bucketPage.Before = ""
+		}
+		statement, args, err := repositoryIndexSelect(namespace, bucket, bucketPage)
+		if err != nil {
+			return nil, err
+		}
+		var bucketRows []repositoryIndexRow
+		if err := s.session.Query(statement, nil).WithContext(ctx).Bind(args...).SelectRelease(&bucketRows); err != nil {
+			return nil, fmt.Errorf("scylla: list repositories bucket %s: %w", bucket, err)
+		}
+		rows = append(rows, bucketRows...)
+		if len(rows) >= limit+1 {
+			rows = rows[:limit+1]
+			break
+		}
+	}
+	if page.Last > 0 {
+		reverseRows(rows)
+	}
+
+	items := make([]*datastore.Repository, 0, len(rows))
+	for _, index := range rows {
+		repository, err := s.GetRepository(ctx, index.UID.String())
+		if errors.Is(err, datastore.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("scylla: hydrate listed repository: %w", err)
+		}
+		items = append(items, repository)
+	}
+	result := buildPageResult(items, limit, page)
+	result.TotalCount = -1
+	return result, nil
+}
+
+func repositoryBucketsForPage(page datastore.PageParams, now time.Time) []string {
+	// Include the adjacent future bucket so accepted clock-skewed timestamps remain pageable.
+	return namespaceBucketsForPage(page, now.AddDate(0, 1, 0))
+}
+
+func repositoryIndexSelect(namespace, bucket string, page datastore.PageParams) (string, []any, error) {
+	tableName := "repositories_by_bucket"
+	columns := "bucket, creation_timestamp, uid"
+	where := "bucket = ?"
+	args := []any{bucket}
+	if namespace != "" {
+		tableName = "repositories_by_namespace"
+		columns = "namespace, bucket, creation_timestamp, uid"
+		where = "namespace = ? AND bucket = ?"
+		args = []any{namespace, bucket}
+	}
+
+	backward := page.Last > 0
+	cursor := page.After
+	operator := "<"
+	order := "DESC"
+	if backward {
+		cursor = page.Before
+		operator = ">"
+		order = "ASC"
+	}
+	if cursor != "" {
+		parsed, err := parsePageCursor(cursor)
+		if err != nil {
+			return "", nil, err
+		}
+		where += fmt.Sprintf(" AND (creation_timestamp, uid) %s (?, ?)", operator)
+		args = append(args, parsed.CreatedAt, mustParseUUID(parsed.ID))
+	}
+	args = append(args, page.Limit()+1)
+	return fmt.Sprintf(
+		"SELECT %s FROM %s WHERE %s ORDER BY creation_timestamp %s, uid %s LIMIT ?",
+		columns,
+		tableName,
+		where,
+		order,
+		order,
+	), args, nil
+}
+
+func (s *scyllaDatastore) UpdateRepository(ctx context.Context, repository *datastore.Repository, expectedResourceVersion string) error {
+	if repository == nil {
+		return fmt.Errorf("%w: repository is nil", datastore.ErrInvalidArgument)
+	}
+	existing, err := s.GetRepository(ctx, repository.UID)
+	if err != nil {
+		return err
+	}
+	if err := s.updateRepositoryAuthoritative(ctx, repository, existing.CreationTimestamp, expectedResourceVersion); err != nil {
+		return err
+	}
+
+	if existing.Namespace != repository.Namespace {
+		if err := s.syncRepositoryNamespaceProjection(ctx, existing, repository); err != nil {
+			return datastore.NewRepairRequiredError(
+				datastore.MutationStep{
+					Operation:    "update_repository",
+					ResourceKind: "Repository",
+					ResourceUID:  repository.UID,
+					Projection:   "repositories_by_namespace",
+					LookupKey:    repository.Namespace,
+					Action:       "roll_forward",
+				},
+				err,
+				fmt.Errorf("authoritative repository version %s is already committed", repository.ResourceVersion),
+			)
+		}
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) updateRepositoryAuthoritative(
+	ctx context.Context,
+	repository *datastore.Repository,
+	creationTimestamp time.Time,
+	expectedResourceVersion string,
+) error {
+	datastore.NormalizeRepositoryContract(repository)
+	row := toRepositoryRow(repository)
+	row.CreationTimestamp = creationTimestamp
+
+	const statement = "UPDATE repositories_by_uid SET api_version=?, kind=?, namespace=?, name=?, generation=?, resource_version=?, revision=?, " +
+		"creation_timestamp=?, creation_actor=?, update_timestamp=?, update_actor=?, labels=?, annotations=?, owner_references=?, finalizers=?, " +
+		"deletion_timestamp=?, repository_id=?, source_path=?, git_commit_sha=?, git_ref=?, spec=?, body=?, status=?, default_branch=?, storage_class=?, " +
+		"max_pack_size_bytes=?, max_file_size_bytes=? WHERE uid=? IF resource_version=?"
 	applied, err := s.session.Query(statement, nil).WithContext(ctx).Bind(
-		row.NamespaceID, row.Name, row.DefaultBranch, row.StorageClass,
-		row.MaxPackSizeBytes, row.MaxFileSizeBytes, row.Generation, row.ResourceVersion, row.Status,
-		row.CreationActor, row.UpdateTimestamp, row.UpdateActor,
-		row.Bucket, row.CreationTimestamp, row.ID, expectedResourceVersion,
+		row.APIVersion, row.Kind, row.Namespace, row.Name, row.Generation, row.ResourceVersion, row.Revision,
+		row.CreationTimestamp, row.CreationActor, row.UpdateTimestamp, row.UpdateActor, row.Labels, row.Annotations, row.OwnerReferences, row.Finalizers,
+		row.DeletionTimestamp, row.RepositoryID, row.SourcePath, row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
+		row.DefaultBranch, row.StorageClass, row.MaxPackSizeBytes, row.MaxFileSizeBytes, row.UID, expectedResourceVersion,
 	).ExecCASRelease()
 	if err != nil {
 		return fmt.Errorf("scylla: update repository: %w", err)
@@ -163,50 +344,192 @@ func (s *scyllaDatastore) UpdateRepository(ctx context.Context, r *datastore.Rep
 	return nil
 }
 
-// HasRepositories reports whether at least one Repository row currently has
-// namespace_id == namespaceID, using the repositories_by_namespace secondary
-// index (migration 002_secondary_indexes.cql).
-func (s *scyllaDatastore) HasRepositories(_ context.Context, namespaceID string) (bool, error) {
-	nsUUID, err := gocql.ParseUUID(namespaceID)
-	if err != nil {
-		return false, fmt.Errorf("%w: invalid namespace_id", datastore.ErrInvalidArgument)
+func (s *scyllaDatastore) syncRepositoryNamespaceProjection(
+	ctx context.Context,
+	existing, repository *datastore.Repository,
+) error {
+	if existing.Namespace == repository.Namespace {
+		return nil
 	}
-	stmt, names := qb.Select("repositories").
-		Columns("id").
-		Where(qb.Eq("namespace_id")).
-		Limit(1).
-		ToCql()
-	var row struct {
-		ID gocql.UUID `db:"id"`
+	uid := mustParseUUID(repository.UID)
+	bucket := namespaceBucket(existing.CreationTimestamp)
+	if err := s.session.Query(
+		"INSERT INTO repositories_by_namespace (namespace, bucket, creation_timestamp, uid) VALUES (?, ?, ?, ?)",
+		nil,
+	).WithContext(ctx).Bind(repository.Namespace, bucket, existing.CreationTimestamp, uid).ExecRelease(); err != nil {
+		return fmt.Errorf("scylla: insert repository namespace projection: %w", err)
 	}
-	if err := s.session.Query(stmt, names).BindMap(qb.M{"namespace_id": nsUUID}).GetRelease(&row); err != nil {
-		if errors.Is(err, gocql.ErrNotFound) {
-			return false, nil
-		}
-		return false, fmt.Errorf("scylla: has repositories: %w", err)
+	if err := s.session.Query(
+		"DELETE FROM repositories_by_namespace WHERE namespace=? AND bucket=? AND creation_timestamp=? AND uid=?",
+		nil,
+	).WithContext(ctx).Bind(existing.Namespace, bucket, existing.CreationTimestamp, uid).ExecRelease(); err != nil {
+		return fmt.Errorf("scylla: delete stale repository namespace projection: %w", err)
 	}
-	return true, nil
+	return nil
 }
 
-func (s *scyllaDatastore) DeleteRepository(ctx context.Context, id string) error {
-	repo, err := s.GetRepository(ctx, id)
+func (s *scyllaDatastore) DeleteRepository(ctx context.Context, uidString string) error {
+	repository, err := s.GetRepository(ctx, uidString)
 	if err != nil {
 		return err
 	}
-	stmt, names := s.repositoryTable.Delete()
-	if err := s.session.Query(stmt, names).BindMap(qb.M{
-		"bucket":             BucketAll,
-		"creation_timestamp": repo.CreationTimestamp,
-		"id":                 mustParseUUID(id),
-	}).ExecRelease(); err != nil {
+	uid := mustParseUUID(uidString)
+	bucket := namespaceBucket(repository.CreationTimestamp)
+	if err := s.deleteRepositoryProjections(ctx, repository.Namespace, bucket, repository.CreationTimestamp, uid); err != nil {
+		return err
+	}
+	if err := s.session.Query("DELETE FROM repositories_by_uid WHERE uid=?", nil).WithContext(ctx).Bind(uid).ExecRelease(); err != nil {
+		if restoreErr := s.insertRepositoryProjections(ctx, repository.Namespace, bucket, repository.CreationTimestamp, uid); restoreErr != nil {
+			return datastore.NewRepairRequiredError(
+				datastore.MutationStep{
+					Operation:    "delete_repository",
+					ResourceKind: "Repository",
+					ResourceUID:  uidString,
+					Projection:   "repositories_by_uid",
+					Action:       "delete_authoritative",
+				},
+				fmt.Errorf("scylla: delete repository: %w", err),
+				restoreErr,
+			)
+		}
 		return fmt.Errorf("scylla: delete repository: %w", err)
 	}
 	return nil
 }
 
-// reverseRows reverses a slice of repositoryRow in place.
+func (s *scyllaDatastore) HasRepositories(ctx context.Context, namespace string) (bool, error) {
+	result, err := s.ListRepositoriesByNamespace(ctx, namespace, datastore.PageParams{First: 1})
+	if err != nil {
+		return false, fmt.Errorf("scylla: has repositories: %w", err)
+	}
+	return len(result.Items) > 0, nil
+}
+
+func (s *scyllaDatastore) insertRepositoryProjections(ctx context.Context, namespace, bucket string, createdAt time.Time, uid gocql.UUID) error {
+	if err := s.session.Query(
+		"INSERT INTO repositories_by_namespace (namespace, bucket, creation_timestamp, uid) VALUES (?, ?, ?, ?)",
+		nil,
+	).WithContext(ctx).Bind(namespace, bucket, createdAt, uid).ExecRelease(); err != nil {
+		return fmt.Errorf("scylla: insert repository namespace projection: %w", err)
+	}
+	if err := s.session.Query(
+		"INSERT INTO repositories_by_bucket (bucket, creation_timestamp, uid) VALUES (?, ?, ?)",
+		nil,
+	).WithContext(ctx).Bind(bucket, createdAt, uid).ExecRelease(); err != nil {
+		_ = s.session.Query(
+			"DELETE FROM repositories_by_namespace WHERE namespace=? AND bucket=? AND creation_timestamp=? AND uid=?",
+			nil,
+		).WithContext(ctx).Bind(namespace, bucket, createdAt, uid).ExecRelease()
+		return fmt.Errorf("scylla: insert repository global projection: %w", err)
+	}
+	return nil
+}
+
+func (s *scyllaDatastore) deleteRepositoryProjections(ctx context.Context, namespace, bucket string, createdAt time.Time, uid gocql.UUID) error {
+	var cleanupErr error
+	if err := s.session.Query(
+		"DELETE FROM repositories_by_namespace WHERE namespace=? AND bucket=? AND creation_timestamp=? AND uid=?",
+		nil,
+	).WithContext(ctx).Bind(namespace, bucket, createdAt, uid).ExecRelease(); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete namespace projection: %w", err))
+	}
+	if err := s.session.Query(
+		"DELETE FROM repositories_by_bucket WHERE bucket=? AND creation_timestamp=? AND uid=?",
+		nil,
+	).WithContext(ctx).Bind(bucket, createdAt, uid).ExecRelease(); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete global projection: %w", err))
+	}
+	if cleanupErr != nil {
+		return fmt.Errorf("scylla: delete repository projections: %w", cleanupErr)
+	}
+	return nil
+}
+
+func toRepositoryRow(repository *datastore.Repository) *repositoryRow {
+	return &repositoryRow{
+		APIVersion:        repository.APIVersion,
+		Kind:              repository.Kind,
+		Namespace:         repository.Namespace,
+		UID:               mustParseUUID(repository.UID),
+		Name:              repository.Name,
+		Generation:        repository.Generation,
+		ResourceVersion:   repository.ResourceVersion,
+		Revision:          repository.Revision,
+		CreationTimestamp: repository.CreationTimestamp,
+		CreationActor:     repository.CreationActor,
+		UpdateTimestamp:   repository.UpdateTimestamp,
+		UpdateActor:       repository.UpdateActor,
+		Labels:            repository.Labels,
+		Annotations:       repository.Annotations,
+		OwnerReferences:   string(repository.OwnerReferences),
+		Finalizers:        append([]string(nil), repository.Finalizers...),
+		DeletionTimestamp: repository.DeletionTimestamp,
+		RepositoryID:      optionalUUID(repository.RepositoryID),
+		SourcePath:        repository.SourcePath,
+		GitCommitSHA:      repository.GitCommitSHA,
+		GitRef:            repository.GitRef,
+		Spec:              string(repository.Spec),
+		Body:              repository.Body,
+		Status:            string(repository.Status),
+		DefaultBranch:     repository.DefaultBranch,
+		StorageClass:      repository.StorageClass,
+		MaxPackSizeBytes:  repository.MaxPackSizeBytes,
+		MaxFileSizeBytes:  repository.MaxFileSizeBytes,
+	}
+}
+
+func fromRepositoryRow(row *repositoryRow) *datastore.Repository {
+	repository := &datastore.Repository{
+		APIVersion:        row.APIVersion,
+		Kind:              row.Kind,
+		Namespace:         row.Namespace,
+		UID:               row.UID.String(),
+		Name:              row.Name,
+		Generation:        row.Generation,
+		ResourceVersion:   row.ResourceVersion,
+		Revision:          row.Revision,
+		CreationTimestamp: row.CreationTimestamp,
+		CreationActor:     row.CreationActor,
+		UpdateTimestamp:   row.UpdateTimestamp,
+		UpdateActor:       row.UpdateActor,
+		Labels:            row.Labels,
+		Annotations:       row.Annotations,
+		OwnerReferences:   jsonOrNil(row.OwnerReferences),
+		Finalizers:        append([]string(nil), row.Finalizers...),
+		DeletionTimestamp: row.DeletionTimestamp,
+		RepositoryID:      uuidString(row.RepositoryID),
+		SourcePath:        row.SourcePath,
+		GitCommitSHA:      row.GitCommitSHA,
+		GitRef:            row.GitRef,
+		Spec:              jsonOrNil(row.Spec),
+		Body:              row.Body,
+		Status:            jsonOrNil(row.Status),
+		DefaultBranch:     row.DefaultBranch,
+		StorageClass:      row.StorageClass,
+		MaxPackSizeBytes:  row.MaxPackSizeBytes,
+		MaxFileSizeBytes:  row.MaxFileSizeBytes,
+	}
+	datastore.NormalizeRepositoryContract(repository)
+	return repository
+}
+
+func optionalUUID(value string) *gocql.UUID {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parsed := mustParseUUID(value)
+	return &parsed
+}
+
+func uuidString(value *gocql.UUID) string {
+	if value == nil {
+		return ""
+	}
+	return value.String()
+}
+
 func reverseRows[T any](rows []T) {
-	for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
-		rows[i], rows[j] = rows[j], rows[i]
+	for left, right := 0, len(rows)-1; left < right; left, right = left+1, right-1 {
+		rows[left], rows[right] = rows[right], rows[left]
 	}
 }

--- a/gitstore-api/internal/datastore/scylla/repository_recovery_test.go
+++ b/gitstore-api/internal/datastore/scylla/repository_recovery_test.go
@@ -427,3 +427,53 @@ func TestRepositoryBucketsForPageIncludesAdjacentFutureBucket(t *testing.T) {
 
 	assert.Equal(t, []string{"2026-05", "2026-06", "2026-07", "2026-08", "2026-09"}, buckets)
 }
+
+func TestCollectRepositoryPageContinuesPastDanglingRows(t *testing.T) {
+	created := time.Date(2026, time.August, 19, 20, 0, 0, 0, time.UTC)
+	danglingOne := "11111111-1111-1111-1111-111111111111"
+	danglingTwo := "22222222-2222-2222-2222-222222222222"
+	liveOne := "33333333-3333-3333-3333-333333333333"
+	liveTwo := "44444444-4444-4444-4444-444444444444"
+	calls := 0
+
+	items, err := collectRepositoryPage(
+		context.Background(),
+		[]string{"2026-08"},
+		datastore.PageParams{First: 1},
+		func(_ context.Context, bucket string, page datastore.PageParams) ([]repositoryIndexRow, error) {
+			assert.Equal(t, "2026-08", bucket)
+			calls++
+			switch calls {
+			case 1:
+				assert.Empty(t, page.After)
+				return []repositoryIndexRow{
+					{Bucket: bucket, CreationTimestamp: created, UID: mustParseUUID(danglingOne)},
+					{Bucket: bucket, CreationTimestamp: created.Add(-time.Second), UID: mustParseUUID(danglingTwo)},
+				}, nil
+			case 2:
+				assert.NotEmpty(t, page.After)
+				return []repositoryIndexRow{
+					{Bucket: bucket, CreationTimestamp: created.Add(-2 * time.Second), UID: mustParseUUID(liveOne)},
+					{Bucket: bucket, CreationTimestamp: created.Add(-3 * time.Second), UID: mustParseUUID(liveTwo)},
+				}, nil
+			default:
+				t.Fatalf("unexpected fetch call %d", calls)
+				return nil, nil
+			}
+		},
+		func(_ context.Context, uid string) (*datastore.Repository, error) {
+			switch uid {
+			case danglingOne, danglingTwo:
+				return nil, datastore.ErrNotFound
+			default:
+				return &datastore.Repository{UID: uid}, nil
+			}
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, liveOne, items[0].UID)
+	assert.Equal(t, liveTwo, items[1].UID)
+	assert.Equal(t, 2, calls)
+}

--- a/gitstore-api/internal/datastore/scylla/repository_recovery_test.go
+++ b/gitstore-api/internal/datastore/scylla/repository_recovery_test.go
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package scylla
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sagaTestRepositoryID = "11111111-1111-1111-1111-111111111111"
+
+type repositorySagaState struct {
+	repository *datastore.Repository
+	paths      map[repositoryPath]string
+	reverse    *repositoryPath
+	fail       map[string]error
+	calls      []string
+}
+
+func newRepositorySagaState(source repositoryPath) *repositorySagaState {
+	reverse := source
+	return &repositorySagaState{
+		repository: &datastore.Repository{
+			UID:             sagaTestRepositoryID,
+			Namespace:       source.namespace,
+			Name:            source.name,
+			Generation:      1,
+			ResourceVersion: "1",
+		},
+		paths:   map[repositoryPath]string{source: sagaTestRepositoryID},
+		reverse: &reverse,
+		fail:    make(map[string]error),
+	}
+}
+
+func (s *repositorySagaState) operations(injector failureInjector) repositorySagaOperations {
+	return repositorySagaOperations{
+		injector: injector,
+		reserve: func(_ context.Context, path repositoryPath, owner string) error {
+			s.calls = append(s.calls, repositorySagaReserveTarget)
+			if err := s.takeFailure(repositorySagaReserveTarget); err != nil {
+				return err
+			}
+			if existing, ok := s.paths[path]; ok && existing != owner {
+				return datastore.ErrAlreadyExists
+			}
+			s.paths[path] = owner
+			return nil
+		},
+		release: func(_ context.Context, path repositoryPath, owner string) error {
+			if err := s.takeFailure("release_target"); err != nil {
+				return err
+			}
+			if existing, ok := s.paths[path]; ok {
+				if existing != owner {
+					return datastore.ErrRepairRequired
+				}
+				delete(s.paths, path)
+			}
+			return nil
+		},
+		commit: func(
+			_ context.Context,
+			_ *datastore.Repository,
+			source, target repositoryPath,
+			version repositorySagaVersion,
+		) (bool, error) {
+			s.calls = append(s.calls, repositorySagaUpdateAuthoritative)
+			if err := s.takeFailure(repositorySagaUpdateAuthoritative); err != nil {
+				return false, err
+			}
+			if repositoryHasPath(s.repository, target) {
+				return true, nil
+			}
+			if !repositoryHasPath(s.repository, source) {
+				return false, datastore.ErrRepairRequired
+			}
+			s.repository.Namespace = target.namespace
+			s.repository.Name = target.name
+			if version == repositorySagaSystemVersion {
+				datastore.AdvanceRepositorySystemVersion(s.repository)
+			} else {
+				datastore.AdvanceRepositorySpecVersion(s.repository)
+			}
+			return true, nil
+		},
+		updateReverse: func(_ context.Context, source, target repositoryPath, _ string) error {
+			s.calls = append(s.calls, repositorySagaUpdateReverse)
+			if err := s.takeFailure(repositorySagaUpdateReverse); err != nil {
+				return err
+			}
+			if s.reverse != nil && *s.reverse != source && *s.reverse != target {
+				return datastore.ErrRepairRequired
+			}
+			updated := target
+			s.reverse = &updated
+			return nil
+		},
+		cleanup: func(_ context.Context, path repositoryPath, owner string) error {
+			s.calls = append(s.calls, repositorySagaCleanupOldPath)
+			if err := s.takeFailure(repositorySagaCleanupOldPath); err != nil {
+				return err
+			}
+			if existing, ok := s.paths[path]; ok {
+				if existing != owner {
+					return datastore.ErrRepairRequired
+				}
+				delete(s.paths, path)
+			}
+			return nil
+		},
+	}
+}
+
+func (s *repositorySagaState) takeFailure(step string) error {
+	err := s.fail[step]
+	delete(s.fail, step)
+	return err
+}
+
+func (s *repositorySagaState) assertConverged(t *testing.T, target repositoryPath) {
+	t.Helper()
+	require.Len(t, s.paths, 1)
+	assert.Equal(t, sagaTestRepositoryID, s.paths[target])
+	require.NotNil(t, s.reverse)
+	assert.Equal(t, target, *s.reverse)
+	assert.True(t, repositoryHasPath(s.repository, target))
+}
+
+func TestRepositoryMappingSagaOrdersAllAwaitedSteps(t *testing.T) {
+	source := repositoryPath{namespace: "source", name: "catalog"}
+	target := repositoryPath{namespace: "source", name: "renamed"}
+	state := newRepositorySagaState(source)
+
+	err := executeRepositoryMappingSaga(
+		context.Background(),
+		state.operations(nil),
+		state.repository,
+		source,
+		target,
+		repositorySagaSpecVersion,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		repositorySagaReserveTarget,
+		repositorySagaUpdateAuthoritative,
+		repositorySagaUpdateReverse,
+		repositorySagaCleanupOldPath,
+	}, state.calls)
+	state.assertConverged(t, target)
+}
+
+func TestRepositoryMappingSagaRejectsTargetOwnedByAnotherRepository(t *testing.T) {
+	source := repositoryPath{namespace: "source", name: "catalog"}
+	target := repositoryPath{namespace: "source", name: "renamed"}
+	state := newRepositorySagaState(source)
+	state.paths[target] = "22222222-2222-2222-2222-222222222222"
+
+	err := executeRepositoryMappingSaga(
+		context.Background(),
+		state.operations(nil),
+		state.repository,
+		source,
+		target,
+		repositorySagaSpecVersion,
+	)
+
+	require.ErrorIs(t, err, datastore.ErrAlreadyExists)
+	assert.True(t, repositoryHasPath(state.repository, source))
+	assert.Equal(t, "1", state.repository.ResourceVersion)
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", state.paths[target])
+}
+
+func TestRepositoryMappingSagaFailureInjectionRetryConverges(t *testing.T) {
+	source := repositoryPath{namespace: "source", name: "catalog"}
+	target := repositoryPath{namespace: "source", name: "renamed"}
+	for _, step := range []string{
+		repositorySagaReserveTarget,
+		repositorySagaUpdateAuthoritative,
+		repositorySagaUpdateReverse,
+		repositorySagaCleanupOldPath,
+	} {
+		for _, point := range []failurePoint{failureBefore, failureAfter} {
+			t.Run(step+"_"+string(point), func(t *testing.T) {
+				state := newRepositorySagaState(source)
+				injector := newTestFailureInjector()
+				injector.fail(step, point)
+
+				err := executeRepositoryMappingSaga(
+					context.Background(),
+					state.operations(injector),
+					state.repository,
+					source,
+					target,
+					repositorySagaSpecVersion,
+				)
+				require.Error(t, err)
+
+				require.NoError(t, executeRepositoryMappingSaga(
+					context.Background(),
+					state.operations(nil),
+					state.repository,
+					source,
+					target,
+					repositorySagaSpecVersion,
+				))
+				state.assertConverged(t, target)
+				assert.Equal(t, int64(2), state.repository.Generation)
+				assert.Equal(t, "2", state.repository.ResourceVersion)
+			})
+		}
+	}
+}
+
+func TestRepositoryMappingSagaApplyFailuresRetryConverges(t *testing.T) {
+	source := repositoryPath{namespace: "source", name: "catalog"}
+	target := repositoryPath{namespace: "target", name: "catalog"}
+	for _, step := range []string{
+		repositorySagaReserveTarget,
+		repositorySagaUpdateAuthoritative,
+		repositorySagaUpdateReverse,
+		repositorySagaCleanupOldPath,
+	} {
+		t.Run(step, func(t *testing.T) {
+			state := newRepositorySagaState(source)
+			state.fail[step] = errors.New("injected apply failure")
+
+			err := executeRepositoryMappingSaga(
+				context.Background(),
+				state.operations(nil),
+				state.repository,
+				source,
+				target,
+				repositorySagaSystemVersion,
+			)
+			require.Error(t, err)
+
+			require.NoError(t, executeRepositoryMappingSaga(
+				context.Background(),
+				state.operations(nil),
+				state.repository,
+				source,
+				target,
+				repositorySagaSystemVersion,
+			))
+			state.assertConverged(t, target)
+			assert.Equal(t, int64(1), state.repository.Generation)
+			assert.Equal(t, "2", state.repository.ResourceVersion)
+		})
+	}
+}
+
+func TestRepositoryMappingSagaCompensatesReservationBeforeCommit(t *testing.T) {
+	source := repositoryPath{namespace: "source", name: "catalog"}
+	target := repositoryPath{namespace: "source", name: "renamed"}
+	state := newRepositorySagaState(source)
+	state.fail[repositorySagaUpdateAuthoritative] = errors.New("authoritative write failed")
+
+	err := executeRepositoryMappingSaga(
+		context.Background(),
+		state.operations(nil),
+		state.repository,
+		source,
+		target,
+		repositorySagaSpecVersion,
+	)
+
+	require.Error(t, err)
+	assert.NotContains(t, state.paths, target)
+	assert.Contains(t, state.paths, source)
+	assert.Equal(t, source, *state.reverse)
+	assert.Equal(t, "1", state.repository.ResourceVersion)
+}
+
+func TestRepositoryMappingSagaCompensationFailureRequiresRepair(t *testing.T) {
+	source := repositoryPath{namespace: "source", name: "catalog"}
+	target := repositoryPath{namespace: "source", name: "renamed"}
+	state := newRepositorySagaState(source)
+	state.fail[repositorySagaUpdateAuthoritative] = errors.New("authoritative write failed")
+	state.fail["release_target"] = errors.New("target release failed")
+
+	err := executeRepositoryMappingSaga(
+		context.Background(),
+		state.operations(nil),
+		state.repository,
+		source,
+		target,
+		repositorySagaSpecVersion,
+	)
+
+	require.ErrorIs(t, err, datastore.ErrRepairRequired)
+	assert.Equal(t, sagaTestRepositoryID, state.paths[target])
+	assert.True(t, repositoryHasPath(state.repository, source))
+}
+
+func TestRepositoryMappingSagaPostCommitFailureRequiresRollForward(t *testing.T) {
+	source := repositoryPath{namespace: "source", name: "catalog"}
+	target := repositoryPath{namespace: "source", name: "renamed"}
+	state := newRepositorySagaState(source)
+	injector := newTestFailureInjector()
+	injector.fail(repositorySagaUpdateReverse, failureBefore)
+
+	err := executeRepositoryMappingSaga(
+		context.Background(),
+		state.operations(injector),
+		state.repository,
+		source,
+		target,
+		repositorySagaSpecVersion,
+	)
+
+	require.ErrorIs(t, err, datastore.ErrRepairRequired)
+	assert.True(t, repositoryHasPath(state.repository, target))
+	assert.Equal(t, source, *state.reverse)
+	assert.Equal(t, sagaTestRepositoryID, state.paths[source])
+	assert.Equal(t, sagaTestRepositoryID, state.paths[target])
+}
+
+func TestRepositoryMappingSagaNeverDeletesAnotherOwnersOldPath(t *testing.T) {
+	source := repositoryPath{namespace: "source", name: "catalog"}
+	target := repositoryPath{namespace: "source", name: "renamed"}
+	state := newRepositorySagaState(source)
+	state.repository.Namespace = target.namespace
+	state.repository.Name = target.name
+	state.repository.Generation = 2
+	state.repository.ResourceVersion = "2"
+	state.paths[target] = sagaTestRepositoryID
+	state.paths[source] = "22222222-2222-2222-2222-222222222222"
+	reverse := target
+	state.reverse = &reverse
+
+	err := executeRepositoryMappingSaga(
+		context.Background(),
+		state.operations(nil),
+		state.repository,
+		source,
+		target,
+		repositorySagaSpecVersion,
+	)
+
+	require.ErrorIs(t, err, datastore.ErrRepairRequired)
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", state.paths[source])
+	assert.Equal(t, sagaTestRepositoryID, state.paths[target])
+}
+
+func TestRepositoryMappingSagaRepeatedRenameAndTransferAreIdempotent(t *testing.T) {
+	tests := []struct {
+		name               string
+		source             repositoryPath
+		target             repositoryPath
+		version            repositorySagaVersion
+		expectedGeneration int64
+	}{
+		{
+			name:               "rename advances spec version once",
+			source:             repositoryPath{namespace: "source", name: "catalog"},
+			target:             repositoryPath{namespace: "source", name: "renamed"},
+			version:            repositorySagaSpecVersion,
+			expectedGeneration: 2,
+		},
+		{
+			name:               "transfer advances system version once",
+			source:             repositoryPath{namespace: "source", name: "catalog"},
+			target:             repositoryPath{namespace: "target", name: "catalog"},
+			version:            repositorySagaSystemVersion,
+			expectedGeneration: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := newRepositorySagaState(test.source)
+			operations := state.operations(nil)
+
+			require.NoError(t, executeRepositoryMappingSaga(
+				context.Background(), operations, state.repository, test.source, test.target, test.version,
+			))
+			require.NoError(t, executeRepositoryMappingSaga(
+				context.Background(), operations, state.repository, test.source, test.target, test.version,
+			))
+
+			state.assertConverged(t, test.target)
+			assert.Equal(t, test.expectedGeneration, state.repository.Generation)
+			assert.Equal(t, "2", state.repository.ResourceVersion)
+		})
+	}
+}
+
+func TestRepositoryMappingSagaRemovesStaleOldMappingOwnedByRepository(t *testing.T) {
+	source := repositoryPath{namespace: "source", name: "catalog"}
+	target := repositoryPath{namespace: "target", name: "catalog"}
+	state := newRepositorySagaState(source)
+	state.repository.Namespace = target.namespace
+	state.repository.Name = target.name
+	state.repository.ResourceVersion = "2"
+	state.paths[target] = sagaTestRepositoryID
+	reverse := target
+	state.reverse = &reverse
+
+	require.NoError(t, executeRepositoryMappingSaga(
+		context.Background(),
+		state.operations(nil),
+		state.repository,
+		source,
+		target,
+		repositorySagaSystemVersion,
+	))
+
+	state.assertConverged(t, target)
+	assert.Equal(t, "2", state.repository.ResourceVersion)
+}
+
+func TestRepositoryBucketsForPageIncludesAdjacentFutureBucket(t *testing.T) {
+	now := time.Date(2026, time.August, 19, 20, 0, 0, 0, time.UTC)
+	cursorTime := time.Date(2026, time.May, 11, 12, 0, 0, 0, time.UTC)
+	buckets := repositoryBucketsForPage(datastore.PageParams{
+		Last:   100,
+		Before: encodeKeysetCursor(cursorTime, sagaTestRepositoryID),
+	}, now)
+
+	assert.Equal(t, []string{"2026-05", "2026-06", "2026-07", "2026-08", "2026-09"}, buckets)
+}

--- a/gitstore-api/tests/contract/datastore/contract_test.go
+++ b/gitstore-api/tests/contract/datastore/contract_test.go
@@ -10,6 +10,7 @@ package datastore_contract_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -65,7 +66,7 @@ func newNamespace(tier datastore.NamespaceTier) *datastore.Namespace {
 	id := newID()
 	name := "ns-" + newID()[:8]
 	return &datastore.Namespace{
-		ID:                id,
+		UID:               id,
 		Name:              name,
 		Tier:              tier,
 		CreationTimestamp: now,
@@ -80,6 +81,136 @@ func newNamespace(tier datastore.NamespaceTier) *datastore.Namespace {
 func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 	t.Helper()
 	ctx := context.Background()
+
+	t.Run("CanonicalEnvelope/AllResourcesRoundTrip", func(t *testing.T) {
+		now := time.Now().UTC().Truncate(time.Millisecond)
+		deletedAt := now.Add(time.Hour)
+		ownerReferences := json.RawMessage(`[{"apiVersion":"catalog.gitstore.dev/v1beta1","kind":"Collection","name":"owner","uid":"00000000-0000-0000-0000-000000000001"}]`)
+		spec := json.RawMessage(`{"displayName":"canonical"}`)
+		status := json.RawMessage(`{"observedGeneration":7,"conditions":[]}`)
+		labels := map[string]string{"environment": "test"}
+		annotations := map[string]string{"gitstore.dev/note": "round-trip"}
+		finalizers := []string{"gitstore.dev/test"}
+
+		namespace := &datastore.Namespace{
+			APIVersion:        "catalog.gitstore.dev/v1beta1",
+			Kind:              "Namespace",
+			UID:               newID(),
+			Name:              "envelope-ns-" + newID()[:8],
+			Title:             "Envelope Namespace",
+			Tier:              datastore.NamespaceTierOrganization,
+			Generation:        7,
+			ResourceVersion:   "9",
+			Revision:          "main@sha1:namespace",
+			CreationTimestamp: now,
+			CreationActor:     "creator",
+			UpdateTimestamp:   now.Add(time.Minute),
+			UpdateActor:       "updater",
+			Labels:            labels,
+			Annotations:       annotations,
+			OwnerReferences:   ownerReferences,
+			Finalizers:        finalizers,
+			DeletionTimestamp: &deletedAt,
+			SourcePath:        "namespaces/envelope.md",
+			GitCommitSHA:      "namespace-sha",
+			GitRef:            "refs/heads/main",
+			Spec:              spec,
+			Body:              "# Namespace body\n",
+			Status:            status,
+		}
+		require.NoError(t, ds.CreateNamespace(ctx, namespace))
+		gotNamespace, err := ds.GetNamespace(ctx, namespace.UID)
+		require.NoError(t, err)
+		assert.Equal(t, namespace, gotNamespace)
+
+		repository := &datastore.Repository{
+			APIVersion:        "catalog.gitstore.dev/v1beta1",
+			Kind:              "Repository",
+			UID:               newID(),
+			Namespace:         namespace.Name,
+			Name:              "envelope-repo-" + newID()[:8],
+			Generation:        7,
+			ResourceVersion:   "9",
+			Revision:          "main@sha1:repository",
+			CreationTimestamp: now,
+			CreationActor:     "creator",
+			UpdateTimestamp:   now.Add(time.Minute),
+			UpdateActor:       "updater",
+			Labels:            labels,
+			Annotations:       annotations,
+			OwnerReferences:   ownerReferences,
+			Finalizers:        finalizers,
+			DeletionTimestamp: &deletedAt,
+			RepositoryID:      newID(),
+			SourcePath:        "repositories/envelope.md",
+			GitCommitSHA:      "repository-sha",
+			GitRef:            "refs/heads/main",
+			Spec:              spec,
+			Body:              "# Repository body\n",
+			Status:            status,
+			DefaultBranch:     "main",
+			StorageClass:      "default",
+		}
+		require.NoError(t, ds.CreateRepository(ctx, repository))
+		gotRepository, err := ds.GetRepository(ctx, repository.UID)
+		require.NoError(t, err)
+		assert.Equal(t, repository, gotRepository)
+
+		product := newProduct()
+		product.Generation, product.ResourceVersion, product.Revision = 7, "9", "main@sha1:product"
+		product.CreationActor, product.UpdateTimestamp, product.UpdateActor = "creator", now.Add(time.Minute), "updater"
+		product.CreationTimestamp = now
+		product.Labels, product.Annotations = labels, annotations
+		product.OwnerReferences, product.Finalizers, product.DeletionTimestamp = ownerReferences, finalizers, &deletedAt
+		product.RepositoryID, product.SourcePath, product.GitCommitSHA, product.GitRef = repository.UID, "products/item.md", "product-sha", "refs/heads/main"
+		product.Spec, product.Body, product.Status = spec, "# Product body\n", status
+		require.NoError(t, ds.CreateProduct(ctx, product))
+		gotProduct, err := ds.GetProduct(ctx, product.UID)
+		require.NoError(t, err)
+		assert.Equal(t, product, gotProduct)
+
+		variant := &datastore.ProductVariant{
+			UID: newID(), Namespace: namespace.Name, Name: "variant-" + newID()[:8],
+			APIVersion: "catalog.gitstore.dev/v1beta1", Kind: "ProductVariant",
+			Generation: 7, ResourceVersion: "9", Revision: "main@sha1:variant",
+			CreationTimestamp: now, CreationActor: "creator", UpdateTimestamp: now.Add(time.Minute), UpdateActor: "updater",
+			Labels: labels, Annotations: annotations, OwnerReferences: ownerReferences,
+			Finalizers: finalizers, DeletionTimestamp: &deletedAt,
+			SKU: "sku-" + newID()[:8], ProductRefName: product.Name,
+			RepositoryID: repository.UID, SourcePath: "variants/item.md", GitCommitSHA: "variant-sha", GitRef: "refs/heads/main",
+			Spec: spec, Body: "# Variant body\n", Status: status,
+		}
+		require.NoError(t, ds.CreateProductVariant(ctx, variant))
+		gotVariant, err := ds.GetProductVariant(ctx, variant.UID)
+		require.NoError(t, err)
+		assert.Equal(t, variant, gotVariant)
+
+		collection := newCollection()
+		collection.Namespace, collection.CreationTimestamp = namespace.Name, now
+		collection.Generation, collection.ResourceVersion, collection.Revision = 7, "9", "main@sha1:collection"
+		collection.CreationActor, collection.UpdateTimestamp, collection.UpdateActor = "creator", now.Add(time.Minute), "updater"
+		collection.Labels, collection.Annotations, collection.OwnerReferences = labels, annotations, ownerReferences
+		collection.Finalizers, collection.DeletionTimestamp = finalizers, &deletedAt
+		collection.RepositoryID, collection.SourcePath, collection.GitCommitSHA, collection.GitRef = repository.UID, "collections/item.md", "collection-sha", "refs/heads/main"
+		collection.Spec, collection.Body, collection.Status = spec, "# Collection body\n", status
+		require.NoError(t, ds.CreateCollection(ctx, collection))
+		gotCollection, err := ds.GetCollection(ctx, collection.UID)
+		require.NoError(t, err)
+		assert.Equal(t, collection, gotCollection)
+
+		category := newCategoryTaxonomy()
+		category.Namespace, category.CreationTimestamp = namespace.Name, now
+		category.Generation, category.ResourceVersion, category.Revision = 7, "9", "main@sha1:category"
+		category.CreationActor, category.UpdateTimestamp, category.UpdateActor = "creator", now.Add(time.Minute), "updater"
+		category.Labels, category.Annotations, category.OwnerReferences = labels, annotations, ownerReferences
+		category.Finalizers, category.DeletionTimestamp = finalizers, &deletedAt
+		category.RepositoryID, category.SourcePath, category.GitCommitSHA, category.GitRef = repository.UID, "categories/item.md", "category-sha", "refs/heads/main"
+		category.Spec, category.Body, category.Status = spec, "# Category body\n", status
+		require.NoError(t, ds.CreateCategoryTaxonomy(ctx, category))
+		gotCategory, err := ds.GetCategoryTaxonomy(ctx, category.UID)
+		require.NoError(t, err)
+		assert.Equal(t, category, gotCategory)
+	})
 
 	t.Run("Product/CreateAndGet", func(t *testing.T) {
 		p := newProduct()
@@ -492,9 +623,9 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 		ns := newNamespace(datastore.NamespaceTierUser)
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
 
-		got, err := ds.GetNamespace(ctx, ns.ID)
+		got, err := ds.GetNamespace(ctx, ns.UID)
 		require.NoError(t, err)
-		assert.Equal(t, ns.ID, got.ID)
+		assert.Equal(t, ns.UID, got.UID)
 		assert.Equal(t, ns.Name, got.Name)
 		assert.Equal(t, ns.Tier, got.Tier)
 		assert.Equal(t, ns.CreationActor, got.CreationActor)
@@ -507,6 +638,16 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 		ns2 := newNamespace(datastore.NamespaceTierUser)
 		ns2.Name = ns.Name // same name
 		err := ds.CreateNamespace(ctx, ns2)
+		assert.ErrorIs(t, err, datastore.ErrAlreadyExists)
+	})
+
+	t.Run("Namespace/TestCreateNamespace_duplicateUID", func(t *testing.T) {
+		ns := newNamespace(datastore.NamespaceTierOrganization)
+		require.NoError(t, ds.CreateNamespace(ctx, ns))
+
+		duplicateUID := newNamespace(datastore.NamespaceTierUser)
+		duplicateUID.UID = ns.UID
+		err := ds.CreateNamespace(ctx, duplicateUID)
 		assert.ErrorIs(t, err, datastore.ErrAlreadyExists)
 	})
 
@@ -551,9 +692,9 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 		ns := newNamespace(datastore.NamespaceTierUser)
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
 
-		got, err := ds.GetNamespace(ctx, ns.ID)
+		got, err := ds.GetNamespace(ctx, ns.UID)
 		require.NoError(t, err)
-		assert.Equal(t, ns.ID, got.ID)
+		assert.Equal(t, ns.UID, got.UID)
 	})
 
 	t.Run("Namespace/TestGetNamespaceByName_success", func(t *testing.T) {
@@ -562,7 +703,7 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 
 		got, err := ds.GetNamespaceByName(ctx, ns.Name)
 		require.NoError(t, err)
-		assert.Equal(t, ns.ID, got.ID)
+		assert.Equal(t, ns.UID, got.UID)
 		assert.Equal(t, ns.Name, got.Name)
 	})
 
@@ -576,7 +717,7 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 		ns.Finalizers = []string{datastore.NamespaceForegroundDeletionFinalizer}
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
 
-		got, err := ds.GetNamespace(ctx, ns.ID)
+		got, err := ds.GetNamespace(ctx, ns.UID)
 		require.NoError(t, err)
 		assert.Equal(t, ns.Generation, got.Generation)
 		assert.Equal(t, ns.ResourceVersion, got.ResourceVersion)
@@ -599,7 +740,7 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 		datastore.AdvanceNamespaceSystemVersion(&stale)
 		assert.ErrorIs(t, ds.UpdateNamespace(ctx, &stale, expectedVersion), datastore.ErrConflict)
 
-		got, err := ds.GetNamespace(ctx, ns.ID)
+		got, err := ds.GetNamespace(ctx, ns.UID)
 		require.NoError(t, err)
 		assert.Equal(t, "updated", got.Title)
 		assert.Equal(t, ns.ResourceVersion, got.ResourceVersion)
@@ -608,10 +749,10 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 	t.Run("Namespace/TestDeleteWithResourceVersion", func(t *testing.T) {
 		ns := newNamespace(datastore.NamespaceTierUser)
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
-		assert.ErrorIs(t, ds.DeleteNamespaceWithResourceVersion(ctx, ns.ID, "stale"), datastore.ErrConflict)
-		require.NoError(t, ds.DeleteNamespaceWithResourceVersion(ctx, ns.ID, ns.ResourceVersion))
+		assert.ErrorIs(t, ds.DeleteNamespaceWithResourceVersion(ctx, ns.UID, "stale"), datastore.ErrConflict)
+		require.NoError(t, ds.DeleteNamespaceWithResourceVersion(ctx, ns.UID, ns.ResourceVersion))
 
-		_, err := ds.GetNamespace(ctx, ns.ID)
+		_, err := ds.GetNamespace(ctx, ns.UID)
 		assert.ErrorIs(t, err, datastore.ErrNotFound)
 		_, err = ds.GetNamespaceByName(ctx, ns.Name)
 		assert.ErrorIs(t, err, datastore.ErrNotFound)
@@ -620,9 +761,9 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 	t.Run("Namespace/TestDeleteNamespace_success", func(t *testing.T) {
 		ns := newNamespace(datastore.NamespaceTierUser)
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
-		require.NoError(t, ds.DeleteNamespace(ctx, ns.ID))
+		require.NoError(t, ds.DeleteNamespace(ctx, ns.UID))
 
-		_, err := ds.GetNamespace(ctx, ns.ID)
+		_, err := ds.GetNamespace(ctx, ns.UID)
 		assert.ErrorIs(t, err, datastore.ErrNotFound)
 	})
 
@@ -634,9 +775,9 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 	t.Run("Namespace/TestDeleteNamespace_thenGetReturnsNotFound", func(t *testing.T) {
 		ns := newNamespace(datastore.NamespaceTierOrganization)
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
-		require.NoError(t, ds.DeleteNamespace(ctx, ns.ID))
+		require.NoError(t, ds.DeleteNamespace(ctx, ns.UID))
 
-		_, errID := ds.GetNamespace(ctx, ns.ID)
+		_, errID := ds.GetNamespace(ctx, ns.UID)
 		assert.ErrorIs(t, errID, datastore.ErrNotFound)
 
 		_, errIdent := ds.GetNamespaceByName(ctx, ns.Name)
@@ -647,22 +788,82 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 		ns := newNamespace(datastore.NamespaceTierUser)
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
 
-		has, err := ds.HasRepositories(ctx, ns.ID)
+		has, err := ds.HasRepositories(ctx, ns.Name)
 		require.NoError(t, err)
 		assert.False(t, has)
 
-		repo := newRepository(ns.ID)
+		repo := newRepository(ns.Name)
 		require.NoError(t, ds.CreateRepository(ctx, repo))
 
-		has, err = ds.HasRepositories(ctx, ns.ID)
+		has, err = ds.HasRepositories(ctx, ns.Name)
 		require.NoError(t, err)
 		assert.True(t, has)
 
-		require.NoError(t, ds.DeleteRepository(ctx, repo.ID))
+		require.NoError(t, ds.DeleteRepository(ctx, repo.UID))
 
-		has, err = ds.HasRepositories(ctx, ns.ID)
+		has, err = ds.HasRepositories(ctx, ns.Name)
 		require.NoError(t, err)
 		assert.False(t, has)
+	})
+
+	t.Run("Repository/TestDuplicateUIDAndScopedName", func(t *testing.T) {
+		namespace := "repo-uniqueness-" + newID()[:8]
+		repository := newRepository(namespace)
+		repository.Name = "shared-name"
+		require.NoError(t, ds.CreateRepository(ctx, repository))
+
+		duplicateUID := newRepository(namespace)
+		duplicateUID.UID = repository.UID
+		require.ErrorIs(t, ds.CreateRepository(ctx, duplicateUID), datastore.ErrAlreadyExists)
+
+		duplicateName := newRepository(namespace)
+		duplicateName.Name = repository.Name
+		require.ErrorIs(t, ds.CreateRepository(ctx, duplicateName), datastore.ErrAlreadyExists)
+
+		otherNamespace := newRepository("other-" + namespace)
+		otherNamespace.Name = repository.Name
+		require.NoError(t, ds.CreateRepository(ctx, otherNamespace))
+	})
+
+	t.Run("Repository/TestGlobalListing", func(t *testing.T) {
+		lister, ok := ds.(datastore.GlobalRepositoryLister)
+		require.True(t, ok)
+
+		first := newRepository("global-a-" + newID()[:8])
+		second := newRepository("global-b-" + newID()[:8])
+		first.CreationTimestamp = time.Now().UTC().Add(-time.Second)
+		second.CreationTimestamp = time.Now().UTC()
+		require.NoError(t, ds.CreateRepository(ctx, first))
+		require.NoError(t, ds.CreateRepository(ctx, second))
+
+		result, err := lister.ListRepositories(ctx, datastore.PageParams{First: 1})
+		require.NoError(t, err)
+		require.Len(t, result.Items, 1)
+		assert.True(t, result.HasNext)
+		assert.True(t, result.TotalCount == -1 || result.TotalCount >= 2)
+	})
+
+	t.Run("Repository/TestMappingRenameAndTransfer", func(t *testing.T) {
+		repositoryID := newID()
+		fromNamespace := "mapping-from-" + newID()[:8]
+		toNamespace := "mapping-to-" + newID()[:8]
+		mapping := &datastore.NamespaceMapping{
+			Namespace:    fromNamespace,
+			Name:         "old-name",
+			RepositoryID: repositoryID,
+		}
+		require.NoError(t, ds.CreateNamespaceMapping(ctx, mapping))
+		require.NoError(t, ds.CreateNamespaceMapping(ctx, mapping))
+
+		require.NoError(t, ds.RenameRepository(ctx, fromNamespace, "old-name", "new-name"))
+		_, err := ds.LookupRepository(ctx, fromNamespace, "old-name")
+		require.ErrorIs(t, err, datastore.ErrNotFound)
+
+		require.NoError(t, ds.TransferRepository(ctx, repositoryID, fromNamespace, toNamespace))
+		got, err := ds.LookupRepository(ctx, toNamespace, "new-name")
+		require.NoError(t, err)
+		assert.Equal(t, repositoryID, got.RepositoryID)
+		assert.Equal(t, toNamespace, got.Namespace)
 	})
 
 	// ── HasCatalogResources ───────────────────────────────────────────────────
@@ -670,18 +871,18 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 	t.Run("Repository/TestHasCatalogResources", func(t *testing.T) {
 		ns := newNamespace(datastore.NamespaceTierUser)
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
-		repo := newRepository(ns.ID)
+		repo := newRepository(ns.Name)
 		require.NoError(t, ds.CreateRepository(ctx, repo))
 
-		has, err := ds.HasCatalogResources(ctx, repo.ID)
+		has, err := ds.HasCatalogResources(ctx, repo.UID)
 		require.NoError(t, err)
 		assert.False(t, has)
 
 		p := newProduct()
 		p.Namespace = ns.Name
-		p.RepositoryID = repo.ID
+		p.RepositoryID = repo.UID
 		require.NoError(t, ds.CreateProduct(ctx, p))
-		has, err = ds.HasCatalogResources(ctx, repo.ID)
+		has, err = ds.HasCatalogResources(ctx, repo.UID)
 		require.NoError(t, err)
 		assert.True(t, has)
 		require.NoError(t, ds.DeleteProduct(ctx, p.UID))
@@ -695,33 +896,33 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 			CreationTimestamp: time.Now(),
 			SKU:               "sku-" + newID()[:8],
 			ProductRefName:    "product-" + newID()[:8],
-			RepositoryID:      repo.ID,
+			RepositoryID:      repo.UID,
 		}
 		require.NoError(t, ds.CreateProductVariant(ctx, v))
-		has, err = ds.HasCatalogResources(ctx, repo.ID)
+		has, err = ds.HasCatalogResources(ctx, repo.UID)
 		require.NoError(t, err)
 		assert.True(t, has)
 		require.NoError(t, ds.DeleteProductVariant(ctx, v.UID))
 
 		c := newCategoryTaxonomy()
 		c.Namespace = ns.Name
-		c.RepositoryID = repo.ID
+		c.RepositoryID = repo.UID
 		require.NoError(t, ds.CreateCategoryTaxonomy(ctx, c))
-		has, err = ds.HasCatalogResources(ctx, repo.ID)
+		has, err = ds.HasCatalogResources(ctx, repo.UID)
 		require.NoError(t, err)
 		assert.True(t, has)
 		require.NoError(t, ds.DeleteCategoryTaxonomy(ctx, c.UID))
 
 		coll := newCollection()
 		coll.Namespace = ns.Name
-		coll.RepositoryID = repo.ID
+		coll.RepositoryID = repo.UID
 		require.NoError(t, ds.CreateCollection(ctx, coll))
-		has, err = ds.HasCatalogResources(ctx, repo.ID)
+		has, err = ds.HasCatalogResources(ctx, repo.UID)
 		require.NoError(t, err)
 		assert.True(t, has)
 		require.NoError(t, ds.DeleteCollection(ctx, coll.UID))
 
-		has, err = ds.HasCatalogResources(ctx, repo.ID)
+		has, err = ds.HasCatalogResources(ctx, repo.UID)
 		require.NoError(t, err)
 		assert.False(t, has)
 	})

--- a/gitstore-api/tests/contract/datastore/hardening_helpers_test.go
+++ b/gitstore-api/tests/contract/datastore/hardening_helpers_test.go
@@ -1,0 +1,36 @@
+//go:build scylla
+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package datastore_contract_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var hardeningEpoch = time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+
+func hardeningTimestamp(monthOffset, sequence int) time.Time {
+	return hardeningEpoch.AddDate(0, monthOffset, 0).Add(time.Duration(sequence) * time.Millisecond)
+}
+
+func hardeningNamespace(sequence int) string {
+	return fmt.Sprintf("hardening-%03d", sequence)
+}
+
+func assertStableIDs(t *testing.T, ids []string) {
+	t.Helper()
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			t.Errorf("duplicate stable id %q", id)
+		}
+		seen[id] = struct{}{}
+	}
+	assert.Len(t, seen, len(ids))
+}

--- a/gitstore-api/tests/contract/datastore/hardening_test.go
+++ b/gitstore-api/tests/contract/datastore/hardening_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+//go:build scylla
+
+package datastore_contract_test
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/stretchr/testify/assert"
+)
+
+const concurrentReservationTrials = 100
+
+func TestScyllaConcurrentNameReservationHasOneWinner(t *testing.T) {
+	requireScyllaHardeningEnvironment(t)
+	first, second := newScyllaDatastores(t)
+
+	for trial := 0; trial < concurrentReservationTrials; trial++ {
+		namespace := hardeningNamespace(trial)
+		name := "shared-name"
+		left := hardeningProduct(namespace, name, newID(), trial)
+		right := hardeningProduct(namespace, name, newID(), trial)
+
+		assertOneReservationWinner(t,
+			func() error { return first.CreateProduct(context.Background(), left) },
+			func() error { return second.CreateProduct(context.Background(), right) },
+		)
+	}
+}
+
+func TestScyllaConcurrentUIDReservationHasOneWinner(t *testing.T) {
+	requireScyllaHardeningEnvironment(t)
+	first, second := newScyllaDatastores(t)
+
+	for trial := 0; trial < concurrentReservationTrials; trial++ {
+		namespace := hardeningNamespace(trial + concurrentReservationTrials)
+		uid := newID()
+		left := hardeningProduct(namespace, "left", uid, trial)
+		right := hardeningProduct(namespace, "right", uid, trial)
+
+		assertOneReservationWinner(t,
+			func() error { return first.CreateProduct(context.Background(), left) },
+			func() error { return second.CreateProduct(context.Background(), right) },
+		)
+	}
+}
+
+func TestScyllaConcurrentSKUReservationHasOneWinner(t *testing.T) {
+	requireScyllaHardeningEnvironment(t)
+	first, second := newScyllaDatastores(t)
+
+	for trial := 0; trial < concurrentReservationTrials; trial++ {
+		namespace := hardeningNamespace(trial + 2*concurrentReservationTrials)
+		sku := "shared-sku"
+		left := hardeningVariant(namespace, "left", sku, trial)
+		right := hardeningVariant(namespace, "right", sku, trial)
+
+		assertOneReservationWinner(t,
+			func() error { return first.CreateProductVariant(context.Background(), left) },
+			func() error { return second.CreateProductVariant(context.Background(), right) },
+		)
+	}
+}
+
+func requireScyllaHardeningEnvironment(t *testing.T) {
+	t.Helper()
+	if os.Getenv("GITSTORE_TEST_SCYLLA_ADDR") == "" {
+		t.Skip("GITSTORE_TEST_SCYLLA_ADDR is required for live concurrent Scylla trials")
+	}
+}
+
+func assertOneReservationWinner(t *testing.T, left, right func() error) {
+	t.Helper()
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var workers sync.WaitGroup
+	workers.Add(2)
+	for _, create := range []func() error{left, right} {
+		create := create
+		go func() {
+			defer workers.Done()
+			<-start
+			results <- create()
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(results)
+
+	var succeeded, conflicted int
+	for err := range results {
+		switch {
+		case err == nil:
+			succeeded++
+		case assert.ErrorIs(t, err, datastore.ErrAlreadyExists):
+			conflicted++
+		}
+	}
+	assert.Equal(t, 1, succeeded)
+	assert.Equal(t, 1, conflicted)
+}
+
+func hardeningProduct(namespace, name, uid string, trial int) *datastore.Product {
+	return &datastore.Product{
+		UID:               uid,
+		Namespace:         namespace,
+		Name:              name,
+		APIVersion:        "catalog.gitstore.dev/v1beta1",
+		Kind:              "Product",
+		ResourceVersion:   "1",
+		Generation:        1,
+		CreationTimestamp: hardeningTimestamp(0, trial),
+	}
+}
+
+func hardeningVariant(namespace, name, sku string, trial int) *datastore.ProductVariant {
+	return &datastore.ProductVariant{
+		UID:               newID(),
+		Namespace:         namespace,
+		Name:              name,
+		APIVersion:        "catalog.gitstore.dev/v1beta1",
+		Kind:              "ProductVariant",
+		ResourceVersion:   "1",
+		Generation:        1,
+		CreationTimestamp: hardeningTimestamp(0, trial),
+		SKU:               sku,
+	}
+}

--- a/gitstore-api/tests/contract/datastore/pagination_test.go
+++ b/gitstore-api/tests/contract/datastore/pagination_test.go
@@ -11,6 +11,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -242,16 +244,16 @@ func RunPaginationSuite(t *testing.T, ds datastore.Datastore) {
 		// Cursor at nss[2] (third-newest): verify nss[1] and nss[0] appear in the page.
 		// Global-table tests share state across -count runs, so we check membership by ID
 		// rather than exact length to avoid counting pre-existing rows from earlier runs.
-		cursor := encodeCursor(nss[2].CreationTimestamp, nss[2].ID)
+		cursor := encodeCursor(nss[2].CreationTimestamp, nss[2].UID)
 		page2, err := ds.ListNamespaces(ctx, datastore.PageParams{First: 10, After: cursor})
 		require.NoError(t, err)
 		assert.True(t, page2.HasPrevious)
 		ids := make(map[string]bool, len(page2.Items))
 		for _, ns := range page2.Items {
-			ids[ns.ID] = true
+			ids[ns.UID] = true
 		}
-		assert.True(t, ids[nss[1].ID], "expected nss[1] in page")
-		assert.True(t, ids[nss[0].ID], "expected nss[0] in page")
+		assert.True(t, ids[nss[1].UID], "expected nss[1] in page")
+		assert.True(t, ids[nss[0].UID], "expected nss[0] in page")
 	})
 
 	t.Run("Namespaces/BackwardPagination", func(t *testing.T) {
@@ -285,25 +287,55 @@ func RunPaginationSuite(t *testing.T, ds datastore.Datastore) {
 			require.NoError(t, ds.CreateNamespace(ctx, namespace))
 		}
 
-		afterMarch := encodeCursor(nss[2].CreationTimestamp, nss[2].ID)
+		afterMarch := encodeCursor(nss[2].CreationTimestamp, nss[2].UID)
 		forward, err := ds.ListNamespaces(ctx, datastore.PageParams{First: 100, After: afterMarch})
 		require.NoError(t, err)
 		forwardIDs := make(map[string]bool, len(forward.Items))
 		for _, namespace := range forward.Items {
-			forwardIDs[namespace.ID] = true
+			forwardIDs[namespace.UID] = true
 		}
-		assert.True(t, forwardIDs[nss[1].ID], "expected February namespace after March cursor")
-		assert.True(t, forwardIDs[nss[0].ID], "expected January namespace after March cursor")
+		assert.True(t, forwardIDs[nss[1].UID], "expected February namespace after March cursor")
+		assert.True(t, forwardIDs[nss[0].UID], "expected January namespace after March cursor")
 
-		beforeJanuary := encodeCursor(nss[0].CreationTimestamp, nss[0].ID)
+		beforeJanuary := encodeCursor(nss[0].CreationTimestamp, nss[0].UID)
 		backward, err := ds.ListNamespaces(ctx, datastore.PageParams{Last: 100, Before: beforeJanuary})
 		require.NoError(t, err)
 		backwardIDs := make(map[string]bool, len(backward.Items))
 		for _, namespace := range backward.Items {
-			backwardIDs[namespace.ID] = true
+			backwardIDs[namespace.UID] = true
 		}
-		assert.True(t, backwardIDs[nss[1].ID], "expected February namespace before January cursor")
-		assert.True(t, backwardIDs[nss[2].ID], "expected March namespace before January cursor")
+		assert.True(t, backwardIDs[nss[1].UID], "expected February namespace before January cursor")
+		assert.True(t, backwardIDs[nss[2].UID], "expected March namespace before January cursor")
+	})
+
+	t.Run("Namespaces/ThreeMonthForwardBackwardWithEmptyBucket", func(t *testing.T) {
+		ctx := context.Background()
+		timestamps := threeMonthPaginationTimestamps()
+		namespaces := make([]*datastore.Namespace, len(timestamps))
+		for i, timestamp := range timestamps {
+			namespaces[i] = newNamespace(datastore.NamespaceTierUser)
+			namespaces[i].CreationTimestamp = timestamp
+			namespaces[i].UpdateTimestamp = timestamp
+			require.NoError(t, ds.CreateNamespace(ctx, namespaces[i]))
+		}
+		expected := sortedNamespaceIDs(namespaces)
+
+		forward, err := ds.ListNamespaces(ctx, datastore.PageParams{
+			First: 100,
+			After: encodeCursor(namespaces[0].CreationTimestamp, namespaces[0].UID),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, expected[1:], namespaceTargetIDs(forward.Items, expected))
+		assertPaginationTotalCount(t, ds, forward.TotalCount, int32(len(namespaces)))
+
+		oldest := namespaces[len(namespaces)-1]
+		backward, err := ds.ListNamespaces(ctx, datastore.PageParams{
+			Last:   100,
+			Before: encodeCursor(oldest.CreationTimestamp, oldest.UID),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, expected[:len(expected)-1], namespaceTargetIDs(backward.Items, expected))
+		assertPaginationTotalCount(t, ds, backward.TotalCount, int32(len(namespaces)))
 	})
 
 	t.Run("Repositories/ForwardPagination", func(t *testing.T) {
@@ -313,12 +345,12 @@ func RunPaginationSuite(t *testing.T, ds datastore.Datastore) {
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
 
 		for i := range 5 {
-			r := newRepository(ns.ID)
+			r := newRepository(ns.Name)
 			r.CreationTimestamp = time.Now().Add(time.Duration(i) * time.Second)
 			require.NoError(t, ds.CreateRepository(ctx, r))
 		}
 
-		page1, err := ds.ListRepositoriesByNamespace(ctx, ns.ID, datastore.PageParams{First: 2})
+		page1, err := ds.ListRepositoriesByNamespace(ctx, ns.Name, datastore.PageParams{First: 2})
 		require.NoError(t, err)
 		assert.Len(t, page1.Items, 2)
 		assert.True(t, page1.HasNext)
@@ -328,15 +360,15 @@ func RunPaginationSuite(t *testing.T, ds datastore.Datastore) {
 		assert.True(t, page1.Items[0].CreationTimestamp.After(page1.Items[1].CreationTimestamp) ||
 			page1.Items[0].CreationTimestamp.Equal(page1.Items[1].CreationTimestamp))
 
-		cursor := encodeCursor(page1.Items[1].CreationTimestamp, page1.Items[1].ID)
-		page2, err := ds.ListRepositoriesByNamespace(ctx, ns.ID, datastore.PageParams{First: 2, After: cursor})
+		cursor := encodeCursor(page1.Items[1].CreationTimestamp, page1.Items[1].UID)
+		page2, err := ds.ListRepositoriesByNamespace(ctx, ns.Name, datastore.PageParams{First: 2, After: cursor})
 		require.NoError(t, err)
 		assert.Len(t, page2.Items, 2)
 		assert.True(t, page2.HasNext)
 		assert.True(t, page2.HasPrevious)
 
-		cursor2 := encodeCursor(page2.Items[1].CreationTimestamp, page2.Items[1].ID)
-		page3, err := ds.ListRepositoriesByNamespace(ctx, ns.ID, datastore.PageParams{First: 2, After: cursor2})
+		cursor2 := encodeCursor(page2.Items[1].CreationTimestamp, page2.Items[1].UID)
+		page3, err := ds.ListRepositoriesByNamespace(ctx, ns.Name, datastore.PageParams{First: 2, After: cursor2})
 		require.NoError(t, err)
 		assert.Len(t, page3.Items, 1)
 		assert.False(t, page3.HasNext)
@@ -350,13 +382,13 @@ func RunPaginationSuite(t *testing.T, ds datastore.Datastore) {
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
 
 		for i := range 5 {
-			r := newRepository(ns.ID)
+			r := newRepository(ns.Name)
 			r.CreationTimestamp = time.Now().Add(time.Duration(i) * time.Second)
 			require.NoError(t, ds.CreateRepository(ctx, r))
 		}
 
 		// last:2 without before — oldest 2
-		result, err := ds.ListRepositoriesByNamespace(ctx, ns.ID, datastore.PageParams{Last: 2})
+		result, err := ds.ListRepositoriesByNamespace(ctx, ns.Name, datastore.PageParams{Last: 2})
 		require.NoError(t, err)
 		assert.Len(t, result.Items, 2)
 		assert.False(t, result.HasNext)
@@ -371,19 +403,19 @@ func RunPaginationSuite(t *testing.T, ds datastore.Datastore) {
 
 		repos := make([]*datastore.Repository, 5)
 		for i := range 5 {
-			repos[i] = newRepository(ns.ID)
+			repos[i] = newRepository(ns.Name)
 			repos[i].CreationTimestamp = time.Now().Add(time.Duration(i) * time.Second)
 			require.NoError(t, ds.CreateRepository(ctx, repos[i]))
 		}
 
 		// Get page to find a mid-point cursor
-		page1, err := ds.ListRepositoriesByNamespace(ctx, ns.ID, datastore.PageParams{First: 3})
+		page1, err := ds.ListRepositoriesByNamespace(ctx, ns.Name, datastore.PageParams{First: 3})
 		require.NoError(t, err)
 		require.Len(t, page1.Items, 3)
 
 		// Go backward from the 3rd item
-		beforeCursor := encodeCursor(page1.Items[2].CreationTimestamp, page1.Items[2].ID)
-		backward, err := ds.ListRepositoriesByNamespace(ctx, ns.ID, datastore.PageParams{Last: 2, Before: beforeCursor})
+		beforeCursor := encodeCursor(page1.Items[2].CreationTimestamp, page1.Items[2].UID)
+		backward, err := ds.ListRepositoriesByNamespace(ctx, ns.Name, datastore.PageParams{Last: 2, Before: beforeCursor})
 		require.NoError(t, err)
 		assert.Len(t, backward.Items, 2)
 		assert.True(t, backward.HasNext) // items exist after the before cursor
@@ -399,19 +431,87 @@ func RunPaginationSuite(t *testing.T, ds datastore.Datastore) {
 
 		// 3 repos in ns1, 2 in ns2
 		for range 3 {
-			require.NoError(t, ds.CreateRepository(ctx, newRepository(ns1.ID)))
+			require.NoError(t, ds.CreateRepository(ctx, newRepository(ns1.Name)))
 		}
 		for range 2 {
-			require.NoError(t, ds.CreateRepository(ctx, newRepository(ns2.ID)))
+			require.NoError(t, ds.CreateRepository(ctx, newRepository(ns2.Name)))
 		}
 
-		r1, err := ds.ListRepositoriesByNamespace(ctx, ns1.ID, datastore.PageParams{})
+		r1, err := ds.ListRepositoriesByNamespace(ctx, ns1.Name, datastore.PageParams{})
 		require.NoError(t, err)
 		assert.Len(t, r1.Items, 3)
 
-		r2, err := ds.ListRepositoriesByNamespace(ctx, ns2.ID, datastore.PageParams{})
+		r2, err := ds.ListRepositoriesByNamespace(ctx, ns2.Name, datastore.PageParams{})
 		require.NoError(t, err)
 		assert.Len(t, r2.Items, 2)
+	})
+
+	t.Run("Repositories/ThreeMonthNamespaceScopedForwardBackwardWithEmptyBucket", func(t *testing.T) {
+		ctx := context.Background()
+		namespace := newNamespace(datastore.NamespaceTierUser)
+		require.NoError(t, ds.CreateNamespace(ctx, namespace))
+
+		timestamps := threeMonthPaginationTimestamps()
+		repositories := make([]*datastore.Repository, len(timestamps))
+		for i, timestamp := range timestamps {
+			repositories[i] = newRepository(namespace.Name)
+			repositories[i].CreationTimestamp = timestamp
+			repositories[i].UpdateTimestamp = timestamp
+			require.NoError(t, ds.CreateRepository(ctx, repositories[i]))
+		}
+		expected := sortedRepositoryIDs(repositories)
+
+		forward, err := ds.ListRepositoriesByNamespace(ctx, namespace.Name, datastore.PageParams{
+			First: 100,
+			After: encodeCursor(repositories[0].CreationTimestamp, repositories[0].UID),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, expected[1:], repositoryTargetIDs(forward.Items, expected))
+		assertPaginationTotalCount(t, ds, forward.TotalCount, int32(len(repositories)))
+
+		oldest := repositories[len(repositories)-1]
+		backward, err := ds.ListRepositoriesByNamespace(ctx, namespace.Name, datastore.PageParams{
+			Last:   100,
+			Before: encodeCursor(oldest.CreationTimestamp, oldest.UID),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, expected[:len(expected)-1], repositoryTargetIDs(backward.Items, expected))
+		assertPaginationTotalCount(t, ds, backward.TotalCount, int32(len(repositories)))
+	})
+
+	t.Run("Repositories/ThreeMonthGlobalForwardBackwardWithEmptyBucket", func(t *testing.T) {
+		ctx := context.Background()
+		global, ok := ds.(datastore.GlobalRepositoryLister)
+		require.True(t, ok, "%T must implement datastore.GlobalRepositoryLister", ds)
+
+		namespace := newNamespace(datastore.NamespaceTierUser)
+		require.NoError(t, ds.CreateNamespace(ctx, namespace))
+		timestamps := threeMonthPaginationTimestamps()
+		repositories := make([]*datastore.Repository, len(timestamps))
+		for i, timestamp := range timestamps {
+			repositories[i] = newRepository(namespace.Name)
+			repositories[i].CreationTimestamp = timestamp
+			repositories[i].UpdateTimestamp = timestamp
+			require.NoError(t, ds.CreateRepository(ctx, repositories[i]))
+		}
+		expected := sortedRepositoryIDs(repositories)
+
+		forward, err := global.ListRepositories(ctx, datastore.PageParams{
+			First: 100,
+			After: encodeCursor(repositories[0].CreationTimestamp, repositories[0].UID),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, expected[1:], repositoryTargetIDs(forward.Items, expected))
+		assertPaginationTotalCount(t, ds, forward.TotalCount, int32(len(repositories)))
+
+		oldest := repositories[len(repositories)-1]
+		backward, err := global.ListRepositories(ctx, datastore.PageParams{
+			Last:   100,
+			Before: encodeCursor(oldest.CreationTimestamp, oldest.UID),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, expected[:len(expected)-1], repositoryTargetIDs(backward.Items, expected))
+		assertPaginationTotalCount(t, ds, backward.TotalCount, int32(len(repositories)))
 	})
 
 	t.Run("EmptyResult/Products", func(t *testing.T) {
@@ -428,7 +528,7 @@ func RunPaginationSuite(t *testing.T, ds datastore.Datastore) {
 		ns := newNamespace(datastore.NamespaceTierUser)
 		require.NoError(t, ds.CreateNamespace(ctx, ns))
 
-		result, err := ds.ListRepositoriesByNamespace(ctx, ns.ID, datastore.PageParams{First: 10})
+		result, err := ds.ListRepositoriesByNamespace(ctx, ns.Name, datastore.PageParams{First: 10})
 		require.NoError(t, err)
 		assert.Empty(t, result.Items)
 		assert.False(t, result.HasNext)
@@ -502,11 +602,11 @@ func newCategoryTaxonomyInNS(ns string) *datastore.CategoryTaxonomy {
 	}
 }
 
-func newRepository(namespaceID string) *datastore.Repository {
+func newRepository(namespace string) *datastore.Repository {
 	now := time.Now()
 	return &datastore.Repository{
-		ID:                newID(),
-		NamespaceID:       namespaceID,
+		UID:               newID(),
+		Namespace:         namespace,
 		Name:              "repo-" + newID()[:8],
 		DefaultBranch:     "main",
 		StorageClass:      "local",
@@ -515,4 +615,84 @@ func newRepository(namespaceID string) *datastore.Repository {
 		UpdateTimestamp:   now,
 		UpdateActor:       "test-user",
 	}
+}
+
+func threeMonthPaginationTimestamps() []time.Time {
+	now := time.Now().UTC()
+	currentMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	middleMonth := currentMonth.AddDate(0, -2, 0)
+	oldestMonth := currentMonth.AddDate(0, -3, 0)
+	return []time.Time{
+		currentMonth.AddDate(0, 1, 0).Add(-time.Millisecond),
+		middleMonth.AddDate(0, 0, 15),
+		middleMonth.AddDate(0, 0, 15),
+		oldestMonth.AddDate(0, 0, 10),
+	}
+}
+
+func sortedNamespaceIDs(items []*datastore.Namespace) []string {
+	sorted := append([]*datastore.Namespace(nil), items...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].CreationTimestamp.Equal(sorted[j].CreationTimestamp) {
+			return sorted[i].UID > sorted[j].UID
+		}
+		return sorted[i].CreationTimestamp.After(sorted[j].CreationTimestamp)
+	})
+	ids := make([]string, len(sorted))
+	for i, item := range sorted {
+		ids[i] = item.UID
+	}
+	return ids
+}
+
+func sortedRepositoryIDs(items []*datastore.Repository) []string {
+	sorted := append([]*datastore.Repository(nil), items...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].CreationTimestamp.Equal(sorted[j].CreationTimestamp) {
+			return sorted[i].UID > sorted[j].UID
+		}
+		return sorted[i].CreationTimestamp.After(sorted[j].CreationTimestamp)
+	})
+	ids := make([]string, len(sorted))
+	for i, item := range sorted {
+		ids[i] = item.UID
+	}
+	return ids
+}
+
+func namespaceTargetIDs(items []*datastore.Namespace, targetIDs []string) []string {
+	targets := make(map[string]struct{}, len(targetIDs))
+	for _, id := range targetIDs {
+		targets[id] = struct{}{}
+	}
+	var ids []string
+	for _, item := range items {
+		if _, ok := targets[item.UID]; ok {
+			ids = append(ids, item.UID)
+		}
+	}
+	return ids
+}
+
+func repositoryTargetIDs(items []*datastore.Repository, targetIDs []string) []string {
+	targets := make(map[string]struct{}, len(targetIDs))
+	for _, id := range targetIDs {
+		targets[id] = struct{}{}
+	}
+	var ids []string
+	for _, item := range items {
+		if _, ok := targets[item.UID]; ok {
+			ids = append(ids, item.UID)
+		}
+	}
+	return ids
+}
+
+func assertPaginationTotalCount(t *testing.T, ds datastore.Datastore, got, minimum int32) {
+	t.Helper()
+	if strings.Contains(fmt.Sprintf("%T", ds), "scylla.") {
+		assert.Equal(t, int32(-1), got, "Scylla must not scan historical buckets for an exact count")
+		return
+	}
+	assert.GreaterOrEqual(t, got, minimum, "backend-neutral stores may provide an exact count")
 }

--- a/gitstore-api/tests/contract/datastore/scylla_test.go
+++ b/gitstore-api/tests/contract/datastore/scylla_test.go
@@ -152,6 +152,11 @@ func newScyllaDatastore(t *testing.T) datastore.Datastore {
 	return store
 }
 
+func newScyllaDatastores(t *testing.T) (datastore.Datastore, datastore.Datastore) {
+	t.Helper()
+	return newScyllaDatastore(t), newScyllaDatastore(t)
+}
+
 func TestContractScylla(t *testing.T) {
 	RunContractSuite(t, newScyllaDatastore(t))
 }


### PR DESCRIPTION
Stack 2/4, based on #363.

- replaces scan/index paths with bounded Scylla projections and monthly pagination
- adds LWT reservations, compensating mutation execution, and recoverable repository sagas
- adds projection audit/repair tooling, metrics, failure injection, and capacity contracts

Validation: datastore, repair CLI, and tagged Scylla suites.

Closes #355
Closes #356
Closes #357
Closes #358