### PR TITLE
fix: scope resource deletion to owning ref, de-flake DoesNotExist selector test

### DIFF
--- a/gitstore-api/internal/cataloggrpc/server.go
+++ b/gitstore-api/internal/cataloggrpc/server.go
@@ -811,7 +811,7 @@ func (s *Server) applyResourceOperations(ctx context.Context, ops []resourceAdmi
 		return err
 	}
 	for _, op := range deletes {
-		if err := s.deleteResource(ctx, op.identity); err != nil {
+		if err := s.deleteResource(ctx, op.identity, admCtx.RefName); err != nil {
 			return err
 		}
 	}
@@ -976,7 +976,7 @@ func (s *Server) lookupResourceByIdentity(ctx context.Context, id resourceIdenti
 
 var errCategoryDeletionBlocked = errors.New("category deletion blocked by child categories")
 
-func (s *Server) deleteResource(ctx context.Context, id resourceIdentity) error {
+func (s *Server) deleteResource(ctx context.Context, id resourceIdentity, refName string) error {
 	existing, err := s.lookupResourceByIdentity(ctx, id)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
@@ -992,6 +992,24 @@ func (s *Server) deleteResource(ctx context.Context, id resourceIdentity) error 
 			zap.String("name", id.Name),
 			zap.Error(err))
 		return fmt.Errorf("delete %s %s/%s: %w", id.Kind, id.Namespace, id.Name, err)
+	}
+
+	// A branch deletion's changed_paths covers every path in the deleted
+	// ref's final tree (git-service's compute_changed_paths), including
+	// files inherited unchanged from another still-live ref (e.g. a
+	// feature branch's full tree, which also contains everything already
+	// on main). Only actually delete when this resource's own
+	// last-admitted ref matches the ref being deleted -- otherwise it is
+	// still legitimately reachable elsewhere and this is a phantom
+	// deletion from the deleted ref's now-irrelevant tree contents.
+	if ownRef, ok := resourceGitRef(existing); ok && refName != "" && ownRef != refName {
+		s.log.Info("admit_resources: delete skipped; resource owned by a different ref",
+			zap.String("kind", id.Kind),
+			zap.String("namespace", id.Namespace),
+			zap.String("name", id.Name),
+			zap.String("deleted_ref", refName),
+			zap.String("owning_ref", ownRef))
+		return nil
 	}
 
 	var uid string
@@ -1072,6 +1090,28 @@ func (s *Server) deleteResource(ctx context.Context, id resourceIdentity) error 
 		zap.String("name", id.Name),
 		zap.String("uid", uid))
 	return nil
+}
+
+// resourceGitRef returns existing's GitRef field and true, or "", false for
+// a kind that has no GitRef (none currently -- kept defensive for future
+// kinds added to lookupResourceByIdentity without one).
+func resourceGitRef(existing any) (string, bool) {
+	switch r := existing.(type) {
+	case *datastore.Product:
+		return r.GitRef, true
+	case *datastore.CategoryTaxonomy:
+		return r.GitRef, true
+	case *datastore.Collection:
+		return r.GitRef, true
+	case *datastore.ProductVariant:
+		return r.GitRef, true
+	case *datastore.File:
+		return r.GitRef, true
+	case *datastore.Namespace:
+		return r.GitRef, true
+	default:
+		return "", false
+	}
 }
 
 // detectCycles delegates to the admission/catalog package implementation.

--- a/gitstore-api/internal/cataloggrpc/server.go
+++ b/gitstore-api/internal/cataloggrpc/server.go
@@ -811,7 +811,7 @@ func (s *Server) applyResourceOperations(ctx context.Context, ops []resourceAdmi
 		return err
 	}
 	for _, op := range deletes {
-		if err := s.deleteResource(ctx, op.identity, admCtx.RefName); err != nil {
+		if err := s.deleteResource(ctx, op.identity, admCtx.RepositoryID, admCtx.RefName); err != nil {
 			return err
 		}
 	}
@@ -976,7 +976,7 @@ func (s *Server) lookupResourceByIdentity(ctx context.Context, id resourceIdenti
 
 var errCategoryDeletionBlocked = errors.New("category deletion blocked by child categories")
 
-func (s *Server) deleteResource(ctx context.Context, id resourceIdentity, refName string) error {
+func (s *Server) deleteResource(ctx context.Context, id resourceIdentity, repositoryID, refName string) error {
 	existing, err := s.lookupResourceByIdentity(ctx, id)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
@@ -999,15 +999,22 @@ func (s *Server) deleteResource(ctx context.Context, id resourceIdentity, refNam
 	// files inherited unchanged from another still-live ref (e.g. a
 	// feature branch's full tree, which also contains everything already
 	// on main). Only actually delete when this resource's own
-	// last-admitted ref matches the ref being deleted -- otherwise it is
-	// still legitimately reachable elsewhere and this is a phantom
-	// deletion from the deleted ref's now-irrelevant tree contents.
-	if ownRef, ok := resourceGitRef(existing); ok && refName != "" && ownRef != refName {
-		s.log.Info("admit_resources: delete skipped; resource owned by a different ref",
+	// last-admitted repository AND ref match the ones being deleted --
+	// otherwise it is still legitimately reachable elsewhere and this is
+	// a phantom deletion from the deleted ref's now-irrelevant tree
+	// contents. Both must match: resource identity (namespace, kind,
+	// name) is not scoped by repository, so two repositories in the same
+	// namespace using the same ref name (e.g. both "refs/heads/main")
+	// could otherwise collide on the ref check alone.
+	if ownRepo, ownRef, ok := resourceOwnership(existing); ok && refName != "" &&
+		(ownRepo != repositoryID || ownRef != refName) {
+		s.log.Info("admit_resources: delete skipped; resource owned by a different repository/ref",
 			zap.String("kind", id.Kind),
 			zap.String("namespace", id.Namespace),
 			zap.String("name", id.Name),
+			zap.String("deleted_repository", repositoryID),
 			zap.String("deleted_ref", refName),
+			zap.String("owning_repository", ownRepo),
 			zap.String("owning_ref", ownRef))
 		return nil
 	}
@@ -1092,25 +1099,24 @@ func (s *Server) deleteResource(ctx context.Context, id resourceIdentity, refNam
 	return nil
 }
 
-// resourceGitRef returns existing's GitRef field and true, or "", false for
-// a kind that has no GitRef (none currently -- kept defensive for future
-// kinds added to lookupResourceByIdentity without one).
-func resourceGitRef(existing any) (string, bool) {
+// resourceOwnership returns existing's (RepositoryID, GitRef) and true, or
+// ("", "", false) for a kind that has no such fields (Namespace isn't
+// scoped to a single repository, and deleteResource's Namespace case
+// returns before this check runs anyway).
+func resourceOwnership(existing any) (string, string, bool) {
 	switch r := existing.(type) {
 	case *datastore.Product:
-		return r.GitRef, true
+		return r.RepositoryID, r.GitRef, true
 	case *datastore.CategoryTaxonomy:
-		return r.GitRef, true
+		return r.RepositoryID, r.GitRef, true
 	case *datastore.Collection:
-		return r.GitRef, true
+		return r.RepositoryID, r.GitRef, true
 	case *datastore.ProductVariant:
-		return r.GitRef, true
+		return r.RepositoryID, r.GitRef, true
 	case *datastore.File:
-		return r.GitRef, true
-	case *datastore.Namespace:
-		return r.GitRef, true
+		return r.RepositoryID, r.GitRef, true
 	default:
-		return "", false
+		return "", "", false
 	}
 }
 

--- a/tests/integration/collection_test.go
+++ b/tests/integration/collection_test.go
@@ -699,27 +699,20 @@ func TestCollection_SelectorDoesNotExist(t *testing.T) {
 	if out, err := hColl.push(); err != nil {
 		t.Fatalf("collection push failed:\n%s", out)
 	}
-	time.Sleep(500 * time.Millisecond)
 
-	coll := queryCollection(t, ns, collName)
-	if coll == nil {
-		t.Fatal("collection not found")
-	}
+	coll := waitForCollectionStatus(t, ns, collName, 10*time.Second, func(c *collectionQueryResult) bool {
+		for _, n := range productNamesFromEdges(c) {
+			if n == noSaleProduct {
+				return true
+			}
+		}
+		return false
+	})
 	names := productNamesFromEdges(coll)
 	for _, n := range names {
 		if n == saleProduct {
 			t.Errorf("sale product (has label) should be excluded by DoesNotExist selector, but was found")
 		}
-	}
-	found := false
-	for _, n := range names {
-		if n == noSaleProduct {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("no-sale product should be included by DoesNotExist selector, but was not found")
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Real correctness bug**: deleting a branch deleted every resource in that branch's *entire tree*, not just resources unique to it — because git-service's `compute_changed_paths` for a branch deletion (zero new-oid) returns every path in the deleted ref's final tree, including files inherited unchanged from another still-live ref (e.g. a feature branch created from `main` contains `main`'s files too). `deleteResource` had no ref-ownership check before actually deleting.
  - Confirmed via logs, deterministically: deleting a feature branch created from `main` also deleted `main`'s own product on every single run. The existing `TestAdmission_BranchDeletion` test only caught this ~20% of the time, because its read-after-delete query usually raced ahead of the deletion's visibility and masked the bug (the failure symptom was "main product missing after feature branch deletion" — the correct, buggy behavior finally observed).
  - Fix: `deleteResource` now skips the delete when the resource's own last-admitted `GitRef` doesn't match the ref being deleted (mirrors the existing `existing.GitRef != admCtx.RefName` "stale write" pattern already used elsewhere in this file for updates). Verified via logs that the shared/inherited resource is now consistently *skipped* while resources genuinely unique to the deleted branch are still removed as before.
- **Test de-flake**: `TestCollection_SelectorDoesNotExist` had the same fixed-500ms-sleep-then-single-fatal-query race already fixed for `TestCollection_ValidPushAccepted` in a prior PR (#391) — replaced with the existing `waitForCollectionStatus` poll helper.

## Test plan
- [x] `go test ./...` (gitstore-api) — all packages pass, no regressions
- [x] Local `ci-integration.yml`-equivalent memdb stack: `TestAdmission_BranchDeletion` 10/10 pass (previously ~20% pass rate on the same fresh-repo setup), confirmed via API logs that main's product is skipped and feature's product is still deleted on every run
- [x] `TestCollection_SelectorDoesNotExist` 5/5 pass in isolation; full `TestCollection*` suite passes with no regressions
- [x] Full local integration suite, fresh repo — all pass

## Note
This session's testing also surfaced several additional pre-existing issues out of scope for this PR (a controller-manager-internal condition-status case-mismatch affecting `IsNoOp`, a separate "category deletion validation unavailable" gRPC symptom on branch deletion, and two other Collection selector tests with likely load-related flakiness) — tracked for a follow-up session, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)