### PR TITLE
fix: de-flake CategoryTaxonomy cycle detection and Collection push tests

### DIFF
--- a/gitstore-controller-manager/internal/categorytaxonomy/reconciler.go
+++ b/gitstore-controller-manager/internal/categorytaxonomy/reconciler.go
@@ -161,6 +161,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key types.WorkItemKey) types
 
 	parentResolvedCond := computeParentResolved(r.cache, current)
 	acyclicCond := computeAcyclic(inCycle[current.Name])
+	acyclicChanged := conditionStatusByType(current.Status.Conditions, conditionAcyclic) != acyclicCond.Status
 	fileRefCond := computeFileRefCondition(current)
 	readyCond := computeReady(parentResolvedCond, acyclicCond, fileRefCond)
 
@@ -207,7 +208,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, key types.WorkItemKey) types
 		return r.reconcileDeletion(ctx, current)
 	}
 
-	if !inCycle[current.Name] && hierarchyChanged(previous, resolved) {
+	// Re-enqueue whatever points at this node (its children per ParentRefName,
+	// or — for a cycle participant — the other cycle member(s), since a
+	// cycle's edges mean each participant is also the other's "child") on
+	// either a structural change or an Acyclic transition. Gating solely on
+	// hierarchyChanged missed the case where a cycle participant flips
+	// Acyclic without a Depth/Path change (FR-008 freezes those while
+	// cycling), leaving affected nodes stuck on stale conditions until an
+	// unrelated event happened to re-trigger them.
+	if hierarchyChanged(previous, resolved) || acyclicChanged {
 		r.reenqueueChildren(key)
 	}
 
@@ -271,6 +280,15 @@ func preserveLastTransitionTimes(fresh []*status.Condition, prior []*status.Cond
 			f.LastTransitionTime = p.LastTransitionTime
 		}
 	}
+}
+
+func conditionStatusByType(conditions []*status.Condition, condType string) string {
+	for _, c := range conditions {
+		if c != nil && c.Type == condType {
+			return c.Status
+		}
+	}
+	return ""
 }
 
 func hierarchyChanged(previous *ResolvedCategoryTaxonomy, current ResolvedCategoryTaxonomy) bool {

--- a/gitstore-controller-manager/internal/categorytaxonomy/reconciler.go
+++ b/gitstore-controller-manager/internal/categorytaxonomy/reconciler.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/cache"
@@ -161,7 +162,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, key types.WorkItemKey) types
 
 	parentResolvedCond := computeParentResolved(r.cache, current)
 	acyclicCond := computeAcyclic(inCycle[current.Name])
-	acyclicChanged := conditionStatusByType(current.Status.Conditions, conditionAcyclic) != acyclicCond.Status
+	// Case-insensitive: current.Status.Conditions comes from the real
+	// GraphQL list/watch path, where ConditionStatus is the enum wire
+	// value ("TRUE"/"FALSE"); acyclicCond.Status uses this package's
+	// internal "True"/"False" constants, normalized to the enum casing
+	// only later, on write, by graphql_status_client.go's
+	// normalizeConditionStatus. A case-sensitive compare here would never
+	// match against real traffic, making this always true and turning
+	// the reenqueue below into an unconditional one on every reconcile.
+	acyclicChanged := !strings.EqualFold(conditionStatusByType(current.Status.Conditions, conditionAcyclic), acyclicCond.Status)
 	fileRefCond := computeFileRefCondition(current)
 	readyCond := computeReady(parentResolvedCond, acyclicCond, fileRefCond)
 

--- a/tests/integration/collection_test.go
+++ b/tests/integration/collection_test.go
@@ -213,6 +213,46 @@ func queryCollection(t *testing.T, namespace, name string) *collectionQueryResul
 	return data.Collection
 }
 
+// tryQueryCollection is queryCollection without the fatal-on-GraphQL-error
+// behavior, so a poll loop can tolerate a transient "not found" (the
+// collection's own existence, not just its status, races the GraphQL read
+// path immediately after push) instead of dying on the first attempt.
+func tryQueryCollection(t *testing.T, namespace, name string) (*collectionQueryResult, []json.RawMessage) {
+	t.Helper()
+	resp := gqlQuery(t, `
+		query($namespace: String!, $name: String!) {
+			collection(by: {namespacePath: {namespace: $namespace, name: $name}}) {
+				id
+				apiVersion
+				kind
+				metadata { name uid }
+				spec { title }
+				status {
+					observedGeneration
+					lastAppliedRevision
+					conditions { type status reason message observedGeneration }
+					resolved { memberCount }
+				}
+				products(first: 50) {
+					edges { node { metadata { name } } }
+					pageInfo { hasNextPage }
+					totalCount
+				}
+			}
+		}
+	`, map[string]any{"namespace": namespace, "name": name})
+	if len(resp.Errors) > 0 {
+		return nil, resp.Errors
+	}
+	var data struct {
+		Collection *collectionQueryResult `json:"collection"`
+	}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("unmarshal collection response: %v", err)
+	}
+	return data.Collection, nil
+}
+
 // findCondition returns the first condition with the given type, or nil.
 func findCondition(conditions []collectionCondition, condType string) *collectionCondition {
 	for i := range conditions {
@@ -220,6 +260,35 @@ func findCondition(conditions []collectionCondition, condType string) *collectio
 			return &conditions[i]
 		}
 	}
+	return nil
+}
+
+// waitForCollectionStatus polls until name's status satisfies want, or fails
+// the test after timeout. Admission-time status writeback races the
+// GraphQL read path under load, so a fixed sleep before the first (and
+// only) query is not reliable — see waitForResolved in
+// categorytaxonomy_reconciler_test.go for the same pattern.
+func waitForCollectionStatus(t *testing.T, namespace, name string, timeout time.Duration, want func(*collectionQueryResult) bool) *collectionQueryResult {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last *collectionQueryResult
+	var lastErrs []json.RawMessage
+	for time.Now().Before(deadline) {
+		coll, errs := tryQueryCollection(t, namespace, name)
+		if len(errs) == 0 {
+			last, lastErrs = coll, nil
+			if last != nil && last.Status != nil && want(last) {
+				return last
+			}
+		} else {
+			lastErrs = errs
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if len(lastErrs) > 0 {
+		t.Fatalf("timed out after %s waiting for collection %q to become queryable; last graphql errors: %s", timeout, name, lastErrs)
+	}
+	t.Fatalf("timed out after %s waiting for collection %q's status to satisfy the expected condition; last observed: %+v", timeout, name, last)
 	return nil
 }
 
@@ -237,25 +306,16 @@ func TestCollection_ValidPushAccepted(t *testing.T) {
 		t.Fatalf("expected push to succeed for valid collection, got error:\n%s", out)
 	}
 
-	time.Sleep(500 * time.Millisecond)
-
-	coll := queryCollection(t, ns, name)
-	if coll == nil {
-		t.Fatalf("collection %q not found after push", name)
-	}
+	coll := waitForCollectionStatus(t, ns, name, 10*time.Second, func(c *collectionQueryResult) bool {
+		return findCondition(c.Status.Conditions, "AdmissionAccepted") != nil
+	})
 	if coll.Kind != "Collection" {
 		t.Errorf("kind: got %q, want %q", coll.Kind, "Collection")
 	}
 	if coll.Spec.Title != name {
 		t.Errorf("spec.title: got %q, want %q", coll.Spec.Title, name)
 	}
-	if coll.Status == nil {
-		t.Fatal("status is nil, expected populated status after admission")
-	}
 	admitted := findCondition(coll.Status.Conditions, "AdmissionAccepted")
-	if admitted == nil {
-		t.Fatalf("AdmissionAccepted condition not found in: %+v", coll.Status.Conditions)
-	}
 	if admitted.Status != "TRUE" {
 		t.Errorf("AdmissionAccepted condition status: got %q, want %q", admitted.Status, "TRUE")
 	}


### PR DESCRIPTION
## Summary
- Fixed a real bug in the CategoryTaxonomy reconciler: `reenqueueChildren` was only triggered by a Depth/Path change, so a node transitioning into/out of a cycle (Acyclic flips without a Depth/Path change per FR-008) never notified dependents — they'd stay stuck on stale Ready/Acyclic conditions until an unrelated event happened to re-trigger them. Now also re-enqueues on an Acyclic-status transition.
- Replaced `TestCollection_ValidPushAccepted`'s fixed 500ms-sleep-then-single-query (which hard-fails on any GraphQL error, including a transient "not found" immediately after push) with a poll loop that tolerates the race until the collection becomes queryable, mirroring the existing `waitForResolved` pattern used by the CategoryTaxonomy reconciler tests.

## Test plan
- [x] `go test ./internal/categorytaxonomy/...` (unit) — pass
- [x] Full local `ci-integration.yml`-equivalent memdb stack (docker compose + bootstrap + seed) — full suite green on first run
- [x] `TestCategoryTaxonomyReconciler_CycleDetection` — 5x isolated reruns, all pass
- [x] `TestCollection_ValidPushAccepted` — 5x isolated reruns, all pass
- [x] No regressions in `TestCategoryTaxonomyReconciler_DepthThreeHierarchy` / `RequiredFileReferenceCondition` from the reenqueue change

## Note
Repeated local stress-reruns against the same persistent seeded repo surfaced two *unrelated* pre-existing flakes not touched by this PR: `TestAdmission_BranchDeletion` (a fixture-name collision from `TestDocumentationExamples_ParseCorrectly` reusing a non-unique product name across runs) and `TestCollection_SelectorDoesNotExist` (likely similar state-pollution from repeated local runs). Neither reproduces against a fresh repo (i.e. CI), and neither is in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)