### PR TITLE
fix: sort memdb label-selector matches and de-flake TestCollection_SelectorNotIn

### DIFF
--- a/gitstore-api/internal/datastore/memdb/backend.go
+++ b/gitstore-api/internal/datastore/memdb/backend.go
@@ -858,6 +858,21 @@ func (m *memdbDatastore) ListProductsByLabelSelector(_ context.Context, namespac
 			result = append(result, cloneProduct(p))
 		}
 	}
+	// Callers (e.g. resolver.BuildProductConnectionFromSlice) require
+	// products pre-sorted by (CreationTimestamp DESC, UID DESC) before
+	// applying a first/last page limit — the memdb "namespace" index
+	// iterates in UID order, not creation order, so without this sort a
+	// selector matching more items than the page size silently truncates
+	// to an arbitrary (UID-lexical) subset instead of the newest N. The
+	// ScyllaDB backend gets this for free by paginating through the
+	// already-sorted ListProducts stream.
+	sort.Slice(result, func(i, j int) bool {
+		cmp := result[i].CreationTimestamp.Compare(result[j].CreationTimestamp)
+		if cmp != 0 {
+			return cmp > 0 // DESC
+		}
+		return result[i].UID > result[j].UID // DESC
+	})
 	return result, nil
 }
 

--- a/gitstore-api/internal/datastore/memdb/backend_test.go
+++ b/gitstore-api/internal/datastore/memdb/backend_test.go
@@ -152,6 +152,49 @@ func TestMemdb_ListProducts_ReturnsAll(t *testing.T) {
 	assert.Len(t, result.Items, 3)
 }
 
+// TestMemdb_ListProductsByLabelSelector_ReturnsCreationTimestampDescOrder guards
+// against a regression where matches were returned in raw memdb index
+// (UID-lexical) order instead of (CreationTimestamp DESC, UID DESC). Callers
+// such as resolver.BuildProductConnectionFromSlice apply a first/last page
+// limit assuming pre-sorted, newest-first input; without the sort, a
+// selector matching more products than the requested page size would
+// silently truncate to an arbitrary subset instead of the newest N — which
+// only surfaces once accumulated matches exceed the page size (invisible in
+// small/fresh datasets, and invisible on the ScyllaDB backend, which already
+// returns matches in creation-time order for free).
+func TestMemdb_ListProductsByLabelSelector_ReturnsCreationTimestampDescOrder(t *testing.T) {
+	ds := newBackend(t)
+	ctx := context.Background()
+	base := time.Now()
+
+	// Create products with UIDs that sort lexically OPPOSITE to their
+	// creation order, so a bug that forgets to sort by CreationTimestamp
+	// (falling back to natural/UID index order) is caught deterministically
+	// rather than by chance.
+	oldest := productFixture("10000000-0000-0000-0000-000000000001", "sel-store", "oldest")
+	oldest.CreationTimestamp = base.Add(-2 * time.Hour)
+	middle := productFixture("90000000-0000-0000-0000-000000000002", "sel-store", "middle")
+	middle.CreationTimestamp = base.Add(-1 * time.Hour)
+	newest := productFixture("f0000000-0000-0000-0000-000000000003", "sel-store", "newest")
+	newest.CreationTimestamp = base
+
+	for _, p := range []*datastore.Product{oldest, middle, newest} {
+		require.NoError(t, ds.CreateProduct(ctx, p))
+	}
+
+	selector := catalog.LabelSelector{
+		MatchExpressions: []catalog.LabelSelectorRequirement{
+			{Key: "gitstore.dev/absent", Operator: "DoesNotExist"},
+		},
+	}
+	got, err := ds.ListProductsByLabelSelector(ctx, "sel-store", selector)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, newest.UID, got[0].UID, "newest product must be first")
+	assert.Equal(t, middle.UID, got[1].UID)
+	assert.Equal(t, oldest.UID, got[2].UID, "oldest product must be last")
+}
+
 func TestMemdb_UpdateProduct(t *testing.T) {
 	ds := newBackend(t)
 	ctx := context.Background()

--- a/tests/integration/collection_test.go
+++ b/tests/integration/collection_test.go
@@ -602,7 +602,6 @@ func TestCollection_SelectorNotIn(t *testing.T) {
 	if out, err := hProducts.push(); err != nil {
 		t.Fatalf("seeding products failed:\n%s", out)
 	}
-	time.Sleep(500 * time.Millisecond)
 
 	collName := fmt.Sprintf("notin-coll-%d", ts)
 	hColl := newPushHelper(t)
@@ -610,27 +609,24 @@ func TestCollection_SelectorNotIn(t *testing.T) {
 	if out, err := hColl.push(); err != nil {
 		t.Fatalf("collection push failed:\n%s", out)
 	}
-	time.Sleep(500 * time.Millisecond)
 
-	coll := queryCollection(t, ns, collName)
-	if coll == nil {
-		t.Fatal("collection not found")
-	}
+	// Admission-time membership computation races the GraphQL read path
+	// under load (same pattern as TestCollection_SelectorDoesNotExist);
+	// poll for the samsung product to appear rather than a fixed sleep
+	// followed by a single query.
+	coll := waitForCollectionStatus(t, ns, collName, 10*time.Second, func(c *collectionQueryResult) bool {
+		for _, n := range productNamesFromEdges(c) {
+			if n == samsungProduct {
+				return true
+			}
+		}
+		return false
+	})
 	names := productNamesFromEdges(coll)
 	for _, n := range names {
 		if n == appleProduct {
 			t.Errorf("apple product should be excluded by NotIn selector, but was found in collection")
 		}
-	}
-	found := false
-	for _, n := range names {
-		if n == samsungProduct {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("samsung product should be included by NotIn selector, but was not found")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `TestCollection_SelectorNotIn` had the same fixed-`time.Sleep`-then-single-query anti-pattern already fixed in two neighboring Collection tests (PR #391, PR #393); switched it to the existing `waitForCollectionStatus` poll helper.
- Reproduced a genuine 10s poll timeout in `TestCollection_SelectorDoesNotExist` under heavy accumulated load (docker-compose, memdb backend, 2nd+ successive full-suite run against the same unreset stack). Root cause: `gitstore-api/internal/datastore/memdb/backend.go`'s `ListProductsByLabelSelector` never sorted its matches (raw memdb index iteration order), while `resolver.BuildProductConnectionFromSlice` (backing `Collection.products`) documents and requires input pre-sorted by `(CreationTimestamp DESC, UID DESC)` before applying a `first`/`last` page limit. Once accumulated matches for a broad selector (e.g. a run-unique `DoesNotExist` key, which matches almost every pre-existing product) exceeded the page size, the truncation silently dropped an effectively random subset instead of the newest N — so a just-created product had a shrinking chance of surviving the page as the namespace grew. Invisible in fresh/isolated runs (matches ≤ page size) and never affects the ScyllaDB backend, which already returns matches pre-sorted via its own paginated scan.
- Fixed by sorting the memdb matches by `(CreationTimestamp DESC, UID DESC)` before returning, matching the convention used elsewhere in this file (`paginateSlice`) and the contract documented in `pagination.go`.
- Added `TestMemdb_ListProductsByLabelSelector_ReturnsCreationTimestampDescOrder`, with UIDs deliberately lexically opposite creation order, so it fails deterministically without the fix rather than by chance.

## Test plan
- [x] `go test ./gitstore-api/internal/datastore/...` — new regression test passes, no existing test regressions
- [x] `make pr-ready` (lint, build, full unit/contract test suite, license headers) — green
- [x] Live repro against `docker-compose` (memdb backend), mirroring `ci-integration.yml`'s bootstrap/seed steps: reproduced the `TestCollection_SelectorDoesNotExist` 10s timeout on the 2nd successive full-suite run against an unreset stack (`docker stats` showed negligible CPU/mem during the failure, ruling out local resource contention as the cause)
- [x] After the fix: 3 consecutive full `tests/integration` suite runs against the same unreset, re-accumulated stack — `TestCollection_SelectorNotIn` and `TestCollection_SelectorDoesNotExist` pass consistently (~1.3–2.0s each, no timeout recurrence); only the separately-tracked, unrelated `TestAdmission_BranchDeletion` flake recurred (out of scope for this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)