### PR TITLE
fix(ci): activate prerelease versioning and bound initial release history

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,9 @@
     ".": {
       "release-type": "simple",
       "versioning": "prerelease",
+      "prerelease": true,
+      "prerelease-type": "alpha",
+      "bootstrap-sha": "c761c09be1dff570ffa781748704d523a973d178",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "c761c09be1dff570ffa781748704d523a973d178",
   "packages": {
     ".": {
       "release-type": "simple",
       "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "alpha",
-      "bootstrap-sha": "c761c09be1dff570ffa781748704d523a973d178",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- PR #385 (the first release-please PR) proposed `0.1.0` with a changelog spanning the entire repo's history — not `0.0.1-alpha.1` as designed. Both root causes verified against release-please's actual JSON schema (`schemas/config.json`), not assumed:
  - `versioning: "prerelease"` alone doesn't activate prerelease version-string computation — a separate `"prerelease": true` boolean is required (schema: *"A prerelease version number will only be created if the prerelease setting is set to true. Default: false."*). Without it, the `feat:` commit in #384 just did a normal minor bump from the `0.0.1` base, ignoring the `-alpha.0` qualifier — exactly what happened.
  - No `bootstrap-sha` was set, so it walked the entire commit history for the "initial release." Added `bootstrap-sha` pinned to `c761c09` (main's tip immediately before #384 merged).
- Also added `prerelease-type: "alpha"` for explicitness.

## Follow-up needed after merge
PR #385 ("chore(main): release 0.1.0") needs to be closed (or will hopefully self-correct once release-please re-runs against this config and force-syncs its own branch — will verify either way after merge).

## Test plan
- [x] Verified both root causes against `release-please`'s actual schema file, not memory/assumption.
- [x] JSON syntax validated.
- [ ] After merge: confirm release-please.yml re-runs and either updates #385 to `0.0.1-alpha.1` with a bounded changelog, or opens a fresh corrected PR (closing #385 manually if it doesn't self-correct).