### PR TITLE
fix: converge concurrent File admissions

### DIFF
--- a/gitstore-api/internal/cataloggrpc/file_replica_test.go
+++ b/gitstore-api/internal/cataloggrpc/file_replica_test.go
@@ -74,6 +74,27 @@ func TestAdmitResources_FileConcurrentDuplicateAdmissionIsIdempotent(t *testing.
 	file, err := store.GetFileByName(context.Background(), "gitstore", "hero")
 	require.NoError(t, err)
 	assert.Equal(t, "Alt text", file.Body)
+	assert.Equal(t, "1", file.ResourceVersion, "an identical create collision must not manufacture an update")
+
+	controllerRevision := "controller-resolved"
+	file, err = store.UpdateFileStatus(context.Background(), "gitstore", "hero", datastore.FileStatusPatch{
+		ResourceVersion: file.ResourceVersion, LastAppliedRevision: &controllerRevision,
+	})
+	require.NoError(t, err)
+	statusAfterController := append([]byte(nil), file.Status...)
+	resourceVersionAfterController := file.ResourceVersion
+
+	// A delayed duplicate delivery for the same commit must remain a no-op
+	// even though the stored representation normalizes omitted metadata maps
+	// to empty maps. In particular it must not erase controller-owned status.
+	_, err = replicas[0].AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
+		RepositoryId: testRepoID, CommitSha: commit, RefName: "refs/heads/main",
+	})
+	require.NoError(t, err)
+	file, err = store.GetFileByName(context.Background(), "gitstore", "hero")
+	require.NoError(t, err)
+	assert.Equal(t, resourceVersionAfterController, file.ResourceVersion)
+	assert.Equal(t, statusAfterController, []byte(file.Status))
 
 	page, err := store.ListFiles(context.Background(), "gitstore", datastore.PageParams{})
 	require.NoError(t, err)

--- a/gitstore-api/internal/cataloggrpc/file_replica_test.go
+++ b/gitstore-api/internal/cataloggrpc/file_replica_test.go
@@ -191,6 +191,119 @@ func TestAdmitResources_FileOlderCommitCannotOverwriteNewerAdmission(t *testing.
 	assert.Equal(t, "2", file.ResourceVersion, "only the winning update may advance the durable version")
 }
 
+type orderedFileUpdateStore struct {
+	datastore.Datastore
+	olderCommit, newerCommit                  string
+	olderEntered, releaseOlder, olderFinished chan struct{}
+	newerEntered, releaseNewer                chan struct{}
+	olderOnce, newerOnce                      sync.Once
+}
+
+func (s *orderedFileUpdateStore) UpdateFile(ctx context.Context, file *datastore.File, expectedResourceVersion string) error {
+	if file.GitCommitSHA == s.olderCommit {
+		s.olderOnce.Do(func() {
+			close(s.olderEntered)
+			<-s.releaseOlder
+		})
+		err := s.Datastore.UpdateFile(ctx, file, expectedResourceVersion)
+		close(s.olderFinished)
+		return err
+	}
+	if file.GitCommitSHA == s.newerCommit {
+		s.newerOnce.Do(func() {
+			close(s.newerEntered)
+			<-s.releaseNewer
+		})
+	}
+	return s.Datastore.UpdateFile(ctx, file, expectedResourceVersion)
+}
+
+// TestAdmitResources_FileCurrentCommitRetriesAfterConcurrentConflict forces
+// both replicas to load resourceVersion 1, lets stale commit B win the first
+// CAS, then proves current commit C reloads resourceVersion 2 and retries to
+// durable convergence instead of logging its conflict and returning success.
+func TestAdmitResources_FileCurrentCommitRetriesAfterConcurrentConflict(t *testing.T) {
+	base := newTestDatastore(t)
+	a := strings.Repeat("a", 40)
+	b := strings.Repeat("b", 40)
+	c := strings.Repeat("c", 40)
+	path := "files/hero.md"
+	files := map[string]map[string][]byte{
+		a: {path: makeFile("hero")},
+		b: {path: makeFileWithBody("hero", "Older update")},
+		c: {path: makeFileWithBody("hero", "Current update")},
+	}
+	current := a
+	seed := newCatalogServer(t, base, newTreeGitReader(&current, files))
+	_, err := seed.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
+		RepositoryId: testRepoID, CommitSha: a, RefName: "refs/heads/main",
+	})
+	require.NoError(t, err)
+
+	store := &orderedFileUpdateStore{
+		Datastore: base, olderCommit: b, newerCommit: c,
+		olderEntered: make(chan struct{}), releaseOlder: make(chan struct{}), olderFinished: make(chan struct{}),
+		newerEntered: make(chan struct{}), releaseNewer: make(chan struct{}),
+	}
+	var mu sync.Mutex
+	current = b
+	git := newTreeGitReader(&current, files)
+	git.resolveRefFunc = func(context.Context, string, string) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return current, nil
+	}
+	olderServer := newCatalogServer(t, store, git)
+	newerServer := newCatalogServer(t, store, git)
+
+	olderDone := make(chan error, 1)
+	go func() {
+		_, err := olderServer.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
+			RepositoryId: testRepoID, OldCommitSha: a, NewCommitSha: b, CommitSha: b,
+			RefName: "refs/heads/main", ChangedPaths: []string{path},
+		})
+		olderDone <- err
+	}()
+	select {
+	case <-store.olderEntered:
+	case <-time.After(time.Second):
+		t.Fatal("older update did not reach the datastore CAS")
+	}
+
+	mu.Lock()
+	current = c
+	mu.Unlock()
+	newerDone := make(chan error, 1)
+	go func() {
+		_, err := newerServer.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
+			RepositoryId: testRepoID, OldCommitSha: b, NewCommitSha: c, CommitSha: c,
+			RefName: "refs/heads/main", ChangedPaths: []string{path},
+		})
+		newerDone <- err
+	}()
+	select {
+	case <-store.newerEntered:
+	case <-time.After(time.Second):
+		t.Fatal("current update did not reach the datastore CAS")
+	}
+
+	close(store.releaseOlder)
+	select {
+	case <-store.olderFinished:
+	case <-time.After(time.Second):
+		t.Fatal("older update did not finish its CAS")
+	}
+	close(store.releaseNewer)
+	require.NoError(t, <-olderDone)
+	require.NoError(t, <-newerDone)
+
+	file, err := base.GetFileByName(context.Background(), "gitstore", "hero")
+	require.NoError(t, err)
+	assert.Equal(t, c, file.GitCommitSHA)
+	assert.Equal(t, "Current update", file.Body)
+	assert.Equal(t, "3", file.ResourceVersion)
+}
+
 // TestAdmitResources_FileUpdateSurvivesReplicaProcessReplacement models a
 // replica crashing (or being rolled) between two pushes: the Server instance
 // that admitted the create is discarded entirely and a brand-new Server

--- a/gitstore-api/internal/cataloggrpc/file_replica_test.go
+++ b/gitstore-api/internal/cataloggrpc/file_replica_test.go
@@ -199,6 +199,108 @@ type orderedFileUpdateStore struct {
 	olderOnce, newerOnce                      sync.Once
 }
 
+type orderedFileCreateStore struct {
+	datastore.Datastore
+	olderCommit, newerCommit                  string
+	olderEntered, releaseOlder, olderFinished chan struct{}
+	newerEntered, releaseNewer                chan struct{}
+	olderOnce, newerOnce                      sync.Once
+}
+
+func (s *orderedFileCreateStore) CreateFile(ctx context.Context, file *datastore.File) error {
+	if file.GitCommitSHA == s.olderCommit {
+		s.olderOnce.Do(func() {
+			close(s.olderEntered)
+			<-s.releaseOlder
+		})
+		err := s.Datastore.CreateFile(ctx, file)
+		close(s.olderFinished)
+		return err
+	}
+	if file.GitCommitSHA == s.newerCommit {
+		s.newerOnce.Do(func() {
+			close(s.newerEntered)
+			<-s.releaseNewer
+		})
+	}
+	return s.Datastore.CreateFile(ctx, file)
+}
+
+// TestAdmitResources_FileCurrentCreateRetriesAfterConcurrentCollision forces
+// two replicas to observe a missing File, lets stale commit B create it first,
+// then proves current commit C reloads that row and converges through the
+// guarded update path after its create receives ErrAlreadyExists.
+func TestAdmitResources_FileCurrentCreateRetriesAfterConcurrentCollision(t *testing.T) {
+	base := newTestDatastore(t)
+	b := strings.Repeat("b", 40)
+	c := strings.Repeat("c", 40)
+	path := "files/hero.md"
+	files := map[string]map[string][]byte{
+		b: {path: makeFileWithBody("hero", "Older create")},
+		c: {path: makeFileWithBody("hero", "Current create")},
+	}
+	store := &orderedFileCreateStore{
+		Datastore: base, olderCommit: b, newerCommit: c,
+		olderEntered: make(chan struct{}), releaseOlder: make(chan struct{}), olderFinished: make(chan struct{}),
+		newerEntered: make(chan struct{}), releaseNewer: make(chan struct{}),
+	}
+	var mu sync.Mutex
+	current := b
+	git := newTreeGitReader(&current, files)
+	git.resolveRefFunc = func(context.Context, string, string) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return current, nil
+	}
+	olderServer := newCatalogServer(t, store, git)
+	newerServer := newCatalogServer(t, store, git)
+
+	olderDone := make(chan error, 1)
+	go func() {
+		_, err := olderServer.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
+			RepositoryId: testRepoID, CommitSha: b, RefName: "refs/heads/main",
+		})
+		olderDone <- err
+	}()
+	select {
+	case <-store.olderEntered:
+	case <-time.After(time.Second):
+		t.Fatal("older admission did not reach File create")
+	}
+
+	mu.Lock()
+	current = c
+	mu.Unlock()
+	newerDone := make(chan error, 1)
+	go func() {
+		_, err := newerServer.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
+			RepositoryId: testRepoID, CommitSha: c, RefName: "refs/heads/main",
+		})
+		newerDone <- err
+	}()
+	select {
+	case <-store.newerEntered:
+	case <-time.After(time.Second):
+		t.Fatal("newer admission did not reach File create")
+	}
+
+	close(store.releaseOlder)
+	select {
+	case <-store.olderFinished:
+	case <-time.After(time.Second):
+		t.Fatal("older admission did not persist its create")
+	}
+	close(store.releaseNewer)
+	require.NoError(t, <-olderDone)
+	require.NoError(t, <-newerDone)
+
+	file, err := base.GetFileByName(context.Background(), "gitstore", "hero")
+	require.NoError(t, err)
+	assert.Equal(t, c, file.GitCommitSHA)
+	assert.Equal(t, "Current create", file.Body)
+	assert.Equal(t, "2", file.ResourceVersion)
+}
+
 func (s *orderedFileUpdateStore) UpdateFile(ctx context.Context, file *datastore.File, expectedResourceVersion string) error {
 	if file.GitCommitSHA == s.olderCommit {
 		s.olderOnce.Do(func() {

--- a/gitstore-api/internal/cataloggrpc/server.go
+++ b/gitstore-api/internal/cataloggrpc/server.go
@@ -1386,6 +1386,8 @@ func fileAdmissionStatus(generation int64, revision string, now time.Time) []byt
 	return b
 }
 
+const maxFileAdmissionUpdateAttempts = 3
+
 func (s *Server) admitFile(
 	ctx context.Context,
 	resource *catalog.FileResource,
@@ -1429,33 +1431,51 @@ func (s *Server) admitFile(
 		}
 		return
 	}
-	changedSpecBody := specBodyChanged(existing.Spec, existing.Body, specJSON, body)
-	changedMetadata := existing.APIVersion != resource.APIVersion || existing.Kind != resource.Kind ||
-		!reflect.DeepEqual(existing.Labels, resource.Metadata.Labels) || !reflect.DeepEqual(existing.Annotations, resource.Metadata.Annotations)
-	changedProvenance := existing.RepositoryID != admCtx.RepositoryID || existing.SourcePath != sourcePath ||
-		existing.GitCommitSHA != admCtx.CommitSHA || existing.GitRef != admCtx.RefName
-	if !changedSpecBody && !changedMetadata && !changedProvenance {
-		return
+	for attempt := 0; attempt < maxFileAdmissionUpdateAttempts; attempt++ {
+		changedSpecBody := specBodyChanged(existing.Spec, existing.Body, specJSON, body)
+		changedMetadata := existing.APIVersion != resource.APIVersion || existing.Kind != resource.Kind ||
+			!reflect.DeepEqual(existing.Labels, resource.Metadata.Labels) || !reflect.DeepEqual(existing.Annotations, resource.Metadata.Annotations)
+		changedProvenance := existing.RepositoryID != admCtx.RepositoryID || existing.SourcePath != sourcePath ||
+			existing.GitCommitSHA != admCtx.CommitSHA || existing.GitRef != admCtx.RefName
+		if !changedSpecBody && !changedMetadata && !changedProvenance {
+			return
+		}
+		if existingSpecContentType(existing.Spec) != resource.Spec.ContentType {
+			s.log.Warn("admit_resources: File contentType is immutable", zap.String("name", resource.Metadata.Name))
+			return
+		}
+		expectedResourceVersion := existing.ResourceVersion
+		gen := existing.Generation
+		if changedSpecBody {
+			gen++
+		}
+		existing.APIVersion, existing.Kind = resource.APIVersion, resource.Kind
+		existing.Labels, existing.Annotations = cloneStringMap(resource.Metadata.Labels), cloneStringMap(resource.Metadata.Annotations)
+		existing.Generation, existing.ResourceVersion = gen, nextResourceVersion(expectedResourceVersion)
+		existing.Revision, existing.RepositoryID, existing.SourcePath = admCtx.Revision, admCtx.RepositoryID, sourcePath
+		existing.GitCommitSHA, existing.GitRef, existing.Spec, existing.Body = admCtx.CommitSHA, admCtx.RefName, specJSON, string(body)
+		existing.Status = fileAdmissionStatus(gen, admCtx.Revision, admCtx.Now)
+		err := s.store.UpdateFile(ctx, existing, expectedResourceVersion)
+		if err == nil {
+			s.publishFileEvent(eventbus.Modified, existing)
+			return
+		}
+		if !errors.Is(err, datastore.ErrConflict) {
+			s.log.Error("admit_resources: update file failed", zap.Error(err))
+			return
+		}
+		if !s.isAdmissionCommitCurrent(ctx, admCtx.RepositoryID, admCtx.RefName, admCtx.CommitSHA) {
+			return
+		}
+		existing, err = s.store.GetFileByName(ctx, namespace, resource.Metadata.Name)
+		if err != nil {
+			s.log.Error("admit_resources: reload File after update conflict failed", zap.Error(err))
+			return
+		}
 	}
-	if existingSpecContentType(existing.Spec) != resource.Spec.ContentType {
-		s.log.Warn("admit_resources: File contentType is immutable", zap.String("name", resource.Metadata.Name))
-		return
-	}
-	gen := existing.Generation
-	if changedSpecBody {
-		gen++
-	}
-	existing.APIVersion, existing.Kind = resource.APIVersion, resource.Kind
-	existing.Labels, existing.Annotations = cloneStringMap(resource.Metadata.Labels), cloneStringMap(resource.Metadata.Annotations)
-	existing.Generation, existing.ResourceVersion = gen, nextResourceVersion(existing.ResourceVersion)
-	existing.Revision, existing.RepositoryID, existing.SourcePath = admCtx.Revision, admCtx.RepositoryID, sourcePath
-	existing.GitCommitSHA, existing.GitRef, existing.Spec, existing.Body = admCtx.CommitSHA, admCtx.RefName, specJSON, string(body)
-	existing.Status = fileAdmissionStatus(gen, admCtx.Revision, admCtx.Now)
-	if err := s.store.UpdateFile(ctx, existing); err != nil {
-		s.log.Error("admit_resources: update file failed", zap.Error(err))
-	} else {
-		s.publishFileEvent(eventbus.Modified, existing)
-	}
+	s.log.Error("admit_resources: update File conflict retry budget exhausted",
+		zap.String("namespace", namespace), zap.String("name", resource.Metadata.Name),
+		zap.String("commit_sha", admCtx.CommitSHA))
 }
 
 func existingSpecContentType(raw []byte) string {

--- a/gitstore-api/internal/cataloggrpc/server.go
+++ b/gitstore-api/internal/cataloggrpc/server.go
@@ -1424,12 +1424,25 @@ func (s *Server) admitFile(
 			GitCommitSHA: admCtx.CommitSHA, GitRef: admCtx.RefName, Spec: specJSON, Body: string(body),
 		}
 		f.Status = fileAdmissionStatus(1, admCtx.Revision, admCtx.Now)
-		if err := s.store.CreateFile(ctx, f); err != nil {
-			s.log.Error("admit_resources: create file failed", zap.Error(err))
-		} else {
+		if err := s.store.CreateFile(ctx, f); err == nil {
 			s.publishFileEvent(eventbus.Added, f)
+			return
+		} else if !errors.Is(err, datastore.ErrAlreadyExists) {
+			s.log.Error("admit_resources: create file failed", zap.Error(err))
+			return
 		}
-		return
+		// Another replica may have created this identity after operationForEntry
+		// observed it as absent. If this admission still owns the ref tip, reload
+		// the winner and converge through the resource-version-guarded update
+		// path below. A stale admission must leave the winner untouched.
+		if !s.isAdmissionCommitCurrent(ctx, admCtx.RepositoryID, admCtx.RefName, admCtx.CommitSHA) {
+			return
+		}
+		existing, err = s.store.GetFileByName(ctx, namespace, resource.Metadata.Name)
+		if err != nil {
+			s.log.Error("admit_resources: reload File after create conflict failed", zap.Error(err))
+			return
+		}
 	}
 	for attempt := 0; attempt < maxFileAdmissionUpdateAttempts; attempt++ {
 		changedSpecBody := specBodyChanged(existing.Spec, existing.Body, specJSON, body)

--- a/gitstore-api/internal/cataloggrpc/server.go
+++ b/gitstore-api/internal/cataloggrpc/server.go
@@ -1447,7 +1447,8 @@ func (s *Server) admitFile(
 	for attempt := 0; attempt < maxFileAdmissionUpdateAttempts; attempt++ {
 		changedSpecBody := specBodyChanged(existing.Spec, existing.Body, specJSON, body)
 		changedMetadata := existing.APIVersion != resource.APIVersion || existing.Kind != resource.Kind ||
-			!reflect.DeepEqual(existing.Labels, resource.Metadata.Labels) || !reflect.DeepEqual(existing.Annotations, resource.Metadata.Annotations)
+			!reflect.DeepEqual(existing.Labels, cloneStringMap(resource.Metadata.Labels)) ||
+			!reflect.DeepEqual(existing.Annotations, cloneStringMap(resource.Metadata.Annotations))
 		changedProvenance := existing.RepositoryID != admCtx.RepositoryID || existing.SourcePath != sourcePath ||
 			existing.GitCommitSHA != admCtx.CommitSHA || existing.GitRef != admCtx.RefName
 		if !changedSpecBody && !changedMetadata && !changedProvenance {

--- a/gitstore-api/internal/datastore/datastore.go
+++ b/gitstore-api/internal/datastore/datastore.go
@@ -300,7 +300,9 @@ type Datastore interface {
 	GetFile(ctx context.Context, uid string) (*File, error)
 	GetFileByName(ctx context.Context, namespace, name string) (*File, error)
 	ListFiles(ctx context.Context, namespace string, page PageParams) (*PageResult[File], error)
-	UpdateFile(ctx context.Context, f *File) error
+	// UpdateFile replaces a File only when expectedResourceVersion still
+	// matches the durable row, returning ErrConflict otherwise.
+	UpdateFile(ctx context.Context, f *File, expectedResourceVersion string) error
 	DeleteFile(ctx context.Context, uid string) error
 	DeleteFileWithResourceVersion(ctx context.Context, uid, expectedResourceVersion string) error
 

--- a/gitstore-api/internal/datastore/instrumented.go
+++ b/gitstore-api/internal/datastore/instrumented.go
@@ -162,9 +162,9 @@ func (d *InstrumentedDatastore) ListFiles(ctx context.Context, namespace string,
 	d.observe("ListFiles", start, err)
 	return v, err
 }
-func (d *InstrumentedDatastore) UpdateFile(ctx context.Context, f *File) error {
+func (d *InstrumentedDatastore) UpdateFile(ctx context.Context, f *File, expectedResourceVersion string) error {
 	start := time.Now()
-	err := d.next.UpdateFile(d.withFindingObserver(ctx), f)
+	err := d.next.UpdateFile(d.withFindingObserver(ctx), f, expectedResourceVersion)
 	d.observe("UpdateFile", start, err)
 	return err
 }

--- a/gitstore-api/internal/datastore/instrumented_test.go
+++ b/gitstore-api/internal/datastore/instrumented_test.go
@@ -36,7 +36,7 @@ func (s *stubDatastore) GetFileByName(_ context.Context, _, _ string) (*datastor
 func (s *stubDatastore) ListFiles(_ context.Context, _ string, _ datastore.PageParams) (*datastore.PageResult[datastore.File], error) {
 	return nil, s.getProductErr
 }
-func (s *stubDatastore) UpdateFile(_ context.Context, _ *datastore.File) error {
+func (s *stubDatastore) UpdateFile(_ context.Context, _ *datastore.File, _ string) error {
 	return s.getProductErr
 }
 func (s *stubDatastore) DeleteFile(_ context.Context, _ string) error { return s.getProductErr }

--- a/gitstore-api/internal/datastore/memdb/backend.go
+++ b/gitstore-api/internal/datastore/memdb/backend.go
@@ -220,14 +220,19 @@ func (m *memdbDatastore) ListFiles(_ context.Context, namespace string, page dat
 	return paginateSlice(all, page, func(f *datastore.File) (time.Time, string) { return f.CreationTimestamp, f.UID }), nil
 }
 
-func (m *memdbDatastore) UpdateFile(_ context.Context, f *datastore.File) error {
+func (m *memdbDatastore) UpdateFile(_ context.Context, f *datastore.File, expectedResourceVersion string) error {
 	if f == nil {
 		return fmt.Errorf("%w: file is nil", datastore.ErrInvalidArgument)
 	}
 	txn := m.db.Txn(true)
-	if raw, _ := txn.First("file", "id", f.UID); raw == nil {
+	raw, _ := txn.First("file", "id", f.UID)
+	if raw == nil {
 		txn.Abort()
 		return fmt.Errorf("%w: file uid %s", datastore.ErrNotFound, f.UID)
+	}
+	if raw.(*datastore.File).ResourceVersion != expectedResourceVersion {
+		txn.Abort()
+		return fmt.Errorf("%w: file uid %s", datastore.ErrConflict, f.UID)
 	}
 	if raw, _ := txn.First("file", "name_namespace", f.Namespace, f.Name); raw != nil && raw.(*datastore.File).UID != f.UID {
 		txn.Abort()

--- a/gitstore-api/internal/datastore/memdb/file_test.go
+++ b/gitstore-api/internal/datastore/memdb/file_test.go
@@ -51,6 +51,31 @@ func TestFileStatusUpdateUsesResourceVersionGuard(t *testing.T) {
 	require.ErrorIs(t, err, datastore.ErrConflict)
 }
 
+func TestFileUpdateUsesResourceVersionGuard(t *testing.T) {
+	store, err := New()
+	require.NoError(t, err)
+	defer store.Close()
+	file := &datastore.File{
+		UID: "00000000-0000-0000-0000-000000000054", Namespace: "ns", Name: "hero",
+		APIVersion: "storage.gitstore.dev/v1beta1", Kind: "File", ResourceVersion: "1",
+	}
+	require.NoError(t, store.CreateFile(context.Background(), file))
+
+	winner := *file
+	winner.ResourceVersion = "2"
+	winner.Body = "winner"
+	require.NoError(t, store.UpdateFile(context.Background(), &winner, "1"))
+
+	stale := *file
+	stale.ResourceVersion = "2"
+	stale.Body = "stale"
+	err = store.UpdateFile(context.Background(), &stale, "1")
+	require.ErrorIs(t, err, datastore.ErrConflict)
+	durable, err := store.GetFile(context.Background(), file.UID)
+	require.NoError(t, err)
+	require.Equal(t, "winner", durable.Body)
+}
+
 func TestFileOwnerReferenceProjectionIsRepositoryScoped(t *testing.T) {
 	store, err := New()
 	require.NoError(t, err)
@@ -71,7 +96,7 @@ func TestFileOwnerReferenceProjectionIsRepositoryScoped(t *testing.T) {
 	require.False(t, blocked)
 	file.OwnerReferences = nil
 	file.ResourceVersion = "2"
-	require.NoError(t, store.UpdateFile(context.Background(), file))
+	require.NoError(t, store.UpdateFile(context.Background(), file, "1"))
 	blocked, err = owners.HasBlockingOwnerDependents(context.Background(), datastore.OwnerReferenceScope{Namespace: "ns", RepositoryID: "owner-repo"}, "owner")
 	require.NoError(t, err)
 	require.False(t, blocked)

--- a/gitstore-api/internal/datastore/scylla/file.go
+++ b/gitstore-api/internal/datastore/scylla/file.go
@@ -143,7 +143,7 @@ func (s *scyllaDatastore) ListFiles(ctx context.Context, ns string, page datasto
 	}
 	return buildPageResult(items, page.Limit(), page), nil
 }
-func (s *scyllaDatastore) UpdateFile(ctx context.Context, f *datastore.File) error {
+func (s *scyllaDatastore) UpdateFile(ctx context.Context, f *datastore.File, expectedResourceVersion string) error {
 	old, err := s.GetFile(ctx, f.UID)
 	if err != nil {
 		return err
@@ -151,12 +151,15 @@ func (s *scyllaDatastore) UpdateFile(ctx context.Context, f *datastore.File) err
 	if old.Namespace != f.Namespace || old.Name != f.Name {
 		return datastore.ErrConflict
 	}
-	if err := validateResourceVersionTransition(old.ResourceVersion, f.ResourceVersion); err != nil {
+	if old.ResourceVersion != expectedResourceVersion {
+		return datastore.ErrConflict
+	}
+	if err := validateResourceVersionTransition(expectedResourceVersion, f.ResourceVersion); err != nil {
 		return err
 	}
 	row := toFileRow(f)
 	row.CreationTimestamp = old.CreationTimestamp
-	if err := s.updateFileAuthoritative(ctx, row, old.ResourceVersion); err != nil {
+	if err := s.updateFileAuthoritative(ctx, row, expectedResourceVersion); err != nil {
 		return err
 	}
 	return s.syncOwnerReferenceDependents(ctx, f.Namespace, f.RepositoryID, "File", f.UID, f.Name, f.ResourceVersion, old.OwnerReferences, f.OwnerReferences)
@@ -196,7 +199,7 @@ func (s *scyllaDatastore) UpdateFileStatus(ctx context.Context, ns, name string,
 	if err := datastore.ApplyFileStatusPatch(f, p); err != nil {
 		return nil, err
 	}
-	if err := s.UpdateFile(ctx, f); err != nil {
+	if err := s.UpdateFile(ctx, f, p.ResourceVersion); err != nil {
 		return nil, err
 	}
 	return f, nil

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -295,14 +295,13 @@ func (a *Authorize) authorizeSubscription(
 ) (any, error) {
 	var kind string
 	switch fc.Field.Name {
-	case "watchCategories":
-		kind = "Category"
-	case "watchProducts":
-		kind = "Product"
 	case "watchFiles":
 		kind = "File"
 	case "watchResources":
 		kind, _ = directStringArg(fc.Args, "kind")
+		if kind != "File" {
+			return next(ctx)
+		}
 	default:
 		return next(ctx)
 	}

--- a/gitstore-api/internal/middleware/security/graphql_file_status_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_file_status_test.go
@@ -149,3 +149,23 @@ func TestGraphQLFieldAuthorizerAuthorizesGenericFileWatch(t *testing.T) {
 	assert.Equal(t, "file.watch", authz.action)
 	assert.Equal(t, "acme-store", authz.resource.Attrs["namespace"])
 }
+
+func TestGraphQLFieldAuthorizerLeavesExistingNonFileWatchesUnchanged(t *testing.T) {
+	authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "no new permission")}
+	registry := auth.NewProviderRegistry(nil, authz, nil)
+	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
+	ctx := graphql.WithFieldContext(context.Background(), &graphql.FieldContext{
+		Object: "Subscription",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "watchProducts"}},
+		Args:   map[string]any{"namespace": "acme-store"},
+	})
+
+	called := false
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) {
+		called = true
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Empty(t, authz.action, "existing Product watch policy must not change in a File-scoped feature")
+}

--- a/gitstore-api/internal/testutil/stubstore.go
+++ b/gitstore-api/internal/testutil/stubstore.go
@@ -33,7 +33,7 @@ func (s *StubStore) GetFileByName(_ context.Context, _, _ string) (*datastore.Fi
 func (s *StubStore) ListFiles(_ context.Context, _ string, _ datastore.PageParams) (*datastore.PageResult[datastore.File], error) {
 	return &datastore.PageResult[datastore.File]{}, nil
 }
-func (s *StubStore) UpdateFile(_ context.Context, _ *datastore.File) error              { return nil }
+func (s *StubStore) UpdateFile(_ context.Context, _ *datastore.File, _ string) error    { return nil }
 func (s *StubStore) DeleteFile(_ context.Context, _ string) error                       { return nil }
 func (s *StubStore) DeleteFileWithResourceVersion(_ context.Context, _, _ string) error { return nil }
 func (s *StubStore) UpdateFileStatus(_ context.Context, _, _ string, _ datastore.FileStatusPatch) (*datastore.File, error) {

--- a/specs/051-file-resource-contract/spec.md
+++ b/specs/051-file-resource-contract/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-08-19
 
-**Status**: Closed
+**Status**: In progress
 
 **Input**: User description: "Support Kubernetes-style `File` frontmatter as the technical media primitive for GitStore (GH#79). Define the declarative `.spec`/`.status` schema contract for a brand-new `File` resource: top-level `apiVersion`/`kind`/`metadata`/`spec`/`status` envelope; `FileSpec` fields `contentType`, `source` (`FileSourceDefinition`), `type`, `processing.image.variants`; a lifecycle `status` indicator (`Uploaded`, `Processing`, `Ready`, `Failed`); the Markdown body used as alt text; validation that documents self-identify as `kind: File`. File-only — `MediaAsset` is an explicitly out-of-scope follow-on resource."
 


### PR DESCRIPTION
Follow-up to #400 for Codex findings posted immediately before its merge.\n\n- make full File updates resource-version guarded in memdb and ScyllaDB\n- retry current-commit admission conflicts so concurrent replicas converge\n- scope the new watch authorization requirement to File resources only\n- mark spec 051 in progress while its dual-version rolling-upgrade harness remains open\n\nValidation: make pr-ready