### PR TITLE
fix(config): remove dead cache.ttl key and wire auth.userdir.provider

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -40,9 +40,6 @@ rate_limit_burst = 100
 [git.grpc]
 uri = "dns:///git-service:50051"
 
-[cache]
-ttl = 300
-
 [datastore]
 backend = "memdb"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,12 +99,6 @@ The following endpoints are served on port `api.git_port` (default `5000`):
 
 For config files, admin auth keys are nested under `[auth.admin]` (for example, `username = "admin"`) and JWT keys are nested under `[auth.jwt]`.
 
-### Cache
-
-| Key         | Env Var               | Type    | Default | Required | Sensitive | Description                            |
-|-------------|-----------------------|---------|---------|----------|-----------|----------------------------------------|
-| `cache.ttl` | `GITSTORE_CACHE__TTL` | integer | `300`   | No       | No        | In-memory catalog cache TTL in seconds |
-
 ### Logging
 
 | Key          | Env Var                | Type   | Default | Required | Sensitive | Description                            |
@@ -192,9 +186,6 @@ refresh_grace = "60s"
 [log]
 level = "debug"
 format = "json"
-
-[cache]
-ttl = 300
 
 [datastore]
 backend = "memdb"

--- a/gitstore-api/internal/app/server.go
+++ b/gitstore-api/internal/app/server.go
@@ -378,7 +378,13 @@ func buildProviderRegistry(cfg *config.Config, log *zap.Logger) (*auth.ProviderR
 	authzProvider = auth.NewDecisionLogger(authzProvider, log)
 
 	// Build UserDir provider.
-	userdirProvider := userdirnone.New()
+	var userdirProvider auth.UserDirProvider
+	switch cfg.Auth.UserDir.Provider {
+	case "none", "":
+		userdirProvider = userdirnone.New()
+	default:
+		return nil, nil, nil, fmt.Errorf("unknown userdir provider %q", cfg.Auth.UserDir.Provider)
+	}
 
 	return auth.NewProviderRegistry(auth.NewChainedAuthN(authnProviders...), authzProvider, userdirProvider), reloader, shutdowns, nil
 }

--- a/gitstore-api/internal/config/config.go
+++ b/gitstore-api/internal/config/config.go
@@ -20,7 +20,6 @@ type Config struct {
 	Api       ApiConfig       `mapstructure:"api"`
 	Git       GitConfig       `mapstructure:"git"`
 	Auth      AuthConfig      `mapstructure:"auth"`
-	Cache     CacheConfig     `mapstructure:"cache"`
 	Datastore DatastoreConfig `mapstructure:"datastore"`
 	Features  FeatureConfig   `mapstructure:"features"`
 	Log       LogConfig       `mapstructure:"log"`
@@ -104,11 +103,6 @@ type UserConfig struct {
 	Password string `mapstructure:"password_hash" validate:"required"`
 }
 
-// CacheConfig holds cache settings.
-type CacheConfig struct {
-	TTL int `mapstructure:"ttl"`
-}
-
 // FeatureConfig holds staged rollout gates.
 type FeatureConfig struct {
 	NamespaceRepositoryFence string `mapstructure:"namespace_repository_fence"`
@@ -170,7 +164,6 @@ func load(path string) (*Config, error) {
 	v.SetDefault("api.rate_limit_per_second", 50)
 	v.SetDefault("api.rate_limit_burst", 100)
 	v.SetDefault("git.grpc.uri", "dns:///localhost:50051")
-	v.SetDefault("cache.ttl", 300)
 	v.SetDefault("log.level", "info")
 	v.SetDefault("log.format", "json")
 	v.SetDefault("auth.admin.username", "")
@@ -229,7 +222,7 @@ func load(path string) (*Config, error) {
 		"api.port": true, "api.git_port": true, "api.grpc_port": true,
 		"api.rate_limit_per_second": true, "api.rate_limit_burst": true,
 		"git.grpc.uri": true,
-		"cache.ttl":    true, "log.level": true, "log.format": true,
+		"log.level":    true, "log.format": true,
 		"auth.admin.username": true, "auth.admin.password_hash": true,
 		"auth.jwt.secret": true, "auth.jwt.duration": true, "auth.jwt.issuer": true, "auth.jwt.refresh_grace": true,
 		"auth.grpc.hmac_secret": true,
@@ -358,7 +351,6 @@ func (c *Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("auth.jwt.issuer", c.Auth.JWT.Issuer)
 	enc.AddString("auth.jwt.refresh_grace", c.Auth.JWT.RefreshGrace)
 	enc.AddString("auth.grpc.hmac_secret", redact(c.Auth.Grpc.HmacSecret))
-	enc.AddInt("cache.ttl", c.Cache.TTL)
 	enc.AddString("log.level", c.Log.Level)
 	enc.AddString("log.format", c.Log.Format)
 	enc.AddString("datastore.backend", c.Datastore.Backend)

--- a/gitstore-api/internal/config/config_test.go
+++ b/gitstore-api/internal/config/config_test.go
@@ -23,7 +23,6 @@ func clearEnv(t *testing.T) func() {
 		"GITSTORE_GIT__GRPC__URI",
 		"GITSTORE_GIT__WS__URI",
 		"GITSTORE_GIT__HTTP__URI",
-		"GITSTORE_CACHE__TTL",
 		"GITSTORE_LOG__LEVEL",
 		"GITSTORE_LOG__FORMAT",
 		"GITSTORE_AUTH__ADMIN__USERNAME",
@@ -81,7 +80,6 @@ func TestLoad_DefaultsAppliedWhenNoSourceSet(t *testing.T) {
 	assert.Equal(t, float64(50), cfg.Api.RateLimitPerSecond)
 	assert.Equal(t, 100, cfg.Api.RateLimitBurst)
 	assert.Equal(t, "dns:///localhost:50051", cfg.Git.Grpc.Uri)
-	assert.Equal(t, 300, cfg.Cache.TTL)
 	assert.Equal(t, "info", cfg.Log.Level)
 	assert.Equal(t, "json", cfg.Log.Format)
 	assert.Equal(t, "24h", cfg.Auth.JWT.Duration)
@@ -125,9 +123,6 @@ format = "text"
 [api]
 port = 7777
 
-[cache]
-ttl = 600
-
 [auth.jwt]
 refresh_grace = "45s"
 `
@@ -143,7 +138,6 @@ refresh_grace = "45s"
 	require.NotNil(t, cfg)
 
 	assert.Equal(t, 7777, cfg.Api.Port)
-	assert.Equal(t, 600, cfg.Cache.TTL)
 	assert.Equal(t, "warn", cfg.Log.Level)
 	assert.Equal(t, "text", cfg.Log.Format)
 	assert.Equal(t, "45s", cfg.Auth.JWT.RefreshGrace)


### PR DESCRIPTION
## Summary
- Audited config keys across all three core services (`gitstore-api`, `gitstore-controller-manager`, `gitstore-git-service`) to find keys that are parsed/defaulted/logged but never actually read to drive behavior.
- `cache.ttl` (`GITSTORE_CACHE__TTL`) in `gitstore-api` was confirmed dead: only defaulted, validated, and logged — no cache implementation ever read `Cache.TTL`. Removed it entirely.
- While auditing, found `auth.userdir.provider` was only read for a startup log line; the actual provider was hardcoded to `userdirnone.New()` regardless of config. Fixed by wiring a `switch` (mirroring the existing `auth.authz.provider` pattern) so the key genuinely selects the provider, matching the original intent of spec `031-pluggable-authn-authz`.
- `gitstore-controller-manager` and `gitstore-git-service` were audited as well — every config key in both is actively read and used in production code, so no changes were needed there.

## Changes
- `gitstore-api/internal/config/config.go`: removed `CacheConfig` type, `Cache` field, its `SetDefault`, `knownKeys` entry, and `MarshalLogObject` log line.
- `gitstore-api/internal/config/config_test.go`: removed `cache.ttl` env var, assertions, and TOML fixture.
- `gitstore-api/internal/app/server.go`: wired `auth.userdir.provider` via a `switch` instead of hardcoding `userdirnone.New()`.
- `docs/configuration.md`, `config/config.toml`: removed the `cache.ttl` / `[cache]` documentation and example.

## Testing
- `go build ./...` (gitstore-api)
- `go vet ./...` (gitstore-api)
- `go test ./...` (gitstore-api) — all packages pass
