### PR TITLE
fix: EnsureSystemRepository now provisions gitstore-system on a fresh namespace

### DIFF
--- a/gitstore-api/internal/graph/resolver/repository.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/repository.resolvers.go
@@ -178,7 +178,10 @@ func (r *queryResolver) Repository(ctx context.Context, by model.RepositoryBy) (
 		}
 		mapping, err := r.service.LookupRepository(ctx, ns.Name, by.NamespacePath.Name)
 		if err != nil {
-			return nil, gqlerror.Errorf("repository not found")
+			return nil, &gqlerror.Error{
+				Message:    "repository not found",
+				Extensions: map[string]any{"code": "NOT_FOUND"},
+			}
 		}
 		repo, err := r.service.GetRepository(ctx, mapping.RepositoryID)
 		if err != nil {

--- a/gitstore-api/internal/graph/resolver/repository.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/repository.resolvers.go
@@ -7,7 +7,9 @@ package resolver
 
 import (
 	"context"
+	"errors"
 
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.uber.org/zap"
@@ -178,10 +180,13 @@ func (r *queryResolver) Repository(ctx context.Context, by model.RepositoryBy) (
 		}
 		mapping, err := r.service.LookupRepository(ctx, ns.Name, by.NamespacePath.Name)
 		if err != nil {
-			return nil, &gqlerror.Error{
-				Message:    "repository not found",
-				Extensions: map[string]any{"code": "NOT_FOUND"},
+			if errors.Is(err, datastore.ErrNotFound) {
+				return nil, &gqlerror.Error{
+					Message:    "repository not found",
+					Extensions: map[string]any{"code": "NOT_FOUND"},
+				}
 			}
+			return nil, err
 		}
 		repo, err := r.service.GetRepository(ctx, mapping.RepositoryID)
 		if err != nil {

--- a/gitstore-api/internal/graph/resolver/repository_not_found_test.go
+++ b/gitstore-api/internal/graph/resolver/repository_not_found_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package resolver_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/gitstore-dev/gitstore/api/internal/datastore/memdb"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"go.uber.org/zap"
+)
+
+const repositoryNotFoundTestNamespaceID = "01960000-0000-7000-8000-000000000140"
+
+// lookupRepositoryErrStore wraps a Datastore and forces LookupRepository to
+// return an arbitrary, non-ErrNotFound error, simulating a genuine failure
+// (e.g. a Scylla timeout) rather than a missing repository.
+type lookupRepositoryErrStore struct {
+	datastore.Datastore
+	err error
+}
+
+func (s *lookupRepositoryErrStore) LookupRepository(_ context.Context, _, _ string) (*datastore.NamespaceMapping, error) {
+	return nil, s.err
+}
+
+func newRepositoryNotFoundHarness(t *testing.T, store datastore.Datastore) (*resolver.Resolver, *datastore.Namespace) {
+	t.Helper()
+	ctx := context.Background()
+	namespace := &datastore.Namespace{
+		UID:               repositoryNotFoundTestNamespaceID,
+		Name:              "repository-not-found-contract",
+		Tier:              datastore.NamespaceTierUser,
+		CreationTimestamp: time.Date(2026, time.August, 29, 0, 0, 0, 0, time.UTC),
+		CreationActor:     "fixture",
+		UpdateActor:       "fixture",
+	}
+	require.NoError(t, store.CreateNamespace(ctx, namespace))
+
+	root, err := resolver.NewResolver(resolver.ResolverDeps{
+		Store:  store,
+		Logger: zap.NewNop(),
+	})
+	require.NoError(t, err)
+	return root, namespace
+}
+
+// TestQueryRepositoryByNamespacePath_MissingRepositoryReportsNotFoundCode
+// confirms the repository(by: namespacePath) query surfaces a genuinely
+// missing repository as a GraphQL error carrying extensions.code
+// "NOT_FOUND" — the contract gitstore-controller-manager's
+// systemRepositoryExists relies on to distinguish "doesn't exist yet" from
+// a hard failure (see EnsureSystemRepository, spec 046).
+func TestQueryRepositoryByNamespacePath_MissingRepositoryReportsNotFoundCode(t *testing.T) {
+	baseStore, err := memdb.New()
+	require.NoError(t, err)
+	root, namespace := newRepositoryNotFoundHarness(t, baseStore)
+
+	_, err = root.Query().Repository(context.Background(), model.RepositoryBy{
+		NamespacePath: &model.RepositoryNamespacePath{
+			Namespace: namespace.Name,
+			Name:      "gitstore-system",
+		},
+	})
+
+	require.Error(t, err)
+	var gqlErr *gqlerror.Error
+	require.True(t, errors.As(err, &gqlErr), "expected *gqlerror.Error, got %T", err)
+	assert.Equal(t, "repository not found", gqlErr.Message)
+	assert.Equal(t, "NOT_FOUND", gqlErr.Extensions["code"])
+}
+
+// TestQueryRepositoryByNamespacePath_GenuineLookupFailurePropagates confirms
+// that a non-ErrNotFound LookupRepository failure (e.g. a datastore
+// timeout) is NOT mislabeled as "repository not found" / NOT_FOUND — it
+// must propagate as a distinct error so callers do not mistake a real
+// failure for "safe to create".
+func TestQueryRepositoryByNamespacePath_GenuineLookupFailurePropagates(t *testing.T) {
+	baseStore, err := memdb.New()
+	require.NoError(t, err)
+	genuineErr := errors.New("datastore: connection reset")
+	store := &lookupRepositoryErrStore{Datastore: baseStore, err: genuineErr}
+	root, namespace := newRepositoryNotFoundHarness(t, store)
+
+	_, err = root.Query().Repository(context.Background(), model.RepositoryBy{
+		NamespacePath: &model.RepositoryNamespacePath{
+			Namespace: namespace.Name,
+			Name:      "gitstore-system",
+		},
+	})
+
+	require.Error(t, err)
+	assert.NotEqual(t, "repository not found", err.Error())
+	var gqlErr *gqlerror.Error
+	if errors.As(err, &gqlErr) {
+		assert.NotEqual(t, "NOT_FOUND", gqlErr.Extensions["code"])
+	}
+}

--- a/gitstore-controller-manager/internal/namespace/graphql_client.go
+++ b/gitstore-controller-manager/internal/namespace/graphql_client.go
@@ -5,6 +5,7 @@ package namespace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/graphqlclient"
@@ -107,9 +108,28 @@ func (c *GraphQLRepositoryClient) systemRepositoryExists(ctx context.Context, na
 			},
 		},
 	}, &response); err != nil {
+		if isNotFoundError(err) {
+			// The repository genuinely does not exist yet — this is the
+			// expected steady state before EnsureSystemRepository creates
+			// it, not a hard failure.
+			return false, nil
+		}
 		return false, fmt.Errorf("namespace repository client: query system repository: %w", err)
 	}
 	return response.Repository != nil, nil
+}
+
+// isNotFoundError reports whether err is a GraphQL error whose extensions
+// carry the "NOT_FOUND" code (the convention gitstore-api's resolvers use
+// for missing resources, e.g. the repository(by: namespacePath) query when
+// no repository has been created yet).
+func isNotFoundError(err error) bool {
+	var gqlErr *graphqlclient.Error
+	if !errors.As(err, &gqlErr) || gqlErr == nil {
+		return false
+	}
+	code, _ := gqlErr.Extensions["code"].(string)
+	return code == "NOT_FOUND"
 }
 
 // HasRepositories reports whether the namespace currently owns any repository.

--- a/gitstore-controller-manager/internal/namespace/graphql_client.go
+++ b/gitstore-controller-manager/internal/namespace/graphql_client.go
@@ -119,17 +119,24 @@ func (c *GraphQLRepositoryClient) systemRepositoryExists(ctx context.Context, na
 	return response.Repository != nil, nil
 }
 
-// isNotFoundError reports whether err is a GraphQL error whose extensions
-// carry the "NOT_FOUND" code (the convention gitstore-api's resolvers use
-// for missing resources, e.g. the repository(by: namespacePath) query when
-// no repository has been created yet).
+// isNotFoundError reports whether err is a GraphQL error signaling that the
+// queried repository does not exist. The primary signal is the "NOT_FOUND"
+// extensions code gitstore-api's resolvers use for missing resources.
+// During a rolling deployment, this controller may still query an
+// older API replica whose repository(by: namespacePath) resolver predates
+// that convention and returns only the plain message "repository not
+// found" with no extensions code — that legacy shape is recognized too, so
+// EnsureSystemRepository keeps working through a mixed-version rollout
+// rather than requiring every old replica to drain first.
 func isNotFoundError(err error) bool {
 	var gqlErr *graphqlclient.Error
 	if !errors.As(err, &gqlErr) || gqlErr == nil {
 		return false
 	}
-	code, _ := gqlErr.Extensions["code"].(string)
-	return code == "NOT_FOUND"
+	if code, _ := gqlErr.Extensions["code"].(string); code == "NOT_FOUND" {
+		return true
+	}
+	return gqlErr.Extensions == nil && gqlErr.Message == "repository not found"
 }
 
 // HasRepositories reports whether the namespace currently owns any repository.

--- a/gitstore-controller-manager/internal/namespace/graphql_client_test.go
+++ b/gitstore-controller-manager/internal/namespace/graphql_client_test.go
@@ -43,6 +43,72 @@ func TestGraphQLRepositoryClientCreatesMissingSystemRepository(t *testing.T) {
 	}
 }
 
+// TestGraphQLRepositoryClientCreatesSystemRepositoryOnNotFoundError mirrors
+// the actual gitstore-api response shape for repository(by: namespacePath)
+// when no repository has been created yet: a real GraphQL error (message
+// "repository not found", extensions.code "NOT_FOUND") rather than a clean
+// null-data response. Before the fix, systemRepositoryExists treated any
+// GraphQL error as a hard failure, so EnsureSystemRepository never fell
+// through to createRepository — this reproduces the reported "never
+// provisions gitstore-system on a fresh environment" bug.
+func TestGraphQLRepositoryClientCreatesSystemRepositoryOnNotFoundError(t *testing.T) {
+	var queries, mutations int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(req.Query, "mutation") {
+			mutations++
+			_, _ = w.Write([]byte(`{"data":{"createRepository":{"repository":{"metadata":{"name":"gitstore-system"}}}}}`))
+			return
+		}
+		queries++
+		_, _ = w.Write([]byte(`{"data":{"repository":null},"errors":[{"message":"repository not found","extensions":{"code":"NOT_FOUND"}}]}`))
+	}))
+	defer srv.Close()
+
+	client := NewGraphQLRepositoryClient(graphqlclient.New(srv.URL, "token"))
+	if err := client.EnsureSystemRepository(context.Background(), "acme"); err != nil {
+		t.Fatalf("EnsureSystemRepository failed: %v", err)
+	}
+	if queries != 1 || mutations != 1 {
+		t.Fatalf("queries=%d mutations=%d, want 1/1 (createRepository must be reached)", queries, mutations)
+	}
+}
+
+// TestGraphQLRepositoryClientPropagatesGenuineQueryErrors confirms that a
+// non-"not found" GraphQL error (e.g. a genuine server error) still
+// propagates as a hard failure and does not silently fall through to
+// createRepository.
+func TestGraphQLRepositoryClientPropagatesGenuineQueryErrors(t *testing.T) {
+	var mutations int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(req.Query, "mutation") {
+			mutations++
+			_, _ = w.Write([]byte(`{"data":{"createRepository":{"repository":{"metadata":{"name":"gitstore-system"}}}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"errors":[{"message":"internal server error"}]}`))
+	}))
+	defer srv.Close()
+
+	client := NewGraphQLRepositoryClient(graphqlclient.New(srv.URL, "token"))
+	err := client.EnsureSystemRepository(context.Background(), "acme")
+	if err == nil {
+		t.Fatal("EnsureSystemRepository succeeded, want error for a genuine (non-not-found) failure")
+	}
+	if mutations != 0 {
+		t.Fatalf("mutations=%d, want 0 — must not create on a genuine query error", mutations)
+	}
+}
+
 func TestGraphQLRepositoryClientTreatsExistingSystemRepositoryAsReady(t *testing.T) {
 	var mutations int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/gitstore-controller-manager/internal/namespace/graphql_client_test.go
+++ b/gitstore-controller-manager/internal/namespace/graphql_client_test.go
@@ -78,6 +78,41 @@ func TestGraphQLRepositoryClientCreatesSystemRepositoryOnNotFoundError(t *testin
 	}
 }
 
+// TestGraphQLRepositoryClientCreatesSystemRepositoryOnLegacyNotFoundMessage
+// covers a mixed-version rolling deployment: during a rollout, the
+// controller-manager may still query an older gitstore-api replica whose
+// repository(by: namespacePath) resolver predates the NOT_FOUND extensions
+// code convention and returns only the plain message "repository not
+// found" with no extensions. EnsureSystemRepository must still recognize
+// that as "doesn't exist yet" rather than aborting until every old replica
+// has drained.
+func TestGraphQLRepositoryClientCreatesSystemRepositoryOnLegacyNotFoundMessage(t *testing.T) {
+	var queries, mutations int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(req.Query, "mutation") {
+			mutations++
+			_, _ = w.Write([]byte(`{"data":{"createRepository":{"repository":{"metadata":{"name":"gitstore-system"}}}}}`))
+			return
+		}
+		queries++
+		_, _ = w.Write([]byte(`{"data":{"repository":null},"errors":[{"message":"repository not found"}]}`))
+	}))
+	defer srv.Close()
+
+	client := NewGraphQLRepositoryClient(graphqlclient.New(srv.URL, "token"))
+	if err := client.EnsureSystemRepository(context.Background(), "acme"); err != nil {
+		t.Fatalf("EnsureSystemRepository failed: %v", err)
+	}
+	if queries != 1 || mutations != 1 {
+		t.Fatalf("queries=%d mutations=%d, want 1/1 (createRepository must actually be called against a legacy API replica)", queries, mutations)
+	}
+}
+
 // TestGraphQLRepositoryClientPropagatesGenuineQueryErrors confirms that a
 // non-"not found" GraphQL error (e.g. a genuine server error) still
 // propagates as a hard failure and does not silently fall through to

--- a/gitstore-controller-manager/internal/namespace/reconciler_test.go
+++ b/gitstore-controller-manager/internal/namespace/reconciler_test.go
@@ -5,10 +5,15 @@ package namespace
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/cache"
+	"github.com/gitstore-dev/gitstore/controller-manager/internal/graphqlclient"
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/status"
 	"github.com/gitstore-dev/gitstore/controller-manager/internal/types"
 )
@@ -134,6 +139,63 @@ func TestReconcileAdmittedNamespaceProvisionsSystemRepositoryAndMarksReady(t *te
 	}
 	if got := conditionByType(t, patch.Conditions, "Ready").Status; got != "TRUE" {
 		t.Errorf("Ready = %q, want TRUE", got)
+	}
+}
+
+// TestReconcileFreshNamespaceProvisionsSystemRepositoryViaRealClient exercises
+// the full Reconcile path with the real GraphQLRepositoryClient (not the
+// fake) against a server that reproduces gitstore-api's actual response for
+// a genuinely fresh environment: repository(by: namespacePath) returns a
+// "repository not found" / NOT_FOUND GraphQL error because gitstore-system
+// has never been created. Before the fix, systemRepositoryExists treated
+// that error as a hard failure and EnsureSystemRepository never reached
+// createRepository, so this reconcile would end in TransientFailure with
+// SystemRepoReady=FALSE forever. After the fix, it must fall through to
+// createRepository and reach Success with SystemRepoReady=TRUE.
+func TestReconcileFreshNamespaceProvisionsSystemRepositoryViaRealClient(t *testing.T) {
+	var queries, mutations int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(req.Query, "mutation") {
+			mutations++
+			_, _ = w.Write([]byte(`{"data":{"createRepository":{"repository":{"metadata":{"name":"gitstore-system"}}}}}`))
+			return
+		}
+		queries++
+		_, _ = w.Write([]byte(`{"data":{"repository":null},"errors":[{"message":"repository not found","extensions":{"code":"NOT_FOUND"}}]}`))
+	}))
+	defer srv.Close()
+
+	current := Namespace{
+		Name:            "acme",
+		Generation:      1,
+		ResourceVersion: "1",
+		Status: status.ResourceStatus{
+			ResourceVersion: "1",
+			Conditions:      []*status.Condition{admittedCondition(1)},
+		},
+	}
+	sc := &fakeStatusClient{}
+	repos := NewGraphQLRepositoryClient(graphqlclient.New(srv.URL, "token"))
+	r := NewReconciler(seedNamespaceCache(t, current), sc, repos, &fakeDeletionClient{})
+
+	result := r.Reconcile(context.Background(), namespaceKey("acme"))
+
+	if _, ok := result.(types.Success); !ok {
+		t.Fatalf("Reconcile result = %#v, want types.Success", result)
+	}
+	if queries != 1 || mutations != 1 {
+		t.Fatalf("queries=%d mutations=%d, want 1/1 (createRepository must actually be called)", queries, mutations)
+	}
+	if len(sc.patches) != 1 {
+		t.Fatalf("status calls = %d, want 1", len(sc.patches))
+	}
+	if got := conditionByType(t, sc.patches[0].Conditions, "SystemRepoReady").Status; got != "TRUE" {
+		t.Errorf("SystemRepoReady = %q, want TRUE", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `systemRepositoryExists` (`gitstore-controller-manager/internal/namespace/graphql_client.go`) treated *any* GraphQL error from the `repository(by: namespacePath)` query as a hard failure, including the API's own "repository not found" error for a genuinely missing repo. `EnsureSystemRepository` therefore never fell through to `createRepository`, so the `gitstore-system` auto-provisioning added in spec 046 was broken on any fresh deployment that relies on the controller to provision it itself (masked locally because every prior verification pre-created the repo via `make bootstrap`, which bypasses the controller's own provisioning path).
- Gave the API resolver's not-found branch (`gitstore-api/internal/graph/resolver/repository.resolvers.go`) the same `extensions.code = "NOT_FOUND"` convention already used by the category/product/status resolvers, and had the client check for that code before treating a query error as fatal. Any other error (network failure, malformed response, genuine server error) still propagates unchanged.
- Added a client-level test reproducing the real not-found error shape, a test confirming genuine errors still propagate (don't create), and a full `Reconciler.Reconcile` test using the real `GraphQLRepositoryClient` (not the fake) against a fresh-namespace response, asserting `createRepository` is actually called and `SystemRepoReady` ends `TRUE`.

## Live verification (not just mocked)
Built and ran the full docker-compose stack from source (`docker compose --env-file gitstore-api/.env -f compose.yml up --build -d`, with `compose.yml`'s port 5000 temporarily remapped to 15000 locally for the AirPlay conflict, reverted before commit). Bootstrapped **only a Namespace** via `make bootstrap-namespace` (not `make bootstrap`, so `gitstore-system` was never pre-created) against a brand-new namespace (`freshtest-1c`). Confirmed via the API's own logs that the controller's first lookup hit `lookup repository not found`, then the controller called `createRepository` (`gRPC CreateRepository succeeded`), and a follow-up GraphQL query for the Namespace's status showed:

```
{"type":"AdmissionAccepted","status":"TRUE"} {"type":"SystemRepoReady","status":"TRUE","reason":"RepositoryReady"} {"type":"Ready","status":"TRUE","reason":"NamespaceReady"}
```

i.e. the controller provisioned `gitstore-system` entirely on its own, from a genuinely fresh namespace, which would have stalled with `SystemRepoReady=FALSE` before this fix.

## Test plan
- [x] `go build ./...` and `go test ./...` pass in both `gitstore-api` and `gitstore-controller-manager`
- [x] `make pr-ready` (lint, build, test, license-check) passes
- [x] `tests/integration` full suite passes against the rebuilt stack
- [x] Live docker-compose verification of the fresh-namespace provisioning path (see above)