### PR TITLE
fix: match condition-status casing to the GraphQL wire enum in CategoryTaxonomy reconciler

### DIFF
--- a/gitstore-controller-manager/internal/categorytaxonomy/conditions.go
+++ b/gitstore-controller-manager/internal/categorytaxonomy/conditions.go
@@ -18,9 +18,16 @@ const (
 	conditionReady          = "Ready"
 	conditionFileRefPrefix  = "FileRefConfirmed"
 
-	statusTrue    = "True"
-	statusFalse   = "False"
-	statusUnknown = "Unknown"
+	// statusTrue/statusFalse/statusUnknown match the GraphQL wire enum
+	// ConditionStatus (shared/schemas/schema.graphqls: TRUE/FALSE/UNKNOWN),
+	// not Go's zero-value bool-ish casing. This matters because
+	// internal/status.StatusPatch.IsNoOp compares Condition.Status
+	// case-sensitively against values read back from the real GraphQL
+	// list/watch path, which always carries the enum's upper-case wire
+	// casing.
+	statusTrue    = "TRUE"
+	statusFalse   = "FALSE"
+	statusUnknown = "UNKNOWN"
 )
 
 // computeParentResolved implements FR-006: True when self.ParentRefName is

--- a/gitstore-controller-manager/internal/categorytaxonomy/conditions_test.go
+++ b/gitstore-controller-manager/internal/categorytaxonomy/conditions_test.go
@@ -17,8 +17,8 @@ func TestComputeParentResolved_AbsentParentRef(t *testing.T) {
 
 	cond := computeParentResolved(c, self)
 
-	if cond.Status != "True" {
-		t.Errorf("Status = %q, want True", cond.Status)
+	if cond.Status != "TRUE" {
+		t.Errorf("Status = %q, want TRUE", cond.Status)
 	}
 }
 
@@ -29,8 +29,8 @@ func TestComputeParentResolved_ResolvingParentRef(t *testing.T) {
 
 	cond := computeParentResolved(c, self)
 
-	if cond.Status != "True" {
-		t.Errorf("Status = %q, want True", cond.Status)
+	if cond.Status != "TRUE" {
+		t.Errorf("Status = %q, want TRUE", cond.Status)
 	}
 }
 
@@ -40,8 +40,8 @@ func TestComputeParentResolved_NonexistentParentRef(t *testing.T) {
 
 	cond := computeParentResolved(c, self)
 
-	if cond.Status != "False" {
-		t.Errorf("Status = %q, want False", cond.Status)
+	if cond.Status != "FALSE" {
+		t.Errorf("Status = %q, want FALSE", cond.Status)
 	}
 	if cond.Reason == "" || cond.Message == "" {
 		t.Error("expected a reason/message identifying the missing parent")
@@ -50,56 +50,56 @@ func TestComputeParentResolved_NonexistentParentRef(t *testing.T) {
 
 func TestComputeAcyclic_CycleParticipantIsFalse(t *testing.T) {
 	cond := computeAcyclic(true)
-	if cond.Status != "False" {
-		t.Errorf("Status = %q, want False", cond.Status)
+	if cond.Status != "FALSE" {
+		t.Errorf("Status = %q, want FALSE", cond.Status)
 	}
 }
 
 func TestComputeAcyclic_NonParticipantIsTrue(t *testing.T) {
 	cond := computeAcyclic(false)
-	if cond.Status != "True" {
-		t.Errorf("Status = %q, want True", cond.Status)
+	if cond.Status != "TRUE" {
+		t.Errorf("Status = %q, want TRUE", cond.Status)
 	}
 }
 
 func TestComputeReady_AllTrueYieldsTrue(t *testing.T) {
-	parentResolved := status.Condition{Type: "ParentResolved", Status: "True"}
-	acyclic := status.Condition{Type: "Acyclic", Status: "True"}
+	parentResolved := status.Condition{Type: "ParentResolved", Status: "TRUE"}
+	acyclic := status.Condition{Type: "Acyclic", Status: "TRUE"}
 
 	cond := computeReady(parentResolved, acyclic, nil)
-	if cond.Status != "True" {
-		t.Errorf("Status = %q, want True", cond.Status)
+	if cond.Status != "TRUE" {
+		t.Errorf("Status = %q, want TRUE", cond.Status)
 	}
 }
 
 func TestComputeReady_AnyNonTrueYieldsFalse(t *testing.T) {
-	parentResolved := status.Condition{Type: "ParentResolved", Status: "False"}
-	acyclic := status.Condition{Type: "Acyclic", Status: "True"}
+	parentResolved := status.Condition{Type: "ParentResolved", Status: "FALSE"}
+	acyclic := status.Condition{Type: "Acyclic", Status: "TRUE"}
 
 	cond := computeReady(parentResolved, acyclic, nil)
-	if cond.Status != "False" {
-		t.Errorf("Status = %q, want False", cond.Status)
+	if cond.Status != "FALSE" {
+		t.Errorf("Status = %q, want FALSE", cond.Status)
 	}
 }
 
 func TestComputeReady_UnknownFileRefConditionYieldsFalse(t *testing.T) {
-	parentResolved := status.Condition{Type: "ParentResolved", Status: "True"}
-	acyclic := status.Condition{Type: "Acyclic", Status: "True"}
-	fileRef := &status.Condition{Type: "FileRefConfirmed", Status: "Unknown"}
+	parentResolved := status.Condition{Type: "ParentResolved", Status: "TRUE"}
+	acyclic := status.Condition{Type: "Acyclic", Status: "TRUE"}
+	fileRef := &status.Condition{Type: "FileRefConfirmed", Status: "UNKNOWN"}
 
 	cond := computeReady(parentResolved, acyclic, fileRef)
-	if cond.Status != "False" {
-		t.Errorf("Status = %q, want False (Unknown is not True)", cond.Status)
+	if cond.Status != "FALSE" {
+		t.Errorf("Status = %q, want FALSE (UNKNOWN is not TRUE)", cond.Status)
 	}
 }
 
 func TestComputeReady_AbsentFileRefConditionDoesNotBlockReady(t *testing.T) {
-	parentResolved := status.Condition{Type: "ParentResolved", Status: "True"}
-	acyclic := status.Condition{Type: "Acyclic", Status: "True"}
+	parentResolved := status.Condition{Type: "ParentResolved", Status: "TRUE"}
+	acyclic := status.Condition{Type: "Acyclic", Status: "TRUE"}
 
 	cond := computeReady(parentResolved, acyclic, nil)
-	if cond.Status != "True" {
-		t.Errorf("Status = %q, want True (no file-ref condition present)", cond.Status)
+	if cond.Status != "TRUE" {
+		t.Errorf("Status = %q, want TRUE (no file-ref condition present)", cond.Status)
 	}
 }
 
@@ -139,8 +139,8 @@ func TestReconcile_CycleParticipant_PathDepthFrozen_AcyclicFalse(t *testing.T) {
 	for _, cond := range sc.calls[0].Conditions {
 		if cond.Type == "Acyclic" {
 			acyclicFound = true
-			if cond.Status != "False" {
-				t.Errorf("Acyclic.Status = %q, want False", cond.Status)
+			if cond.Status != "FALSE" {
+				t.Errorf("Acyclic.Status = %q, want FALSE", cond.Status)
 			}
 		}
 	}
@@ -199,8 +199,8 @@ func TestReconcile_CycleBroken_AcyclicTrueAndRecomputes(t *testing.T) {
 	}
 
 	for _, cond := range sc.calls[0].Conditions {
-		if cond.Type == "Acyclic" && cond.Status != "True" {
-			t.Errorf("Acyclic.Status = %q, want True", cond.Status)
+		if cond.Type == "Acyclic" && cond.Status != "TRUE" {
+			t.Errorf("Acyclic.Status = %q, want TRUE", cond.Status)
 		}
 	}
 }

--- a/gitstore-controller-manager/internal/categorytaxonomy/fileref_test.go
+++ b/gitstore-controller-manager/internal/categorytaxonomy/fileref_test.go
@@ -17,8 +17,8 @@ func TestComputeFileRefCondition_RequiredMediaProducesUnknownCondition(t *testin
 	if cond == nil {
 		t.Fatal("expected a non-nil condition for an optional:false media entry")
 	}
-	if cond.Status != "Unknown" {
-		t.Errorf("Status = %q, want Unknown", cond.Status)
+	if cond.Status != "UNKNOWN" {
+		t.Errorf("Status = %q, want UNKNOWN", cond.Status)
 	}
 }
 
@@ -48,8 +48,8 @@ func TestComputeFileRefCondition_MixedMediaOnlyFlagsRequired(t *testing.T) {
 
 	cond := computeFileRefCondition(c)
 
-	if cond == nil || cond.Status != "Unknown" {
-		t.Fatalf("expected an Unknown condition when any required entry exists, got %+v", cond)
+	if cond == nil || cond.Status != "UNKNOWN" {
+		t.Fatalf("expected an UNKNOWN condition when any required entry exists, got %+v", cond)
 	}
 }
 

--- a/gitstore-controller-manager/internal/categorytaxonomy/reconciler.go
+++ b/gitstore-controller-manager/internal/categorytaxonomy/reconciler.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/cache"
@@ -162,15 +161,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, key types.WorkItemKey) types
 
 	parentResolvedCond := computeParentResolved(r.cache, current)
 	acyclicCond := computeAcyclic(inCycle[current.Name])
-	// Case-insensitive: current.Status.Conditions comes from the real
-	// GraphQL list/watch path, where ConditionStatus is the enum wire
-	// value ("TRUE"/"FALSE"); acyclicCond.Status uses this package's
-	// internal "True"/"False" constants, normalized to the enum casing
-	// only later, on write, by graphql_status_client.go's
-	// normalizeConditionStatus. A case-sensitive compare here would never
-	// match against real traffic, making this always true and turning
-	// the reenqueue below into an unconditional one on every reconcile.
-	acyclicChanged := !strings.EqualFold(conditionStatusByType(current.Status.Conditions, conditionAcyclic), acyclicCond.Status)
+	// current.Status.Conditions comes from the real GraphQL list/watch
+	// path, where ConditionStatus is the enum wire value ("TRUE"/"FALSE");
+	// acyclicCond.Status uses this package's statusTrue/statusFalse
+	// constants, which now match that same wire casing directly, so a
+	// plain equality compare is safe here.
+	acyclicChanged := conditionStatusByType(current.Status.Conditions, conditionAcyclic) != acyclicCond.Status
 	fileRefCond := computeFileRefCondition(current)
 	readyCond := computeReady(parentResolvedCond, acyclicCond, fileRefCond)
 
@@ -186,7 +182,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key types.WorkItemKey) types
 		}
 		conditions = append(conditions, &status.Condition{
 			Type:               "Terminating",
-			Status:             "True",
+			Status:             statusTrue,
 			ObservedGeneration: current.Generation,
 			LastTransitionTime: transition,
 			Reason:             "DeletionRequested",

--- a/gitstore-controller-manager/internal/categorytaxonomy/reconciler_test.go
+++ b/gitstore-controller-manager/internal/categorytaxonomy/reconciler_test.go
@@ -123,9 +123,9 @@ func TestReconcile_NoOpWhenPatchMatchesCurrentStatus(t *testing.T) {
 		ResourceVersion: "1",
 		Resolved:        resolved,
 		Conditions: []*status.Condition{
-			{Type: "ParentResolved", Status: "True", LastTransitionTime: now},
-			{Type: "Acyclic", Status: "True", LastTransitionTime: now},
-			{Type: "Ready", Status: "True", LastTransitionTime: now},
+			{Type: "ParentResolved", Status: "TRUE", LastTransitionTime: now},
+			{Type: "Acyclic", Status: "TRUE", LastTransitionTime: now},
+			{Type: "Ready", Status: "TRUE", LastTransitionTime: now},
 		},
 	}
 	c := seedCache(t, root)
@@ -170,10 +170,10 @@ func TestReconcile_TerminatingCategoryDecouplesProductsThenCompletes(t *testing.
 		Status: status.ResourceStatus{
 			ResourceVersion: "4", Resolved: resolved,
 			Conditions: []*status.Condition{
-				{Type: "ParentResolved", Status: "True", LastTransitionTime: deletedAt},
-				{Type: "Acyclic", Status: "True", LastTransitionTime: deletedAt},
-				{Type: "Ready", Status: "True", LastTransitionTime: deletedAt},
-				{Type: "Terminating", Status: "True", LastTransitionTime: deletedAt},
+				{Type: "ParentResolved", Status: "TRUE", LastTransitionTime: deletedAt},
+				{Type: "Acyclic", Status: "TRUE", LastTransitionTime: deletedAt},
+				{Type: "Ready", Status: "TRUE", LastTransitionTime: deletedAt},
+				{Type: "Terminating", Status: "TRUE", LastTransitionTime: deletedAt},
 			},
 		},
 	}
@@ -201,10 +201,10 @@ func TestReconcile_TerminatingCategoryContinuesAfterBoundedProductPage(t *testin
 		Status: status.ResourceStatus{
 			ResourceVersion: "4", Resolved: resolved,
 			Conditions: []*status.Condition{
-				{Type: "ParentResolved", Status: "True", LastTransitionTime: deletedAt},
-				{Type: "Acyclic", Status: "True", LastTransitionTime: deletedAt},
-				{Type: "Ready", Status: "True", LastTransitionTime: deletedAt},
-				{Type: "Terminating", Status: "True", LastTransitionTime: deletedAt},
+				{Type: "ParentResolved", Status: "TRUE", LastTransitionTime: deletedAt},
+				{Type: "Acyclic", Status: "TRUE", LastTransitionTime: deletedAt},
+				{Type: "Ready", Status: "TRUE", LastTransitionTime: deletedAt},
+				{Type: "Terminating", Status: "TRUE", LastTransitionTime: deletedAt},
 			},
 		},
 	}
@@ -236,7 +236,7 @@ func TestReconcile_TerminationStatusIsVisibleBeforeLifecycleOperations(t *testin
 	conditions := statusClient.calls[0].Conditions
 	require.Condition(t, func() bool {
 		for _, condition := range conditions {
-			if condition.Type == "Terminating" && condition.Status == "True" && condition.Reason == "DeletionRequested" {
+			if condition.Type == "Terminating" && condition.Status == "TRUE" && condition.Reason == "DeletionRequested" {
 				return true
 			}
 		}
@@ -254,10 +254,10 @@ func TestReconcile_TerminatingCategoryRetriesDecouplingAndCompletionConflicts(t 
 		Namespace: "acme", Name: "electronics", ResourceVersion: "4",
 		DeletionTimestamp: &deletedAt, Finalizers: []string{datastoreForegroundDeletionFinalizer},
 		Status: status.ResourceStatus{ResourceVersion: "4", Resolved: resolved, Conditions: []*status.Condition{
-			{Type: "ParentResolved", Status: "True", LastTransitionTime: deletedAt},
-			{Type: "Acyclic", Status: "True", LastTransitionTime: deletedAt},
-			{Type: "Ready", Status: "True", LastTransitionTime: deletedAt},
-			{Type: "Terminating", Status: "True", LastTransitionTime: deletedAt},
+			{Type: "ParentResolved", Status: "TRUE", LastTransitionTime: deletedAt},
+			{Type: "Acyclic", Status: "TRUE", LastTransitionTime: deletedAt},
+			{Type: "Ready", Status: "TRUE", LastTransitionTime: deletedAt},
+			{Type: "Terminating", Status: "TRUE", LastTransitionTime: deletedAt},
 		}},
 	}
 	for name, deletion := range map[string]*fakeDeletionClient{

--- a/gitstore-controller-manager/internal/status/graphql_status_client.go
+++ b/gitstore-controller-manager/internal/status/graphql_status_client.go
@@ -99,6 +99,13 @@ func toUpdateCategoryStatusInput(key types.WorkItemKey, patch *StatusPatch) (map
 	return input, nil
 }
 
+// normalizeConditionStatus upper-cases a Condition.Status value before it is
+// sent over the wire as the GraphQL ConditionStatus enum (TRUE/FALSE/UNKNOWN).
+// categorytaxonomy's own statusTrue/statusFalse/statusUnknown constants
+// already match this casing directly, so this is a no-op for that package,
+// but internal/namespace's reconciler still constructs conditions with
+// Go-idiomatic "True"/"False" literals -- this remains load-bearing for
+// that caller and must not be deleted while that's still the case.
 func normalizeConditionStatus(status string) string {
 	status = strings.TrimSpace(status)
 	switch strings.ToUpper(status) {

--- a/gitstore-controller-manager/tests/integration/categorytaxonomy_deletion_capacity_test.go
+++ b/gitstore-controller-manager/tests/integration/categorytaxonomy_deletion_capacity_test.go
@@ -28,10 +28,10 @@ func TestIntegration_CategoryDeletionHighCardinalityContinuation(t *testing.T) {
 		Namespace: "acme", Name: "high-cardinality", ResourceVersion: "3",
 		DeletionTimestamp: &deletedAt, Finalizers: []string{"gitstore.dev/foreground-deletion"},
 		Status: status.ResourceStatus{ResourceVersion: "3", Conditions: []*status.Condition{
-			{Type: "ParentResolved", Status: "True", LastTransitionTime: deletedAt},
-			{Type: "Acyclic", Status: "True", LastTransitionTime: deletedAt},
-			{Type: "Ready", Status: "True", LastTransitionTime: deletedAt},
-			{Type: "Terminating", Status: "True", LastTransitionTime: deletedAt},
+			{Type: "ParentResolved", Status: "TRUE", LastTransitionTime: deletedAt},
+			{Type: "Acyclic", Status: "TRUE", LastTransitionTime: deletedAt},
+			{Type: "Ready", Status: "TRUE", LastTransitionTime: deletedAt},
+			{Type: "Terminating", Status: "TRUE", LastTransitionTime: deletedAt},
 		}},
 	})
 	categories.MarkSynced()

--- a/gitstore-controller-manager/tests/integration/categorytaxonomy_deletion_test.go
+++ b/gitstore-controller-manager/tests/integration/categorytaxonomy_deletion_test.go
@@ -57,10 +57,10 @@ func TestIntegration_CategoryDeletionResumesAfterControllerRestart(t *testing.T)
 		UID: "parent-uid", Namespace: "acme", Name: "parent", ResourceVersion: "5",
 		DeletionTimestamp: &deletedAt, Finalizers: []string{"gitstore.dev/foreground-deletion"},
 		Status: status.ResourceStatus{ResourceVersion: "5", Resolved: resolved, Conditions: []*status.Condition{
-			{Type: "ParentResolved", Status: "True", LastTransitionTime: deletedAt},
-			{Type: "Acyclic", Status: "True", LastTransitionTime: deletedAt},
-			{Type: "Ready", Status: "True", LastTransitionTime: deletedAt},
-			{Type: "Terminating", Status: "True", LastTransitionTime: deletedAt},
+			{Type: "ParentResolved", Status: "TRUE", LastTransitionTime: deletedAt},
+			{Type: "Acyclic", Status: "TRUE", LastTransitionTime: deletedAt},
+			{Type: "Ready", Status: "TRUE", LastTransitionTime: deletedAt},
+			{Type: "Terminating", Status: "TRUE", LastTransitionTime: deletedAt},
 		}},
 	}
 	categories := cache.New[categorytaxonomy.CategoryTaxonomy]()


### PR DESCRIPTION
## Summary
- `gitstore-controller-manager/internal/categorytaxonomy/conditions.go`'s `statusTrue`/`statusFalse`/`statusUnknown` constants used Go-idiomatic `"True"`/`"False"`/`"Unknown"` casing, but the GraphQL `ConditionStatus` enum's wire values are `TRUE`/`FALSE`/`UNKNOWN` (confirmed in `shared/schemas/schema.graphqls` and `gitstore-api/internal/graph/model/models_gen.go`).
- `internal/status.StatusPatch.IsNoOp`/`conditionsEqual` compares `Condition.Status` case-sensitively against the value read back from the real GraphQL list/watch path, so a freshly computed condition never matched — every dispatch of an already-converged `CategoryTaxonomy` kept issuing a redundant status-write mutation instead of short-circuiting as a no-op.
- Fixed at the source by uppercasing the three constants; updated the one other literal-cased `Status: "True"` in `reconciler.go`'s `Terminating` condition, and all test fixtures/assertions in the same package (`conditions_test.go`, `fileref_test.go`, `reconciler_test.go`) and integration deletion tests that constructed `Condition{Status: "True"/"Unknown"}` literals matching the old casing.
- PR #391 had already worked around one instance of this exact bug in the `Acyclic` re-enqueue check via `strings.EqualFold`; that's now unnecessary since both sides use the same casing, so it's simplified back to a plain `!=`.
- `internal/status.normalizeConditionStatus` (the write-side uppercasing helper) is **kept**, not deleted — tracing its only caller (`toConditionInputs`) shows `internal/namespace`'s reconciler independently constructs conditions with the same non-wire `"True"`/`"False"` casing, so the helper remains load-bearing for that package even though it's now a no-op for `categorytaxonomy`. Left a comment explaining why.

## Verification
- `go build ./...` and `go test ./...` pass in `gitstore-controller-manager`.
- `make pr-ready` (lint, build, test, license-check across the whole workspace) passes.
- Live verification against a local `docker compose` stack: pushed a root/mid/leaf `CategoryTaxonomy` hierarchy, waited for it to converge, then observed the API's `category.status.write` authz-decision logs. Before convergence there were 1-2 status-write mutations per resource (normal, including conflict retries); across an 86s idle window afterward there were **zero** further status-write mutations for the converged resources — confirming `IsNoOp` now correctly short-circuits.
- Ran the full `tests/integration` suite once against this build: all `TestCategoryTaxonomy*`/`TestCollection_*` tests pass. The only failure, `TestAdmission_BranchDeletion`, is the pre-existing, unrelated flaky "category deletion validation unavailable" push rejection already tracked separately (not caused by this change).

## Test plan
- [x] `go build ./...` in `gitstore-controller-manager`
- [x] `go test ./...` in `gitstore-controller-manager`
- [x] `make pr-ready`
- [x] Live docker-compose verification of reconcile-loop quiescence for a converged CategoryTaxonomy hierarchy
- [x] Full `tests/integration` suite run