### PR TITLE
fix: match Namespace condition-status casing to the GraphQL wire enum

### DIFF
--- a/gitstore-controller-manager/internal/namespace/reconciler.go
+++ b/gitstore-controller-manager/internal/namespace/reconciler.go
@@ -25,6 +25,16 @@ const (
 	conditionSystemRepoReady   = "SystemRepoReady"
 	conditionReady             = "Ready"
 
+	// statusTrue/statusFalse match the GraphQL wire enum ConditionStatus
+	// (shared/schemas/schema.graphqls: TRUE/FALSE/UNKNOWN), not Go's
+	// zero-value bool-ish casing. This matters because
+	// internal/status.StatusPatch.IsNoOp compares Condition.Status
+	// case-sensitively against values read back from the real GraphQL
+	// list/watch path, which always carries the enum's upper-case wire
+	// casing.
+	statusTrue  = "TRUE"
+	statusFalse = "FALSE"
+
 	namespaceDrainPollInterval = 5 * time.Second
 )
 
@@ -154,7 +164,7 @@ func mergeControllerConditions(current Namespace, admitted, systemReady bool, pr
 
 	systemCondition := &status.Condition{
 		Type:               conditionSystemRepoReady,
-		Status:             "False",
+		Status:             statusFalse,
 		ObservedGeneration: current.Generation,
 		LastTransitionTime: time.Now(),
 	}
@@ -166,21 +176,21 @@ func mergeControllerConditions(current Namespace, admitted, systemReady bool, pr
 		systemCondition.Reason = "ProvisioningFailed"
 		systemCondition.Message = provisionErr.Error()
 	default:
-		systemCondition.Status = "True"
+		systemCondition.Status = statusTrue
 		systemCondition.Reason = "RepositoryReady"
 		systemCondition.Message = "per-namespace gitstore-system repository exists"
 	}
 
 	readyCondition := &status.Condition{
 		Type:               conditionReady,
-		Status:             "False",
+		Status:             statusFalse,
 		ObservedGeneration: current.Generation,
 		LastTransitionTime: time.Now(),
 		Reason:             "ConditionsNotSatisfied",
 		Message:            "AdmissionAccepted and SystemRepoReady must both be True",
 	}
 	if admitted && systemReady {
-		readyCondition.Status = "True"
+		readyCondition.Status = statusTrue
 		readyCondition.Reason = "NamespaceReady"
 		readyCondition.Message = "namespace admission and system repository provisioning are complete"
 	}

--- a/gitstore-controller-manager/internal/namespace/reconciler_test.go
+++ b/gitstore-controller-manager/internal/namespace/reconciler_test.go
@@ -69,7 +69,7 @@ func seedNamespaceCache(t *testing.T, items ...Namespace) cache.CacheAccessor[Na
 }
 
 func admittedCondition(generation int64) *status.Condition {
-	return &status.Condition{Type: "AdmissionAccepted", Status: "True", ObservedGeneration: generation}
+	return &status.Condition{Type: "AdmissionAccepted", Status: "TRUE", ObservedGeneration: generation}
 }
 
 func conditionByType(t *testing.T, conditions []*status.Condition, conditionType string) *status.Condition {
@@ -126,14 +126,14 @@ func TestReconcileAdmittedNamespaceProvisionsSystemRepositoryAndMarksReady(t *te
 	if patch.ResourceVersion != "7" || patch.ObservedGeneration == nil || *patch.ObservedGeneration != 3 {
 		t.Fatalf("patch version fields = %+v, want rv=7 generation=3", patch)
 	}
-	if got := conditionByType(t, patch.Conditions, "AdmissionAccepted").Status; got != "True" {
-		t.Errorf("AdmissionAccepted = %q, want True", got)
+	if got := conditionByType(t, patch.Conditions, "AdmissionAccepted").Status; got != "TRUE" {
+		t.Errorf("AdmissionAccepted = %q, want TRUE", got)
 	}
-	if got := conditionByType(t, patch.Conditions, "SystemRepoReady").Status; got != "True" {
-		t.Errorf("SystemRepoReady = %q, want True", got)
+	if got := conditionByType(t, patch.Conditions, "SystemRepoReady").Status; got != "TRUE" {
+		t.Errorf("SystemRepoReady = %q, want TRUE", got)
 	}
-	if got := conditionByType(t, patch.Conditions, "Ready").Status; got != "True" {
-		t.Errorf("Ready = %q, want True", got)
+	if got := conditionByType(t, patch.Conditions, "Ready").Status; got != "TRUE" {
+		t.Errorf("Ready = %q, want TRUE", got)
 	}
 }
 
@@ -168,11 +168,11 @@ func TestReconcileProvisionFailureWritesFalseConditionsAndRetries(t *testing.T) 
 	if len(sc.patches) != 1 {
 		t.Fatalf("status calls = %d, want 1", len(sc.patches))
 	}
-	if got := conditionByType(t, sc.patches[0].Conditions, "SystemRepoReady").Status; got != "False" {
-		t.Errorf("SystemRepoReady = %q, want False", got)
+	if got := conditionByType(t, sc.patches[0].Conditions, "SystemRepoReady").Status; got != "FALSE" {
+		t.Errorf("SystemRepoReady = %q, want FALSE", got)
 	}
-	if got := conditionByType(t, sc.patches[0].Conditions, "Ready").Status; got != "False" {
-		t.Errorf("Ready = %q, want False", got)
+	if got := conditionByType(t, sc.patches[0].Conditions, "Ready").Status; got != "FALSE" {
+		t.Errorf("Ready = %q, want FALSE", got)
 	}
 }
 
@@ -188,14 +188,14 @@ func TestReconcileReadyStatusNoOpDoesNotWriteAgain(t *testing.T) {
 				admittedCondition(2),
 				{
 					Type:               "SystemRepoReady",
-					Status:             "True",
+					Status:             "TRUE",
 					ObservedGeneration: 2,
 					Reason:             "RepositoryReady",
 					Message:            "per-namespace gitstore-system repository exists",
 				},
 				{
 					Type:               "Ready",
-					Status:             "True",
+					Status:             "TRUE",
 					ObservedGeneration: 2,
 					Reason:             "NamespaceReady",
 					Message:            "namespace admission and system repository provisioning are complete",
@@ -235,8 +235,8 @@ func TestReconcileWithoutAdmissionDoesNotProvision(t *testing.T) {
 	if len(repos.ensured) != 0 {
 		t.Fatalf("ensured = %v, want no provisioning before admission", repos.ensured)
 	}
-	if got := conditionByType(t, sc.patches[0].Conditions, "SystemRepoReady").Status; got != "False" {
-		t.Errorf("SystemRepoReady = %q, want False", got)
+	if got := conditionByType(t, sc.patches[0].Conditions, "SystemRepoReady").Status; got != "FALSE" {
+		t.Errorf("SystemRepoReady = %q, want FALSE", got)
 	}
 }
 

--- a/gitstore-controller-manager/internal/status/graphql_resource_status_client_test.go
+++ b/gitstore-controller-manager/internal/status/graphql_resource_status_client_test.go
@@ -32,7 +32,7 @@ func TestResourceStatusApplySendsKindAwareMutation(t *testing.T) {
 		ObservedGeneration: &generation,
 		Conditions: []*status.Condition{{
 			Type:               "SystemRepoReady",
-			Status:             "True",
+			Status:             "TRUE",
 			ObservedGeneration: generation,
 		}},
 	})

--- a/gitstore-controller-manager/internal/status/graphql_status_client.go
+++ b/gitstore-controller-manager/internal/status/graphql_status_client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/graphqlclient"
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/types"
@@ -99,33 +98,12 @@ func toUpdateCategoryStatusInput(key types.WorkItemKey, patch *StatusPatch) (map
 	return input, nil
 }
 
-// normalizeConditionStatus upper-cases a Condition.Status value before it is
-// sent over the wire as the GraphQL ConditionStatus enum (TRUE/FALSE/UNKNOWN).
-// categorytaxonomy's own statusTrue/statusFalse/statusUnknown constants
-// already match this casing directly, so this is a no-op for that package,
-// but internal/namespace's reconciler still constructs conditions with
-// Go-idiomatic "True"/"False" literals -- this remains load-bearing for
-// that caller and must not be deleted while that's still the case.
-func normalizeConditionStatus(status string) string {
-	status = strings.TrimSpace(status)
-	switch strings.ToUpper(status) {
-	case "TRUE":
-		return "TRUE"
-	case "FALSE":
-		return "FALSE"
-	case "UNKNOWN":
-		return "UNKNOWN"
-	default:
-		return status
-	}
-}
-
 func toConditionInputs(conditions []*Condition) []map[string]any {
 	out := make([]map[string]any, 0, len(conditions))
 	for _, c := range conditions {
 		out = append(out, map[string]any{
 			"type":               c.Type,
-			"status":             normalizeConditionStatus(c.Status),
+			"status":             c.Status,
 			"observedGeneration": c.ObservedGeneration,
 			"lastTransitionTime": c.LastTransitionTime.Format(graphQLDateTimeLayout),
 			"reason":             c.Reason,

--- a/gitstore-controller-manager/internal/status/graphql_status_client_test.go
+++ b/gitstore-controller-manager/internal/status/graphql_status_client_test.go
@@ -29,7 +29,7 @@ func testPatch() *status.StatusPatch {
 		ObservedGeneration: &gen,
 		Conditions: []*status.Condition{{
 			Type:               "Ready",
-			Status:             "True",
+			Status:             "TRUE",
 			ObservedGeneration: gen,
 			LastTransitionTime: now,
 		}},


### PR DESCRIPTION
## Summary
- `internal/namespace`'s `Reconciler` independently built conditions with Go-idiomatic `"True"`/`"False"` literals instead of the `ConditionStatus` wire enum's `TRUE`/`FALSE`/`UNKNOWN` casing — the same root cause fixed for `CategoryTaxonomy` in #397, found as a second instance in this package while that PR was in flight. Because `internal/status.StatusPatch.IsNoOp` compares `Condition.Status` case-sensitively, a freshly computed condition never matched the value read back from the real GraphQL list/watch path, so every dispatch of an already-converged Namespace re-issued a redundant `updateResourceStatus` mutation (and reset `LastTransitionTime` every time too, via the same casing mismatch in `preserveTransitionTime`).
- Adds `statusTrue`/`statusFalse` constants to `reconciler.go` (mirroring `categorytaxonomy/conditions.go`'s pattern) and updates `reconciler_test.go` fixtures to the wire casing.
- `internal/status.normalizeConditionStatus` was a write-path workaround kept alive specifically for this Namespace instance (per #397's own comment). With both reconcilers now emitting wire-cased conditions, it has no remaining caller relying on non-wire casing — deleted as dead code, and the two direct unit tests that exercised its normalizing behavior were updated to assert on wire-cased input instead.

## Verification
- `go build ./...` and `go test ./...` pass in `gitstore-controller-manager`.
- Live-verified against a local `docker compose` stack: pushed a Namespace update through the git-backed admission path, confirmed it converges to `AdmissionAccepted=TRUE`/`SystemRepoReady=TRUE`/`Ready=TRUE`, then captured a 15s idle window of `docker compose logs controller-manager` with **zero** additional Namespace reconcile/status-write log lines — matching #397's methodology for CategoryTaxonomy.
  - Note: reaching convergence required manually pre-creating the namespace's `gitstore-system` repository, because of an unrelated, pre-existing bug in `GraphQLRepositoryClient.systemRepositoryExists` (the `repository(by:)` query returns a top-level GraphQL error for "not found" instead of a null result, which `EnsureSystemRepository` doesn't special-case, so it returns early without ever attempting `createRepository`). This is out of scope for this change and left as a follow-up.
- Full `tests/integration` suite passes (`go test ./...`), including `TestNamespaceLifecycle_CreateAndUpdateThroughAdmission` and `TestNamespaceLifecycle_AuthoredStatusIsIgnored`.

## Test plan
- [x] `go build ./...` (gitstore-controller-manager)
- [x] `go test ./...` (gitstore-controller-manager)
- [x] Live docker-compose verification of Namespace convergence + idle-window churn check
- [x] `go test ./...` (tests/integration), focused re-run of `TestNamespace*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)