### PR TITLE
fix: forward OwnerReferenceStore/CategoryTaxonomyDeletionStore through InstrumentedDatastore

### DIFF
--- a/gitstore-api/internal/cataloggrpc/server.go
+++ b/gitstore-api/internal/cataloggrpc/server.go
@@ -394,6 +394,9 @@ func (s *Server) ValidateCategoryTaxonomyDeletion(
 	}
 	namespace, err := s.resolveNamespaceIdentifier(ctx, req.GetRepositoryId())
 	if err != nil {
+		s.log.Error("validate_category_taxonomy_deletion: cannot resolve namespace for repository",
+			zap.String("repository_id", req.GetRepositoryId()),
+			zap.Error(err))
 		return nil, grpcstatus.Error(codes.Unavailable, "category deletion validation unavailable")
 	}
 
@@ -445,6 +448,9 @@ func (s *Server) ValidateCategoryTaxonomyDeletion(
 		// covers children authored in other repositories of the namespace.
 		owners, ok := s.store.(datastore.OwnerReferenceStore)
 		if !ok {
+			s.log.Error("validate_category_taxonomy_deletion: datastore does not implement OwnerReferenceStore",
+				zap.String("repository_id", req.GetRepositoryId()),
+				zap.String("namespace", namespace))
 			return nil, grpcstatus.Error(codes.Unavailable, "category deletion validation unavailable")
 		}
 		for _, operation := range deriveResourceAdmissionOperations(oldEntries, proposedEntries, nil) {
@@ -456,12 +462,23 @@ func (s *Server) ValidateCategoryTaxonomyDeletion(
 				if errors.Is(lookupErr, datastore.ErrNotFound) {
 					continue
 				}
+				s.log.Error("validate_category_taxonomy_deletion: lookup category taxonomy failed",
+					zap.String("repository_id", req.GetRepositoryId()),
+					zap.String("namespace", operation.identity.Namespace),
+					zap.String("name", operation.identity.Name),
+					zap.Error(lookupErr))
 				return nil, grpcstatus.Error(codes.Unavailable, "category deletion validation unavailable")
 			}
 			cursor := ""
 			for {
 				page, listErr := owners.ListBlockingOwnerDependents(ctx, datastore.OwnerReferenceScope{Namespace: owner.Namespace, RepositoryID: owner.RepositoryID}, owner.UID, cursor, datastore.MaxOwnerDependentPageSize)
 				if listErr != nil {
+					s.log.Error("validate_category_taxonomy_deletion: list blocking owner dependents failed",
+						zap.String("repository_id", req.GetRepositoryId()),
+						zap.String("namespace", owner.Namespace),
+						zap.String("owner_uid", owner.UID),
+						zap.String("cursor", cursor),
+						zap.Error(listErr))
 					return nil, grpcstatus.Error(codes.Unavailable, "category deletion validation unavailable")
 				}
 				for _, dependent := range page.Items {

--- a/gitstore-api/internal/datastore/instrumented.go
+++ b/gitstore-api/internal/datastore/instrumented.go
@@ -533,6 +533,82 @@ func (d *InstrumentedDatastore) DeleteNamespaceMapping(ctx context.Context, name
 	return err
 }
 
+// ── OwnerReferenceStore ──────────────────────────────────────────────────────
+//
+// OwnerReferenceStore and CategoryTaxonomyDeletionStore below are additive to
+// Datastore (see their doc comments in datastore.go), so InstrumentedDatastore
+// must forward them explicitly rather than relying on method promotion:
+// wrapping next in this decorator would otherwise make every backend look
+// like it doesn't implement these interfaces to a type assertion on the
+// wrapper, even though the concrete backend (memdb, Scylla) does.
+
+func (d *InstrumentedDatastore) HasBlockingOwnerDependents(ctx context.Context, scope OwnerReferenceScope, ownerUID string) (bool, error) {
+	start := time.Now()
+	owners, ok := d.next.(OwnerReferenceStore)
+	if !ok {
+		err := fmt.Errorf("%w: backend does not support owner-reference queries", ErrInvalidArgument)
+		d.observe("HasBlockingOwnerDependents", start, err)
+		return false, err
+	}
+	v, err := owners.HasBlockingOwnerDependents(d.withFindingObserver(ctx), scope, ownerUID)
+	d.observe("HasBlockingOwnerDependents", start, err)
+	return v, err
+}
+
+func (d *InstrumentedDatastore) ListBlockingOwnerDependents(ctx context.Context, scope OwnerReferenceScope, ownerUID, after string, limit int) (OwnerDependentPage, error) {
+	start := time.Now()
+	owners, ok := d.next.(OwnerReferenceStore)
+	if !ok {
+		err := fmt.Errorf("%w: backend does not support owner-reference queries", ErrInvalidArgument)
+		d.observe("ListBlockingOwnerDependents", start, err)
+		return OwnerDependentPage{}, err
+	}
+	v, err := owners.ListBlockingOwnerDependents(d.withFindingObserver(ctx), scope, ownerUID, after, limit)
+	d.observe("ListBlockingOwnerDependents", start, err)
+	return v, err
+}
+
+func (d *InstrumentedDatastore) ListNonBlockingProductOwnerDependents(ctx context.Context, scope OwnerReferenceScope, ownerUID, after string, limit int) (OwnerDependentPage, error) {
+	start := time.Now()
+	owners, ok := d.next.(OwnerReferenceStore)
+	if !ok {
+		err := fmt.Errorf("%w: backend does not support owner-reference queries", ErrInvalidArgument)
+		d.observe("ListNonBlockingProductOwnerDependents", start, err)
+		return OwnerDependentPage{}, err
+	}
+	v, err := owners.ListNonBlockingProductOwnerDependents(d.withFindingObserver(ctx), scope, ownerUID, after, limit)
+	d.observe("ListNonBlockingProductOwnerDependents", start, err)
+	return v, err
+}
+
+// ── CategoryTaxonomyDeletionStore ────────────────────────────────────────────
+
+func (d *InstrumentedDatastore) MarkCategoryTaxonomyDeletion(ctx context.Context, namespace, name, expectedResourceVersion string, at time.Time) (*CategoryTaxonomy, error) {
+	start := time.Now()
+	lifecycle, ok := d.next.(CategoryTaxonomyDeletionStore)
+	if !ok {
+		err := fmt.Errorf("%w: backend does not support category taxonomy deletion lifecycle", ErrInvalidArgument)
+		d.observe("MarkCategoryTaxonomyDeletion", start, err)
+		return nil, err
+	}
+	v, err := lifecycle.MarkCategoryTaxonomyDeletion(d.withFindingObserver(ctx), namespace, name, expectedResourceVersion, at)
+	d.observe("MarkCategoryTaxonomyDeletion", start, err)
+	return v, err
+}
+
+func (d *InstrumentedDatastore) CompleteCategoryTaxonomyDeletion(ctx context.Context, namespace, name, expectedResourceVersion string) (*CategoryTaxonomy, error) {
+	start := time.Now()
+	lifecycle, ok := d.next.(CategoryTaxonomyDeletionStore)
+	if !ok {
+		err := fmt.Errorf("%w: backend does not support category taxonomy deletion lifecycle", ErrInvalidArgument)
+		d.observe("CompleteCategoryTaxonomyDeletion", start, err)
+		return nil, err
+	}
+	v, err := lifecycle.CompleteCategoryTaxonomyDeletion(d.withFindingObserver(ctx), namespace, name, expectedResourceVersion)
+	d.observe("CompleteCategoryTaxonomyDeletion", start, err)
+	return v, err
+}
+
 // ── Lifecycle ──────────────────────────────────────────────────────────────
 
 func (d *InstrumentedDatastore) Close() error {


### PR DESCRIPTION
## Summary

- Root-caused `TestAdmission_BranchDeletion`'s intermittent `! [remote rejected] ... (category deletion validation unavailable)` failure (tracked in this session's deflake backlog, item #2) by catching it live: under concurrent load, `gitstore-git-service`'s `category_taxonomy_deletion_validation_complete` trace showed `duration_ms: 1`, `outcome: "service_unavailable"` — ruling out the 10s timeout path entirely. The new API-side logging (added in this PR) pinpointed the exact line: `cataloggrpc/server.go:451`'s `s.store.(datastore.OwnerReferenceStore)` type assertion failing.
- The real bug: `InstrumentedDatastore` (which unconditionally wraps every backend in `gitstore-api`'s real server construction, per `internal/app/server.go`) never forwarded the additive `OwnerReferenceStore`/`CategoryTaxonomyDeletionStore` interfaces to `next`, even though both memdb and Scylla implement them. Any type assertion against the wrapped store for these interfaces therefore **always** failed in production/dev — not just under test load. This means **any** git push that deletes a `CategoryTaxonomy` resource (whenever that push's diff reaches the reverse owner-reference check) was unconditionally rejected. It only looked "intermittent" in this one test because the test's own push has zero CategoryTaxonomy resources — the assertion was only reached when other concurrently-running tests had already left CategoryTaxonomy resources on the shared branch.
- Fix: add `HasBlockingOwnerDependents`/`ListBlockingOwnerDependents`/`ListNonBlockingProductOwnerDependents` (OwnerReferenceStore) and `MarkCategoryTaxonomyDeletion`/`CompleteCategoryTaxonomyDeletion` (CategoryTaxonomyDeletionStore) forwarding methods to `InstrumentedDatastore`, matching the existing `GlobalRepositoryLister`/`RepositoryNamespaceLookup` fallback pattern already used in the same file (type-assert `next`, return an `ErrInvalidArgument`-wrapped error if the concrete backend genuinely doesn't support it).
- Also added structured `zap` error logging to every previously-silent failure branch in `ValidateCategoryTaxonomyDeletion` (namespace resolution, the store-type-assertion fallback, category lookup, and owner-dependent listing) so a future occurrence is diagnosable from `gitstore-api` logs alone, without needing a live repro.

## Verification

- Reproduced live: ran `TestAdmission_BranchDeletion` with `-count=40/50` while two full integration-suite runs executed concurrently against the same docker-compose stack. Before the fix: dozens of `category deletion validation unavailable` push rejections, and `gitstore-api` logs showed `validate_category_taxonomy_deletion: datastore does not implement OwnerReferenceStore` at the exact failure timestamps.
- After the fix, rebuilt and reran the identical load pattern (`-count=50` + 2 concurrent full suites): **zero** occurrences of `category deletion validation unavailable`. The only remaining category-deletion rejections were legitimate `child categories present` (correct behavior given shared-repo state pollution from concurrent tests, not a bug).
- `go build ./...`, `go vet ./...`, `gofmt -s -l .`, `staticcheck ./...`, and `go test ./...` all clean in `gitstore-api`.

## Test plan

- [x] `go test ./...` (gitstore-api) passes
- [x] Live docker-compose repro before/after confirms the fix eliminates the failure mode
- [x] `make lint`-equivalent checks (gofmt, go vet, staticcheck) clean
- [ ] CI green