### PR TITLE
fix(ci): don't emit an invalid sha tag on tag-triggered builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,7 +106,7 @@ jobs:
           type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
-          type=sha,prefix={{branch}}-
+          type=sha,prefix={{branch}}-,enable=${{ github.ref_type == 'branch' }}
 
     - name: Build and push Git Service image
       uses: docker/build-push-action@v7
@@ -158,7 +158,7 @@ jobs:
           type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
-          type=sha,prefix={{branch}}-
+          type=sha,prefix={{branch}}-,enable=${{ github.ref_type == 'branch' }}
 
     - name: Build and push API image
       uses: docker/build-push-action@v7
@@ -210,7 +210,7 @@ jobs:
           type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
-          type=sha,prefix={{branch}}-
+          type=sha,prefix={{branch}}-,enable=${{ github.ref_type == 'branch' }}
 
     - name: Build and push Admin image
       uses: docker/build-push-action@v7
@@ -262,7 +262,7 @@ jobs:
           type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
-          type=sha,prefix={{branch}}-
+          type=sha,prefix={{branch}}-,enable=${{ github.ref_type == 'branch' }}
 
     - name: Build and push Controller Manager image
       uses: docker/build-push-action@v7

--- a/gitstore-git-service/Cargo.lock
+++ b/gitstore-git-service/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "git-service"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Summary
The `v0.1.0-alpha.1` tag push failed all 4 image builds: `invalid tag "ghcr.io/gitstore-dev/git-service:-4b35282": invalid reference format`.

**Root cause**: `type=sha,prefix={{branch}}-` assumes `{{branch}}` is always non-empty. On a tag-triggered push (not a branch push), it resolves to an empty string, producing a tag that's just `-<sha>` — Docker rejects any tag starting with a hyphen. This is a **pre-existing bug in `cd.yml`, unrelated to Release Please** — it just never got exercised before because this was the first real tag ever pushed to this repo.

**Fix**: gate that tag pattern to branch pushes only via `enable=${{ github.ref_type == 'branch' }}` — a documented `docker/metadata-action` global attribute (verified against its README), applied to all 4 image jobs. Tag-triggered builds already get a proper semver tag; they don't need a sha-based one.

Also includes `Cargo.lock` catching up to `Cargo.toml`'s version bump (`0.1.0-alpha.1`) from the merged release PR.

## What about the already-failed v0.1.0-alpha.1 build?
Tags are immutable and this fix lands after that tag's commit, so its build will always use the old broken workflow — re-running that specific run won't help. Recommend: once this merges, the *next* release (a `fix:`-type commit like this one just bumps the alpha counter to `0.1.0-alpha.2`, per the prerelease versioning strategy) will build correctly. Separately, want me to delete the `v0.1.0-alpha.1` tag/release since it never actually published any images? That's your call — it's a destructive action I won't do unprompted.

## Test plan
- [x] Verified `enable=` is a valid, documented global attribute for all `docker/metadata-action` tag types before applying.
- [x] YAML validated.
- [ ] After merge + next release: confirm the tag-triggered `cd.yml` run succeeds and produces valid, correctly-tagged images.