### PR TITLE
fix(api): enforce authorization on GraphQL watch subscriptions

### DIFF
--- a/docs/runbooks/controller-watch-status.md
+++ b/docs/runbooks/controller-watch-status.md
@@ -4,6 +4,15 @@
 
 A controller's `watchCategories`/`watchResources` subscription disconnects and reconnects (a normal occurrence), or its `updateCategoryStatus`/`updateResourceStatus` writes are being rejected. This runbook helps distinguish a transient, self-healing disconnect from a cursor that has actually expired (requiring a re-list), and helps interpret a sustained status-write-conflict rate.
 
+## Diagnostic Steps: Subscription Authorization Denials
+
+Every watch subscription field (`watchCategories`, `watchFiles`, `watchProducts`, and the generic `watchResources`) is authorized once, at subscribe time, by `GraphQLFieldAuthorizer` (`gitstore-api/internal/middleware/security/graphql.go`) — the same seam that already gates mutations like `updateCategoryStatus`. A denied subscribe attempt fails immediately with a GraphQL error carrying `extensions.code == "FORBIDDEN"` and never opens an event channel (the resolver never runs, so no partial/empty stream is returned).
+
+1. If a controller or client's subscription is rejected outright (not disconnecting/reconnecting, but failing on the initial `subscribe`), check the derived action string in the error's `permission denied: <reason>` message. The action follows `<kind>.watch` (e.g. `categoryTaxonomy.watch`, `file.watch`, `product.watch`, or `<kind>.watch` for whatever kind was passed to `watchResources`).
+2. Under the default `allow-all` AuthZ provider (local/dev `docker compose`), this check always passes — denials are only possible when the deployment is configured with `rbac-local` (`GITSTORE_AUTH__AUTHZ__PROVIDER=rbac-local`) or another `AuthZProvider` that enforces per-namespace policy.
+3. If a deployment switched to `rbac-local` and a previously-working controller (e.g. `gitstore-controller-manager`, which always calls these subscriptions without a `namespace` argument — i.e. it watches every namespace) starts failing to subscribe, grant its bound role the corresponding `<kind>.watch` action (or `"*"`) in `policy.yaml`, the same way the existing `controller` role convention already grants `*.status.write` (see `specs/040-controller-watch-status-api/research.md` R5).
+4. This check runs once per subscription, not once per delivered event — a subscription that was authorized to open cannot be revoked mid-stream by a later policy change (the caller must resubscribe for a new decision to take effect).
+
 ## Diagnostic Steps: Watch Disconnects
 
 1. Check the rate of subscriptions being opened for the affected kind:

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -112,13 +112,19 @@ func (a *Authorize) GraphQLAuthorizer(ctx context.Context, next graphql.Operatio
 }
 
 // GraphQLFieldAuthorizer runs fine-grained GraphQL authorization checks for
-// mutation fields that require policy evaluation against resource context.
+// mutation and subscription fields that require policy evaluation against
+// resource context. For subscriptions, this runs exactly once per field —
+// at subscribe time, when gqlgen resolves the root Subscription field to
+// obtain its event channel — not once per delivered event (gqlgen's
+// per-event marshaling of a subscription's result type re-enters
+// AroundFields with FieldContext.Object set to that result type, e.g.
+// "FileWatchEvent", never "Subscription" again).
 func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Resolver) (any, error) {
 	if a.logger == nil {
 		a.logger = zap.NewNop()
 	}
 	fc := graphql.GetFieldContext(ctx)
-	if fc == nil || fc.Object != "Mutation" {
+	if fc == nil || (fc.Object != "Mutation" && fc.Object != "Subscription") {
 		return next(ctx)
 	}
 
@@ -277,9 +283,58 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 				Extensions: map[string]any{"code": "FORBIDDEN"},
 			}
 		}
+	case "watchCategories":
+		if err := a.authorizeWatch(ctx, principal, authz, "categoryTaxonomy.watch", "CategoryTaxonomy", fc.Args); err != nil {
+			return nil, err
+		}
+	case "watchFiles":
+		if err := a.authorizeWatch(ctx, principal, authz, "file.watch", "File", fc.Args); err != nil {
+			return nil, err
+		}
+	case "watchProducts":
+		if err := a.authorizeWatch(ctx, principal, authz, "product.watch", "Product", fc.Args); err != nil {
+			return nil, err
+		}
+	case "watchResources":
+		kind, _ := fc.Args["kind"].(string)
+		action := lowerCamelFirst(kind) + ".watch"
+		if err := a.authorizeWatch(ctx, principal, authz, action, kind, fc.Args); err != nil {
+			return nil, err
+		}
 	}
 
 	return next(ctx)
+}
+
+// authorizeWatch enforces subscribe-time authorization for a watchXxx
+// subscription field. namespace (when present in args) is threaded through
+// as a ResourceContext attribute for forward-compatibility with
+// attribute-aware AuthZProvider implementations; rbac-local's current
+// policy engine only matches on the action string, mirroring the same
+// coarse-grained enforcement already applied to "repository.read" (Git
+// Smart HTTP) and every other action in this codebase.
+func (a *Authorize) authorizeWatch(ctx context.Context, principal *auth.Principal, authz auth.AuthZProvider, action, kind string, args map[string]any) error {
+	if authz == nil {
+		return gqlerror.Errorf("authorization service unavailable")
+	}
+	attrs := map[string]any{}
+	if ns, ok := args["namespace"].(*string); ok && ns != nil {
+		attrs["namespace"] = *ns
+	}
+	decision, err := authz.Authorize(ctx, principal, action, auth.ResourceContext{
+		Kind:  kind,
+		Attrs: attrs,
+	})
+	if err != nil {
+		return gqlerror.Errorf("authorization error")
+	}
+	if decision.Outcome == auth.OutcomeDeny {
+		return &gqlerror.Error{
+			Message:    fmt.Sprintf("permission denied: %s", decision.Reason),
+			Extensions: map[string]any{"code": "FORBIDDEN"},
+		}
+	}
+	return nil
 }
 
 func decodeCategoryID(encoded string) (string, error) {

--- a/gitstore-api/internal/middleware/security/graphql_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_test.go
@@ -601,6 +601,113 @@ func TestGraphQLFieldAuthorizerDeleteCategoryUsesPersistedScope(t *testing.T) {
 	assert.Equal(t, "catalog-repo", authz.resource.Attrs["repositoryID"])
 }
 
+func TestGraphQLFieldAuthorizerWatchFilesUsesWatchAction(t *testing.T) {
+	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	mw := NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+	ns := "acme"
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "alice", AuthMethod: "static-admin"})
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Subscription",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "watchFiles"}},
+		Args:   map[string]any{"namespace": &ns},
+	})
+
+	called := false
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) { called = true; return "ok", nil })
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "file.watch", authz.action)
+	assert.Equal(t, "File", authz.resource.Kind)
+	assert.Equal(t, "acme", authz.resource.Attrs["namespace"])
+}
+
+func TestGraphQLFieldAuthorizerWatchCategoriesUsesWatchAction(t *testing.T) {
+	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	mw := NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "alice", AuthMethod: "static-admin"})
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Subscription",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "watchCategories"}},
+		Args:   map[string]any{"namespace": (*string)(nil)},
+	})
+
+	called := false
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) { called = true; return "ok", nil })
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "categoryTaxonomy.watch", authz.action)
+	assert.NotContains(t, authz.resource.Attrs, "namespace")
+}
+
+func TestGraphQLFieldAuthorizerWatchProductsUsesWatchAction(t *testing.T) {
+	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	mw := NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "alice", AuthMethod: "static-admin"})
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Subscription",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "watchProducts"}},
+		Args:   map[string]any{},
+	})
+
+	called := false
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) { called = true; return "ok", nil })
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "product.watch", authz.action)
+}
+
+func TestGraphQLFieldAuthorizerWatchResourcesUsesLowerCamelKindWatchAction(t *testing.T) {
+	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	mw := NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "alice", AuthMethod: "static-admin"})
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Subscription",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "watchResources"}},
+		Args:   map[string]any{"kind": "BackfillJob"},
+	})
+
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) { return "ok", nil })
+	require.NoError(t, err)
+	assert.Equal(t, "backfillJob.watch", authz.action)
+	assert.Equal(t, "BackfillJob", authz.resource.Kind)
+}
+
+func TestGraphQLFieldAuthorizerWatchFilesDenyReturnsForbidden(t *testing.T) {
+	authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "no rights to this namespace")}
+	mw := NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+	ns := "other-tenant"
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "eve", AuthMethod: "static-admin"})
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Subscription",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "watchFiles"}},
+		Args:   map[string]any{"namespace": &ns},
+	})
+
+	called := false
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) { called = true; return "ok", nil })
+	require.Error(t, err)
+	assert.False(t, called, "the subscription resolver must never run when the field authorizer denies")
+	var gqlErr *gqlerror.Error
+	require.True(t, errors.As(err, &gqlErr))
+	assert.Equal(t, "FORBIDDEN", gqlErr.Extensions["code"])
+}
+
+func TestGraphQLFieldAuthorizerWatchFilesFailsWithoutAuthZ(t *testing.T) {
+	mw := NewAuthorizeWithStore(auth.NewProviderRegistry(nil, nil, nil), &testutil.StubStore{}, zap.NewNop())
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "eve", AuthMethod: "static-admin"})
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Subscription",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: "watchFiles"}},
+		Args:   map[string]any{"namespace": (*string)(nil)},
+	})
+
+	called := false
+	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) { called = true; return "ok", nil })
+	require.Error(t, err)
+	assert.False(t, called)
+	assert.Contains(t, err.Error(), "authorization service unavailable")
+}
+
 func TestGraphQLFieldAuthorizerUpdateResourceStatusUsesLowerCamelKindAction(t *testing.T) {
 	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
 	registry := auth.NewProviderRegistry(nil, authz, nil)

--- a/gitstore-api/tests/contract/watch_authz_test.go
+++ b/gitstore-api/tests/contract/watch_authz_test.go
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package contract_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/gitstore-dev/gitstore/api/internal/auth"
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/gitstore-dev/gitstore/api/internal/eventbus"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
+	"github.com/gitstore-dev/gitstore/api/internal/middleware/security"
+	"github.com/gitstore-dev/gitstore/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"go.uber.org/zap"
+)
+
+// namespaceScopedAuthZ denies watch actions for any namespace other than
+// allowedNamespace, mirroring a tenant boundary an operator would configure
+// via a real AuthZProvider. rbac-local itself doesn't evaluate the
+// namespace attribute today (it only matches on the action string), but
+// this stub proves the enforcement seam GraphQLFieldAuthorizer now wires
+// through actually reaches an attribute-aware provider correctly.
+type namespaceScopedAuthZ struct {
+	allowedNamespace string
+}
+
+func (n *namespaceScopedAuthZ) Name() string { return "namespace-scoped-stub" }
+
+func (n *namespaceScopedAuthZ) Authorize(_ context.Context, _ *auth.Principal, action string, res auth.ResourceContext) (auth.Decision, error) {
+	if ns, _ := res.Attrs["namespace"].(string); ns != "" && ns != n.allowedNamespace {
+		return auth.Deny("namespace-scoped-stub", "principal has no rights to namespace "+ns), nil
+	}
+	return auth.Allow("namespace-scoped-stub", "action "+action+" permitted for namespace"), nil
+}
+
+// subscribeThroughFieldAuthorizer runs GraphQLFieldAuthorizer exactly the
+// way gqlgen's AroundFields hook runs it for a Subscription root field
+// (once, at subscribe time — see graphql.go's GraphQLFieldAuthorizer
+// doc comment), then invokes resolve to obtain the subscription's event
+// channel. Mirrors gitstore-api/internal/middleware/security/graphql_test.go's
+// existing GraphQLFieldAuthorizer test pattern for mutations.
+func subscribeThroughFieldAuthorizer(
+	ctx context.Context,
+	mw security.Authorize,
+	fieldName string,
+	args map[string]any,
+	resolve func(ctx context.Context) (any, error),
+) (any, error) {
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Subscription",
+		Field:  graphql.CollectedField{Field: &ast.Field{Name: fieldName}},
+		Args:   args,
+	})
+	return mw.GraphQLFieldAuthorizer(ctx, resolve)
+}
+
+func TestWatchFiles_UnauthorizedNamespaceRejectsSubscribeAttempt(t *testing.T) {
+	r, _, _ := newWatchTestResolver(t)
+	authz := &namespaceScopedAuthZ{allowedNamespace: "acme"}
+	mw := security.NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "eve", AuthMethod: "static-admin"})
+	resolved := false
+	result, err := subscribeThroughFieldAuthorizer(ctx, mw, "watchFiles", map[string]any{"namespace": strptr("other-tenant")},
+		func(innerCtx context.Context) (any, error) {
+			resolved = true
+			return r.Subscription().WatchFiles(innerCtx, strptr("other-tenant"), nil, nil)
+		})
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.False(t, resolved, "resolver must never run — the subscription attempt itself must be rejected, not silently return an empty channel")
+	var gqlErr *gqlerror.Error
+	require.ErrorAs(t, err, &gqlErr)
+	require.Equal(t, "FORBIDDEN", gqlErr.Extensions["code"])
+}
+
+func TestWatchResources_UnauthorizedNamespaceRejectsSubscribeAttempt(t *testing.T) {
+	r, _, _ := newWatchTestResolver(t)
+	authz := &namespaceScopedAuthZ{allowedNamespace: "acme"}
+	mw := security.NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "eve", AuthMethod: "static-admin"})
+	resolved := false
+	_, err := subscribeThroughFieldAuthorizer(ctx, mw, "watchResources", map[string]any{"kind": "File", "namespace": strptr("other-tenant")},
+		func(innerCtx context.Context) (any, error) {
+			resolved = true
+			return r.Subscription().WatchResources(innerCtx, "File", strptr("other-tenant"), nil, nil)
+		})
+
+	require.Error(t, err)
+	require.False(t, resolved)
+	var gqlErr *gqlerror.Error
+	require.ErrorAs(t, err, &gqlErr)
+	require.Equal(t, "FORBIDDEN", gqlErr.Extensions["code"])
+}
+
+func TestWatchCategories_UnauthorizedNamespaceRejectsSubscribeAttempt(t *testing.T) {
+	r, _, _ := newWatchTestResolver(t)
+	authz := &namespaceScopedAuthZ{allowedNamespace: "acme"}
+	mw := security.NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "eve", AuthMethod: "static-admin"})
+	resolved := false
+	_, err := subscribeThroughFieldAuthorizer(ctx, mw, "watchCategories", map[string]any{"namespace": strptr("other-tenant")},
+		func(innerCtx context.Context) (any, error) {
+			resolved = true
+			return r.Subscription().WatchCategories(innerCtx, strptr("other-tenant"), nil, nil)
+		})
+
+	require.Error(t, err)
+	require.False(t, resolved)
+	var gqlErr *gqlerror.Error
+	require.ErrorAs(t, err, &gqlErr)
+	require.Equal(t, "FORBIDDEN", gqlErr.Extensions["code"])
+}
+
+func TestWatchProducts_UnauthorizedNamespaceRejectsSubscribeAttempt(t *testing.T) {
+	r, _, _ := newWatchTestResolver(t)
+	authz := &namespaceScopedAuthZ{allowedNamespace: "acme"}
+	mw := security.NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "eve", AuthMethod: "static-admin"})
+	resolved := false
+	_, err := subscribeThroughFieldAuthorizer(ctx, mw, "watchProducts", map[string]any{"namespace": strptr("other-tenant")},
+		func(innerCtx context.Context) (any, error) {
+			resolved = true
+			return r.Subscription().WatchProducts(innerCtx, strptr("other-tenant"), nil, nil)
+		})
+
+	require.Error(t, err)
+	require.False(t, resolved)
+	var gqlErr *gqlerror.Error
+	require.ErrorAs(t, err, &gqlErr)
+	require.Equal(t, "FORBIDDEN", gqlErr.Extensions["code"])
+}
+
+// TestWatchFiles_AuthorizedPrincipalSubscribesAndReceivesEvents is the no-
+// regression counterpart to the deny tests above: a principal with rights
+// to its own namespace still opens the subscription and receives events
+// published for that namespace, unchanged from pre-fix behavior.
+func TestWatchFiles_AuthorizedPrincipalSubscribesAndReceivesEvents(t *testing.T) {
+	r, _, bus := newWatchTestResolver(t)
+	authz := &namespaceScopedAuthZ{allowedNamespace: "acme"}
+	mw := security.NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = auth.ContextWithPrincipal(ctx, &auth.Principal{Subject: "alice", AuthMethod: "static-admin"})
+
+	resolved := false
+	result, err := subscribeThroughFieldAuthorizer(ctx, mw, "watchFiles", map[string]any{"namespace": strptr("acme")},
+		func(innerCtx context.Context) (any, error) {
+			resolved = true
+			return r.Subscription().WatchFiles(innerCtx, strptr("acme"), nil, nil)
+		})
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	events, ok := result.(<-chan *model.FileWatchEvent)
+	require.True(t, ok)
+
+	file := &datastore.File{
+		UID: "00000000-0000-0000-0000-000000000099", Namespace: "acme", Name: "hero",
+		APIVersion: "storage.gitstore.dev/v1beta1", Kind: "File",
+	}
+	bus.Publish(eventbus.Event{Type: eventbus.Added, Kind: "File", Namespace: "acme", Name: "hero", ResourceVersion: "1", Object: file})
+
+	select {
+	case ev := <-events:
+		require.Equal(t, "hero", ev.Name)
+	case <-time.After(time.Second):
+		t.Fatal("authorized principal never received its own namespace's event")
+	}
+}
+
+// TestWatchResources_AuthorizedPrincipalSubscribesAndReceivesEvents is the
+// generic-path no-regression counterpart: a principal with rights to its own
+// namespace still opens a watchResources subscription and receives events,
+// unchanged from pre-fix behavior.
+func TestWatchResources_AuthorizedPrincipalSubscribesAndReceivesEvents(t *testing.T) {
+	r, _, bus := newWatchTestResolver(t)
+	authz := &namespaceScopedAuthZ{allowedNamespace: "acme"}
+	mw := security.NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = auth.ContextWithPrincipal(ctx, &auth.Principal{Subject: "alice", AuthMethod: "static-admin"})
+
+	resolved := false
+	result, err := subscribeThroughFieldAuthorizer(ctx, mw, "watchResources", map[string]any{"kind": "File", "namespace": strptr("acme")},
+		func(innerCtx context.Context) (any, error) {
+			resolved = true
+			return r.Subscription().WatchResources(innerCtx, "File", strptr("acme"), nil, nil)
+		})
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	events, ok := result.(<-chan *model.WatchEvent)
+	require.True(t, ok)
+
+	file := &datastore.File{
+		UID: "00000000-0000-0000-0000-000000000098", Namespace: "acme", Name: "hero",
+		APIVersion: "storage.gitstore.dev/v1beta1", Kind: "File",
+	}
+	bus.Publish(eventbus.Event{Type: eventbus.Added, Kind: "File", Namespace: "acme", Name: "hero", ResourceVersion: "1", Object: file})
+
+	select {
+	case ev := <-events:
+		require.Equal(t, "hero", ev.Name)
+	case <-time.After(time.Second):
+		t.Fatal("authorized principal never received its own namespace's event")
+	}
+}
+
+// TestWatchCategories_AuthorizedPrincipalSubscribesAndReceivesEvents is the
+// no-regression counterpart to the watchCategories deny test above.
+func TestWatchCategories_AuthorizedPrincipalSubscribesAndReceivesEvents(t *testing.T) {
+	r, _, bus := newWatchTestResolver(t)
+	authz := &namespaceScopedAuthZ{allowedNamespace: "acme"}
+	mw := security.NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = auth.ContextWithPrincipal(ctx, &auth.Principal{Subject: "alice", AuthMethod: "static-admin"})
+
+	resolved := false
+	result, err := subscribeThroughFieldAuthorizer(ctx, mw, "watchCategories", map[string]any{"namespace": strptr("acme")},
+		func(innerCtx context.Context) (any, error) {
+			resolved = true
+			return r.Subscription().WatchCategories(innerCtx, strptr("acme"), nil, nil)
+		})
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	events, ok := result.(<-chan *model.CategoryWatchEvent)
+	require.True(t, ok)
+
+	bus.Publish(eventbus.Event{Type: eventbus.Added, Kind: "CategoryTaxonomy", Namespace: "acme", Name: "electronics", ResourceVersion: "1"})
+
+	e := mustReceiveCategoryEvent(t, events)
+	require.Equal(t, "electronics", e.Name)
+}
+
+// TestWatchFiles_MissingAuthZProviderRejectsSubscribeAttempt matches the
+// existing "authorization service unavailable" behavior mutations already
+// get in graphql_test.go when no AuthZProvider is configured — subscriptions
+// must fail closed too, not fall back to unauthenticated streaming.
+func TestWatchFiles_MissingAuthZProviderRejectsSubscribeAttempt(t *testing.T) {
+	mw := security.NewAuthorizeWithStore(auth.NewProviderRegistry(nil, nil, nil), &testutil.StubStore{}, zap.NewNop())
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "eve", AuthMethod: "static-admin"})
+
+	resolved := false
+	_, err := subscribeThroughFieldAuthorizer(ctx, mw, "watchFiles", map[string]any{"namespace": strptr("acme")},
+		func(context.Context) (any, error) {
+			resolved = true
+			return nil, nil
+		})
+	require.Error(t, err)
+	require.False(t, resolved)
+	require.Contains(t, err.Error(), "authorization service unavailable")
+}


### PR DESCRIPTION
## Summary
- `watchCategories`/`watchFiles`/`watchProducts`/`watchResources` subscription resolvers bypassed `GraphQLFieldAuthorizer` entirely — its dispatch only checked `fc.Object == "Mutation"`, so a subscription request skipped straight to `next(ctx)` with no authorization check at all, regardless of AuthZ provider configuration.
- Extends `GraphQLFieldAuthorizer` to also authorize `Subscription` root fields, deriving a `<kind>.watch` action string per the existing `lowerCamelFirst(kind) + ".<verb>"` convention already used for `updateResourceStatus`. A denied attempt returns a `FORBIDDEN` GraphQL error and the resolver never runs (no empty-channel fallback).
- This is checked exactly once per subscription, at subscribe time: gqlgen's `AroundFields` hook wraps the resolver call that establishes the event channel (via `graphql.ResolveFieldStream`), not each subsequently streamed event — confirmed by reading `github.com/99designs/gqlgen@v0.17.90/graphql/resolve_field.go`. Per-event re-authorization is neither necessary nor structurally possible at this seam, which is documented in the new code comment.
- Adds a `docs/runbooks/controller-watch-status.md` section explaining the new `FORBIDDEN` failure mode and the operator action needed if a deployment switches from the default `allow-all` provider to `rbac-local` (grant the bound role the corresponding `<kind>.watch` action).

## Test plan
- [x] `gitstore-api/internal/middleware/security/graphql_test.go`: new unit tests for each `watchXxx` field covering allow, deny (`FORBIDDEN`), missing-AuthZ-provider, and the generic `watchResources` kind-derivation.
- [x] `gitstore-api/tests/contract/watch_authz_test.go`: contract-level tests proving (a) an unauthorized principal's subscribe attempt is rejected before the resolver ever runs (no silent empty channel) for all four fields, and (b) an authorized principal still subscribes and receives real events off the eventbus (no regression), using a namespace-aware stub `AuthZProvider` to demonstrate the enforcement seam correctly reaches attribute-aware providers.
- [x] `cd gitstore-api && go build ./... && go test -count=1 -race ./...` — full suite green.
- [x] Live-verified against the real `docker compose` stack (rbac-local provider, minted JWT bearer tokens for two subjects over the real `graphql-transport-ws` protocol via a `ws`-based Node client): an unbound subject's `watchFiles`/`watchResources` subscribe attempt got an immediate `FORBIDDEN` error; a subject bound to a role granting the watch action subscribed successfully with no error (connection stayed open, matching the resolver having actually run).
- [x] Full `tests/integration` suite run against a fresh `docker compose` stack (CI's exact recipe) — all green, no regressions.
- [x] `compose.yml`/`gitstore-git-service/Cargo.lock` local-testing drift reverted; `docker compose down -v` run before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)