### PR TITLE
perf(namespace): share watch tailer and add capacity harness

### DIFF
--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -29,6 +29,8 @@
 **Replica/Scaling Model**: [affected core services, state ownership, coordination, failover, and autoscaling behavior or N/A]
 **Authentication/Authorization**: [user/service identities, policy enforcement points, and isolation impact or N/A]
 **Load/Backpressure Model**: [peak and sustained workload, queue/concurrency bounds, timeouts, retries, and soak target or N/A]
+**Capacity Profile**: [`tests/capacity/profiles/<profile>.js`, declared thresholds, correctness verifier, evidence location, or N/A with justification]
+**Fault Profile**: [`tests/chaos/profiles/<profile>.json`, target boundary, steady-state/recovery assertions, or N/A with justification]
 
 ## Constitution Check
 
@@ -40,6 +42,7 @@
 - **Replica Safety**: Core-service changes remain correct with at least two replicas and rolling upgrades.
 - **Multi-User Security**: AuthN/AuthZ enforcement and namespace/repository isolation are explicit.
 - **Production Capacity**: Plans address 5,000,000-product scale and sustained Git push load where applicable.
+- **Repeatable Evidence**: Load-bearing plans use `make capacity` for offered-load evidence and `make chaos` for declared failure/recovery scenarios; a tool exit code alone never substitutes for domain correctness verification.
 - **Bounded Work**: Queries, queues, workers, retries, payloads, and partitions have explicit bounds.
 - **Observability**: Logs, metrics, readiness, saturation, and recovery signals are designed.
 - **Incremental Delivery**: Slices can deploy independently across mixed-version replicas.

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -101,6 +101,8 @@
 - **PR-002 Multi-User Security**: [Define authentication, authorization, isolation, and audit behavior]
 - **PR-003 Capacity**: [Define dataset size, peak/sustained concurrency, payload shape, latency, and error objectives]
 - **PR-004 Backpressure**: [Define queue, worker, retry, timeout, and overload behavior]
+- **PR-005 Capacity Evidence**: [Name the reusable `make capacity CAPACITY_PROFILE=...` profile, required dataset/topology proof, threshold set, and domain-correctness verifier]
+- **PR-006 Fault Recovery**: [Name the reusable `make chaos CHAOS_PROFILE=...` profile(s), bounded target, steady-state hypothesis, and recovery deadline]
 - **PR-005 Recovery**: [Define convergence and data-integrity behavior after partial failure]
 
 ### Key Entities *(include if feature involves data)*

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -159,6 +159,8 @@ Examples of foundational tasks (adjust based on your project):
 - [ ] TXXX Rolling-upgrade compatibility validation
 - [ ] TXXX Multi-user AuthN/AuthZ and isolation tests
 - [ ] TXXX Sustained load/soak and backpressure validation
+- [ ] TXXX Record a passing `make capacity CAPACITY_PROFILE=<profile>` evidence bundle, including topology/dataset proof and domain-verifier result
+- [ ] TXXX Record passing declared `make chaos CHAOS_PROFILE=<profile>` recovery experiments while the capacity workload is active
 - [ ] TXXX Operational dashboards, alerts, and runbook updates
 - [ ] TXXX Run quickstart.md validation
 

--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,30 @@ NAMESPACE_WATCH_API_B ?= http://localhost:4001
 NAMESPACE_WATCH_API_REPLACEMENT ?=
 NAMESPACE_WATCH_REPLACEMENT_TRIGGER_FILE ?=
 NAMESPACE_WATCH_TOKEN ?=
+NAMESPACE_WATCH_TOKEN_FILE ?=
 NAMESPACE_WATCH_OVERFLOW_TRANSITIONS ?=
+CAPACITY_PROFILE ?= api-readiness
+CAPACITY_EVIDENCE_DIR ?= $(ROOT)/.gitstore/capacity
+CAPACITY_ENV_FILE ?=
+CAPACITY_TOKEN_FILE ?=
+CAPACITY_CONFIG_MANIFEST ?=
+CAPACITY_ENVIRONMENT_MANIFEST ?=
+K6_IMAGE ?= grafana/k6:2.1.0
+CHAOS_PROFILE ?= api-restart
+CHAOS_TARGET ?=
+CHAOS_CONFIRM ?= 0
+CHAOS_EVIDENCE_DIR ?= $(ROOT)/.gitstore/chaos
+PUMBA_IMAGE ?= ghcr.io/alexei-led/pumba:1.1.7
+CAPACITY_CHAOS_PROFILE ?=
+CAPACITY_CHAOS_TARGET ?=
+CAPACITY_CHAOS_DELAY ?=30s
+CAPACITY_CHAOS_CONFIRM ?=0
 
 export API_URL ADMIN_USERNAME ADMIN_PASSWORD BOOTSTRAP_TOKEN BOOTSTRAP_TOKEN_CACHE
 export NAMESPACE NAMESPACE_DISPLAY_NAME NAMESPACE_TIER REPOSITORY DEFAULT_BRANCH
 
 .PHONY: help git api controller dev compose scylla ps logs stop down validate-local-config compose-config-check
-.PHONY: build test lint license-check pr-ready test-scylla-hardening test-scylla-integration test-scylla-capacity test-namespace-admission-capacity test-namespace-watch-capacity test-namespace-watch-recovery
+.PHONY: build test lint license-check pr-ready capacity chaos test-scylla-hardening test-scylla-integration test-scylla-capacity test-namespace-admission-capacity test-namespace-watch-capacity test-namespace-watch-recovery
 .PHONY: bootstrap bootstrap-token bootstrap-namespace bootstrap-repository git-clean-data
 .PHONY: admin-compose admin-down admin-stop admin-logs bootstrap-tools gen-admin-password gen-jwt-secret gen-hmac-secret
 
@@ -93,6 +110,9 @@ help: ## Show available targets and common variables.
 	@printf "  NAMESPACE_WATCH_CAPACITY_DURATION=%s\n" "$(NAMESPACE_WATCH_CAPACITY_DURATION)"
 	@printf "  NAMESPACE_WATCH_CAPACITY_SUBSCRIBERS=%s\n" "$(NAMESPACE_WATCH_CAPACITY_SUBSCRIBERS)"
 	@printf "  NAMESPACE_WATCH_CAPACITY_REPLAY_EVENTS=%s NAMESPACE_WATCH_CAPACITY_REPLAY_SAMPLES=%s\n" "$(NAMESPACE_WATCH_CAPACITY_REPLAY_EVENTS)" "$(NAMESPACE_WATCH_CAPACITY_REPLAY_SAMPLES)"
+	@printf "  CAPACITY_PROFILE=%s        Reusable k6 capacity profile\n" "$(CAPACITY_PROFILE)"
+	@printf "  CHAOS_PROFILE=%s           Reusable Pumba fault profile\n" "$(CHAOS_PROFILE)"
+	@printf "  CHAOS_TARGET=<name>        Explicit GitStore container targeted by chaos\n"
 	@printf "  NAMESPACE_WATCH_API_A=%s NAMESPACE_WATCH_API_B=%s\n" "$(NAMESPACE_WATCH_API_A)" "$(NAMESPACE_WATCH_API_B)"
 	@printf "  NAMESPACE_WATCH_REPLACEMENT_TRIGGER_FILE=<path> Required coordination signal for an actual replica restart\n"
 	@printf "  NAMESPACE_WATCH_TOKEN=<token> Required for the cross-replica Namespace watch probe\n"
@@ -204,6 +224,28 @@ test: ## Run Rust and Go test suites.
 	@cd "$(API_DIR)" && go test -count=1 -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 	@cd "$(CONTROLLER_MANAGER_DIR)" && go test -count=1 -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
+capacity: ## Run a reusable k6 capacity profile and retain structured evidence.
+	@CAPACITY_PROFILE="$(CAPACITY_PROFILE)" \
+		CAPACITY_EVIDENCE_DIR="$(CAPACITY_EVIDENCE_DIR)" \
+		CAPACITY_ENV_FILE="$(CAPACITY_ENV_FILE)" \
+		CAPACITY_TOKEN_FILE="$(CAPACITY_TOKEN_FILE)" \
+		CAPACITY_CONFIG_MANIFEST="$(CAPACITY_CONFIG_MANIFEST)" \
+		CAPACITY_ENVIRONMENT_MANIFEST="$(CAPACITY_ENVIRONMENT_MANIFEST)" \
+		CAPACITY_CHAOS_PROFILE="$(CAPACITY_CHAOS_PROFILE)" \
+		CAPACITY_CHAOS_TARGET="$(CAPACITY_CHAOS_TARGET)" \
+		CAPACITY_CHAOS_DELAY="$(CAPACITY_CHAOS_DELAY)" \
+		CAPACITY_CHAOS_CONFIRM="$(CAPACITY_CHAOS_CONFIRM)" \
+		K6_IMAGE="$(K6_IMAGE)" \
+		./scripts/run-capacity.sh "$(CAPACITY_PROFILE)"
+
+chaos: ## Inject an opt-in container fault and retain structured evidence.
+	@CHAOS_PROFILE="$(CHAOS_PROFILE)" \
+		CHAOS_TARGET="$(CHAOS_TARGET)" \
+		CHAOS_CONFIRM="$(CHAOS_CONFIRM)" \
+		CHAOS_EVIDENCE_DIR="$(CHAOS_EVIDENCE_DIR)" \
+		PUMBA_IMAGE="$(PUMBA_IMAGE)" \
+		./scripts/run-chaos.sh "$(CHAOS_PROFILE)"
+
 test-scylla-hardening: ## Run focused datastore hardening tests without an external Scylla instance.
 	@cd "$(API_DIR)" && go test -count=1 ./internal/datastore/... ./tests/contract/datastore/...
 
@@ -232,6 +274,7 @@ test-namespace-watch-capacity: ## Run the deployed two-replica 60-minute Namespa
 		NAMESPACE_WATCH_API_REPLACEMENT="$(NAMESPACE_WATCH_API_REPLACEMENT)" \
 		NAMESPACE_WATCH_REPLACEMENT_TRIGGER_FILE="$(NAMESPACE_WATCH_REPLACEMENT_TRIGGER_FILE)" \
 		NAMESPACE_WATCH_TOKEN="$(NAMESPACE_WATCH_TOKEN)" \
+		NAMESPACE_WATCH_TOKEN_FILE="$(NAMESPACE_WATCH_TOKEN_FILE)" \
 		NAMESPACE_WATCH_CAPACITY_DURATION="$(NAMESPACE_WATCH_CAPACITY_DURATION)" \
 		NAMESPACE_WATCH_CAPACITY_SUBSCRIBERS="$(NAMESPACE_WATCH_CAPACITY_SUBSCRIBERS)" \
 		NAMESPACE_WATCH_CAPACITY_REPLAY_EVENTS="$(NAMESPACE_WATCH_CAPACITY_REPLAY_EVENTS)" \
@@ -251,6 +294,7 @@ test-namespace-watch-recovery: ## Probe bootstrap/resume, replacement, expiry, a
 		NAMESPACE_WATCH_API_B="$(NAMESPACE_WATCH_API_B)" \
 		NAMESPACE_WATCH_API_REPLACEMENT="$(NAMESPACE_WATCH_API_REPLACEMENT)" \
 		NAMESPACE_WATCH_TOKEN="$(NAMESPACE_WATCH_TOKEN)" \
+		NAMESPACE_WATCH_TOKEN_FILE="$(NAMESPACE_WATCH_TOKEN_FILE)" \
 		NAMESPACE_WATCH_OVERFLOW_TRANSITIONS="$(NAMESPACE_WATCH_OVERFLOW_TRANSITIONS)" \
 		go test -count=1 -run '^TestNamespaceWatch(CrossReplicaBootstrapAndResume|RecoveryProbe|DocumentedConsumer)$$' .
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -57,6 +57,13 @@ Production paths must also define:
 - sustained Git push load and downstream backpressure behavior;
 - repeatable replica, failover, load, soak, and recovery validation.
 
+Repository-wide capacity and fault tooling is exposed through the root
+Makefile. Use `make capacity CAPACITY_PROFILE=<profile>` for k6 offered-load
+and threshold evidence, and `make chaos CHAOS_PROFILE=<profile>
+CHAOS_TARGET=<gitstore-container> CHAOS_CONFIRM=1` for bounded container fault
+injection. See [Production readiness testing](runbooks/production-readiness-testing.md)
+for profile authoring, correctness-verifier, evidence, and safety requirements.
+
 ## Local Development
 
 Start the Docker stack:

--- a/docs/namespace/namespace-watch.md
+++ b/docs/namespace/namespace-watch.md
@@ -121,6 +121,21 @@ The pre-existing `watchResources(kind: "Namespace")` path remains compatible
 and uses the same cursor stream and error contract, but typed
 `watchNamespaces` is recommended.
 
+## Replica-local fan-out
+
+Each API process tails the shared durable journal once and fans live events out
+through a bounded in-memory ring. This keeps steady Scylla polling proportional
+to API replica count rather than WebSocket count. The ring is not a source of
+truth: initial resume, process replacement, and any subscriber that falls
+behind the ring read the missing bounded range from Scylla before rejoining
+live delivery. Replay-to-live registration captures a high-water under the
+same tailer lock, so events cannot fall into a handoff gap.
+
+A slow socket retains its independent output buffer and backpressure deadline;
+it cannot stall the shared tailer or healthy peers. If continuity can no longer
+be proven within the configured replay/buffer bounds, only that subscription
+terminates with the documented `WATCH_EXPIRED` reason.
+
 ## Non-goals
 
 This contract does not change Namespace mutation/admission semantics from spec

--- a/docs/runbooks/production-readiness-testing.md
+++ b/docs/runbooks/production-readiness-testing.md
@@ -157,6 +157,81 @@ as-is for the overlap requirement.
 
 ## 2. Capacity/soak testing
 
+### Repository-wide capacity and fault harness
+
+New load-bearing specifications MUST use the repository-wide harness instead
+of adding another in-process load scheduler:
+
+```bash
+make capacity CAPACITY_PROFILE=api-readiness \
+  CAPACITY_ENV_FILE=/absolute/path/to/non-committed-capacity.env
+```
+
+The runner uses the pinned `grafana/k6:2.1.0` image unless a local `k6` binary
+or `K6_BIN` is supplied. Profiles live under `tests/capacity/profiles/`, shared
+JavaScript modules live under `tests/capacity/lib/`, and every invocation writes
+an evidence bundle under `.gitstore/capacity/<profile>/<run-id>/`. The bundle
+contains the Git revision and dirty state, tool identity, k6 log, structured
+summary, timestamps, exit code, and pass/fail status. Tokens belong in the
+untracked environment file and MUST NOT be copied into evidence.
+
+A k6 pass proves only that the declared offered load and metric thresholds
+passed. Each feature profile MUST pair it with a domain correctness verifier
+when correctness cannot be expressed by k6 checks—for example exact watch
+event coverage, cursor replay, ordering, datastore row-count proof, or
+controller convergence. A production-readiness claim requires all of:
+
+1. validated production-like topology and dataset scale;
+2. zero unintended k6 dropped iterations;
+3. passing latency, throughput, and error-rate thresholds;
+4. passing feature-specific correctness verification; and
+5. passing declared fault/recovery experiments during active load.
+
+The environment verifier MUST also prove that every datastore node stayed up
+for the full measurement window: no OOM kill, unexpected restart, or membership
+loss. A load result collected across an undeclared datastore restart is failure
+evidence, not a basis for relaxing application timeouts, buffers, or retry
+defaults. Record per-node memory limits, CPU/shard allocation, restart counts,
+and OOM state before and after the run.
+
+Capacity preflight MUST identify optimized/release service artifacts. Debug
+builds are useful for functional diagnosis but cannot produce capacity evidence;
+their lock, allocator, and instrumentation costs are not representative.
+
+Capacity evidence is also the basis for application defaults. Every gate run
+attaches a sanitized effective-config manifest and an environment manifest.
+When tuning defaults, keep workload/topology/hardware constant, vary one related
+configuration group, repeat each candidate at least three times, and select the
+smallest value that meets latency/error/recovery objectives with headroom and
+bounded overload behavior. Compare CPU, retained memory, goroutines, queue
+depth/backpressure, and datastore pressure as well as throughput. A single
+passing run MUST NOT automatically rewrite configuration defaults.
+
+When a run fails because the declared environment exhausted memory or CPU,
+repeat it with sufficient fixed datastore resources before varying application
+configuration. Do not tune application defaults to conceal an undersized or
+unstable test cluster.
+
+Container fault injection uses pinned Pumba profiles:
+
+```bash
+make chaos CHAOS_PROFILE=api-restart \
+  CHAOS_TARGET=gitstore-capacity-api-a \
+  CHAOS_CONFIRM=1
+```
+
+Profiles live under `tests/chaos/profiles/`, and evidence is written under
+`.gitstore/chaos/<profile>/<run-id>/`. The wrapper accepts one explicit
+container name beginning with `gitstore-`, verifies that it exists, and refuses
+to run without `CHAOS_CONFIRM=1`. Start with lifecycle faults (`restart` and
+bounded `pause`). Network loss/latency and CPU/memory pressure MAY be added as
+new reviewed profiles when their rollback behavior is proven on every supported
+developer runtime. Never point the wrapper at a shared or production container.
+
+The constitution intentionally specifies outcomes rather than k6 or Pumba.
+Tool pins and operating instructions belong here and in the root `Makefile`, so
+the implementation can evolve without a governance amendment.
+
 **What it verifies:** real load and soak behavior against a live backend at
 production scale — dataset size, sustained throughput, and (where the test
 measures them) error rate and partition-size ceilings — deliberately kept out
@@ -278,17 +353,12 @@ runbook can work around after the fact:
    copying `capacity_test.go`, build the row-count assertion in from the
    start rather than inheriting this gap.
 
-**Where results get recorded:** there is no separate results file or
-dashboard convention yet. The established practice (see `capacity_test.go`'s
-own `t.Logf` calls, and `docs/developer-guide.md`'s "Projection audit,
-repair, and capacity validation" section) is `t.Logf`/`go test -v` output as
-the record, captured by whoever runs it — `specs/048-scylla-query-design`'s
-own `quickstart.md` documents the *test scenarios* (cross-bucket pagination
-correctness, etc.) but does not itself define a structured results-recording
-format. If your spec's capacity run needs durable evidence beyond captured
-test-log output (e.g. for a PR description or an ADR), redirect
-`go test -v`'s stdout to a file under the spec's `specs/<NNN>/` directory and
-reference it from the spec's `tasks.md` — don't invent a new dashboard.
+**Where results get recorded:** new tests use the structured evidence bundle
+created by `make capacity`. Existing Go-only gates may retain `go test -v`
+output during migration, but MUST store it alongside equivalent metadata and
+MUST NOT claim that a bare `PASS` proves the offered workload or dataset scale.
+Specs reference the evidence bundle and summarize its thresholds and verifier
+result; evidence containing secrets is never committed.
 
 **How to apply this to a new resource:**
 

--- a/gitstore-api/internal/config/config.go
+++ b/gitstore-api/internal/config/config.go
@@ -222,6 +222,8 @@ func load(path string) (*Config, error) {
 	v.SetDefault("datastore.scylla.username", "")
 	v.SetDefault("datastore.scylla.password", "")
 	v.SetDefault("datastore.scylla.tls", false)
+	v.SetDefault("datastore.scylla.disable_shard_aware_port", false)
+	v.SetDefault("datastore.scylla.ignore_peer_addr", false)
 	v.SetDefault("features.namespace_repository_fence", "auto")
 	v.SetDefault("watch.namespace.readers_enabled", true)
 	v.SetDefault("watch.namespace.materializer_enabled", true)
@@ -286,6 +288,7 @@ func load(path string) (*Config, error) {
 		"datastore.backend": true, "datastore.scylla.hosts": true,
 		"datastore.scylla.keyspace": true, "datastore.scylla.username": true,
 		"datastore.scylla.password": true, "datastore.scylla.tls": true,
+		"datastore.scylla.disable_shard_aware_port": true, "datastore.scylla.ignore_peer_addr": true,
 		"features.namespace_repository_fence": true,
 		"watch.namespace.readers_enabled":     true, "watch.namespace.materializer_enabled": true,
 		"watch.namespace.journal_retention_seconds": true, "watch.namespace.cdc_retention_seconds": true,

--- a/gitstore-api/internal/config/config_test.go
+++ b/gitstore-api/internal/config/config_test.go
@@ -561,6 +561,21 @@ func TestLoad_UnknownKeyInConfigFileDoesNotAbortStartup(t *testing.T) {
 	require.NotNil(t, cfg)
 }
 
+func TestLoad_ScyllaDockerAddressOptionsAreKnown(t *testing.T) {
+	restore := clearEnv(t)
+	defer restore()
+	setRequiredAuth(t)
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := "[datastore.scylla]\ndisable_shard_aware_port = true\nignore_peer_addr = true\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	cfg, err := LoadFrom(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.Datastore.Scylla.DisableShardAwarePort)
+	assert.True(t, cfg.Datastore.Scylla.IgnorePeerAddr)
+}
+
 // T009: datastore backend config validation tests
 
 func TestLoad_DatastoreBackendDefaultsToMemdb(t *testing.T) {

--- a/gitstore-api/internal/graph/resolver/namespace_commit_order_test.go
+++ b/gitstore-api/internal/graph/resolver/namespace_commit_order_test.go
@@ -93,6 +93,36 @@ type descendantCommitGitWriter struct {
 	resolveOnce         sync.Once
 }
 
+// advancingAfterAdmissionGitWriter models unrelated commits continuously
+// landing after this request's exact-head pre-write check. Requiring the head
+// to remain unchanged after the conditional datastore write makes progress
+// impossible under that otherwise-safe traffic.
+type advancingAfterAdmissionGitWriter struct {
+	*commitOrderGitWriter
+	resolveCount int
+}
+
+func (w *advancingAfterAdmissionGitWriter) ResolveRefForRepo(
+	ctx context.Context,
+	repositoryID, ref string,
+) (string, error) {
+	w.mu.Lock()
+	w.resolveCount++
+	resolveCount := w.resolveCount
+	if resolveCount >= 3 {
+		sha := string(rune('a'+resolveCount)) + "000000000000000000000000000000000000000"
+		tree := cloneCommitTree(w.trees[w.current])
+		tree["namespaces/unrelated-"+sha[:1]+".md"] = namespaceManifestForGraphQL(
+			"unrelated-"+sha[:1], "Unrelated", model.NamespaceTierUser,
+		)
+		w.trees[sha] = tree
+		w.current = sha
+	}
+	current := w.current
+	w.mu.Unlock()
+	return current, nil
+}
+
 func newDescendantCommitGitWriter(current string, commits ...string) *descendantCommitGitWriter {
 	return &descendantCommitGitWriter{
 		commitOrderGitWriter: newCommitOrderGitWriter(current, commits...),
@@ -373,6 +403,30 @@ func TestNamespaceGraphQLDescendantConvergence(t *testing.T) {
 		assert.Equal(t, newerSHA, persisted.GitCommitSHA)
 		assertNamespaceAdmissionRevision(t, persisted, "main@sha1:"+newerSHA)
 	})
+}
+
+func TestNamespaceGraphQLReturnsAfterExactHeadAdmissionDespiteLaterDisjointCommits(t *testing.T) {
+	seed := newTestSvc(t, &mockGitWriter{})
+	base := newCommitOrderGitWriter(
+		"deadbeef",
+		"9999999999999999999999999999999999999999",
+	)
+	writer := &advancingAfterAdmissionGitWriter{commitOrderGitWriter: base}
+	service := newCommitOrderService(t, seed.Store(), writer)
+
+	created, err := service.CreateNamespace(
+		context.Background(),
+		createNamespaceInput("post-admission-progress", model.NamespaceTierUser),
+		"alice",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "post-admission-progress", created.Name)
+	assert.Equal(t, 3, writer.resolveCount,
+		"an unchanged file at the post-write descendant head must finish without chasing further commits")
+
+	persisted, err := seed.GetNamespaceByName(context.Background(), created.Name)
+	require.NoError(t, err)
+	assert.Equal(t, created.GitCommitSHA, persisted.GitCommitSHA)
 }
 
 func TestNamespaceGraphQLDescendantSameResourceRejectsStaleRowBeforeExactHeadAdmission(t *testing.T) {

--- a/gitstore-api/internal/graph/resolver/service.go
+++ b/gitstore-api/internal/graph/resolver/service.go
@@ -727,6 +727,17 @@ func (s *Service) convergeCommittedNamespace(
 			return nil, fmt.Errorf("%w: %v", namespaceadmission.ErrAuthoringRefCheck, resolveErr)
 		}
 		if currentHead != targetSHA {
+			latestContent, readErr := s.gitWriter.ReadFileForRepo(ctx, repositoryID, path, currentHead)
+			if readErr != nil {
+				return nil, fmt.Errorf("%w: read descendant Namespace manifest: %v", namespaceadmission.ErrAuthoringRefCheck, readErr)
+			}
+			// The exact-head check before the conditional datastore write is
+			// sufficient when later commits leave this Namespace unchanged. Only
+			// a same-path descendant requires another convergence attempt; chasing
+			// every unrelated commit starves admission on the shared repository.
+			if bytes.Equal(latestContent, committedContent) {
+				return namespace, nil
+			}
 			targetOperation = ""
 			targetPreflight = namespaceadmission.Preflight{}
 			continue

--- a/gitstore-api/internal/watchjournal/subscriber.go
+++ b/gitstore-api/internal/watchjournal/subscriber.go
@@ -6,6 +6,7 @@ package watchjournal
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
@@ -30,6 +31,9 @@ type Stream struct {
 type Subscriber struct {
 	store Store
 	cfg   SubscriberConfig
+
+	mu   sync.Mutex
+	live *journalTailer
 }
 
 func NewSubscriber(store Store, cfg SubscriberConfig) *Subscriber {
@@ -102,6 +106,10 @@ func (s *Subscriber) SubscribePath(ctx context.Context, rawCursor, path string) 
 
 	events := make(chan datastore.NamespaceWatchEvent, s.cfg.BufferSize)
 	errorsOut := make(chan error, 1)
+	live, replayHighWater, err := s.registerLive(ctx, start, bounds)
+	if err != nil {
+		return nil, err
+	}
 	if bootstrap {
 		events <- datastore.NamespaceWatchEvent{
 			Epoch: bounds.Epoch, Sequence: bounds.HighWater,
@@ -111,97 +119,130 @@ func (s *Subscriber) SubscribePath(ctx context.Context, rawCursor, path string) 
 	if s.cfg.Metrics != nil {
 		s.cfg.Metrics.IncSubscribers(path)
 	}
-	go s.run(ctx, start, bounds.HighWater, path, events, errorsOut)
+	go s.run(ctx, start, replayHighWater, path, live, events, errorsOut)
 	return &Stream{Events: events, Errors: errorsOut}, nil
 }
 
-func (s *Subscriber) run(ctx context.Context, cursor datastore.NamespaceWatchCursor, initialHighWater uint64, path string, events chan datastore.NamespaceWatchEvent, errorsOut chan error) {
+func (s *Subscriber) run(ctx context.Context, cursor datastore.NamespaceWatchCursor, replayHighWater uint64, path string, live *liveSubscriber, events chan datastore.NamespaceWatchEvent, errorsOut chan error) {
 	defer close(events)
 	defer close(errorsOut)
+	defer s.unregisterLive(live)
 	if s.cfg.Metrics != nil {
 		defer s.cfg.Metrics.DecSubscribers(path)
 	}
-	delay := s.cfg.PollMin
 	replayed := 0
 	replayStarted := time.Now()
+	if err := s.replayThrough(ctx, &cursor, replayHighWater, events, &replayed); err != nil {
+		s.sendTerminal(errorsOut, err)
+		return
+	}
+	if replayed > 0 && s.cfg.Metrics != nil {
+		s.cfg.Metrics.ObserveReplay(replayed, time.Since(replayStarted))
+	}
+
 	for {
-		batch, err := s.store.ReadAfter(ctx, cursor, s.cfg.ReadBatchSize)
+		batch, catchupHighWater, err := s.liveBatch(live, cursor)
 		if err != nil {
-			reason := ReasonJournalDiscontinuity
-			if errors.Is(err, datastore.ErrWatchRetentionExpired) {
-				reason = ReasonRetentionExpired
-			} else if errors.Is(err, datastore.ErrWatchCursorEpoch) {
-				reason = ReasonEpochMismatch
-			}
-			s.sendExpired(errorsOut, reason, err)
+			s.sendTerminal(errorsOut, err)
 			return
+		}
+		if catchupHighWater > cursor.Sequence {
+			catchupStarted := time.Now()
+			catchupEvents := 0
+			if err := s.replayThrough(ctx, &cursor, catchupHighWater, events, &catchupEvents); err != nil {
+				s.sendTerminal(errorsOut, err)
+				return
+			}
+			if catchupEvents > 0 && s.cfg.Metrics != nil {
+				s.cfg.Metrics.ObserveReplay(catchupEvents, time.Since(catchupStarted))
+			}
+			continue
 		}
 		if len(batch) == 0 {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(delay):
-			}
-			bounds, boundsErr := s.store.Bounds(ctx)
-			if boundsErr != nil {
-				s.sendUnavailable(errorsOut, boundsErr)
+			case terminal := <-live.errors:
+				if terminal != nil {
+					s.sendTerminal(errorsOut, terminal)
+				}
 				return
-			}
-			if bounds.Epoch != cursor.Epoch {
-				s.sendExpired(errorsOut, ReasonEpochMismatch, errors.New("journal epoch changed"))
-				return
-			}
-			if s.cfg.MaxMaterializerLag > 0 && (bounds.ProgressAt.IsZero() || time.Since(bounds.ProgressAt) > s.cfg.MaxMaterializerLag) {
-				s.sendUnavailable(errorsOut, errors.New("materializer lag exceeds readiness bound"))
-				return
-			}
-			delay *= 2
-			if delay > s.cfg.PollMax {
-				delay = s.cfg.PollMax
+			case <-live.ready:
 			}
 			continue
 		}
-		delay = s.cfg.PollMin
 		for _, event := range batch {
 			if event.Sequence != cursor.Sequence+1 {
 				s.sendExpired(errorsOut, ReasonJournalDiscontinuity, errors.New("missing journal sequence"))
 				return
 			}
-			if event.Sequence <= initialHighWater {
-				replayed++
-			}
-			if replayed > s.cfg.MaxReplayEvents {
-				s.sendExpired(errorsOut, ReasonReplayLimit, errors.New("replay limit exceeded"))
+			if err := s.deliver(ctx, events, event); err != nil {
+				s.sendTerminal(errorsOut, err)
 				return
 			}
-			timer := time.NewTimer(s.cfg.BackpressureTimeout)
-			select {
-			case events <- event:
-				if !timer.Stop() {
-					<-timer.C
-				}
-				cursor.Sequence = event.Sequence
-				if s.cfg.Metrics != nil {
-					s.cfg.Metrics.ObserveDelivery(event, time.Now())
-				}
-			case <-ctx.Done():
-				if !timer.Stop() {
-					<-timer.C
-				}
-				return
-			case <-timer.C:
-				if s.cfg.Metrics != nil {
-					s.cfg.Metrics.IncOverflow()
-				}
-				s.sendExpired(errorsOut, ReasonSubscriberOverflow, errors.New("subscriber buffer full"))
-				return
-			}
-		}
-		if replayed > 0 && cursor.Sequence >= initialHighWater && s.cfg.Metrics != nil {
-			s.cfg.Metrics.ObserveReplay(replayed, time.Since(replayStarted))
-			replayed = 0
+			cursor.Sequence = event.Sequence
 		}
 	}
+}
+
+func (s *Subscriber) replayThrough(ctx context.Context, cursor *datastore.NamespaceWatchCursor, highWater uint64, events chan<- datastore.NamespaceWatchEvent, replayed *int) error {
+	for cursor.Sequence < highWater {
+		batch, err := s.store.ReadAfter(ctx, *cursor, s.cfg.ReadBatchSize)
+		if err != nil {
+			return subscriberReadError(err)
+		}
+		if len(batch) == 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(s.cfg.PollMin):
+			}
+			continue
+		}
+		for _, event := range batch {
+			if event.Sequence > highWater {
+				break
+			}
+			if event.Sequence != cursor.Sequence+1 {
+				return expired(ReasonJournalDiscontinuity, errors.New("missing journal sequence"))
+			}
+			(*replayed)++
+			if *replayed > s.cfg.MaxReplayEvents {
+				return expired(ReasonReplayLimit, errors.New("replay limit exceeded"))
+			}
+			if err := s.deliver(ctx, events, event); err != nil {
+				return err
+			}
+			cursor.Sequence = event.Sequence
+		}
+	}
+	return nil
+}
+
+func (s *Subscriber) deliver(ctx context.Context, events chan<- datastore.NamespaceWatchEvent, event datastore.NamespaceWatchEvent) error {
+	timer := time.NewTimer(s.cfg.BackpressureTimeout)
+	defer timer.Stop()
+	select {
+	case events <- event:
+		if s.cfg.Metrics != nil {
+			s.cfg.Metrics.ObserveDelivery(event, time.Now())
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return expired(ReasonSubscriberOverflow, errors.New("subscriber buffer full"))
+	}
+}
+
+func subscriberReadError(err error) error {
+	reason := ReasonJournalDiscontinuity
+	if errors.Is(err, datastore.ErrWatchRetentionExpired) {
+		reason = ReasonRetentionExpired
+	} else if errors.Is(err, datastore.ErrWatchCursorEpoch) {
+		reason = ReasonEpochMismatch
+	}
+	return expired(reason, err)
 }
 
 func (s *Subscriber) expired(reason Reason, detail string) error {
@@ -218,6 +259,20 @@ func (s *Subscriber) sendExpired(out chan<- error, reason Reason, cause error) {
 	out <- expired(reason, cause)
 }
 
-func (s *Subscriber) sendUnavailable(out chan<- error, cause error) {
-	out <- unavailable(cause)
+func (s *Subscriber) sendTerminal(out chan<- error, err error) {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	terminal, ok := AsTerminal(err)
+	if !ok {
+		err = unavailable(err)
+		terminal, _ = AsTerminal(err)
+	}
+	if s.cfg.Metrics != nil && terminal != nil && terminal.Code == CodeExpired {
+		s.cfg.Metrics.IncExpiry(terminal.Reason)
+		if terminal.Reason == ReasonSubscriberOverflow {
+			s.cfg.Metrics.IncOverflow()
+		}
+	}
+	out <- err
 }

--- a/gitstore-api/internal/watchjournal/subscriber_tailer.go
+++ b/gitstore-api/internal/watchjournal/subscriber_tailer.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package watchjournal
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+)
+
+// journalTailer is the one durable-journal poller shared by every Namespace
+// watch attached to a Resolver. Scylla remains the source of truth; the ring
+// only avoids repeating the same live read for every local WebSocket.
+type journalTailer struct {
+	ctx         context.Context
+	cancel      context.CancelFunc
+	cursor      datastore.NamespaceWatchCursor
+	ring        []datastore.NamespaceWatchEvent
+	subscribers map[*liveSubscriber]struct{}
+}
+
+// liveSubscriber receives edge-triggered wakeups. It does not own an event
+// queue: a healthy reader drains the shared bounded ring, while a lagging
+// reader catches up from the durable journal before rejoining live delivery.
+type liveSubscriber struct {
+	tailer *journalTailer
+	ready  chan struct{}
+	errors chan error
+}
+
+func (s *Subscriber) registerLive(_ context.Context, cursor datastore.NamespaceWatchCursor, bounds datastore.NamespaceWatchBounds) (*liveSubscriber, uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tailer := s.live
+	if tailer != nil && tailer.cursor.Epoch != bounds.Epoch {
+		return nil, 0, s.expired(ReasonEpochMismatch, "journal epoch changed")
+	}
+	if tailer == nil {
+		tailerCtx, cancel := context.WithCancel(context.Background())
+		tailer = &journalTailer{
+			ctx:         tailerCtx,
+			cancel:      cancel,
+			cursor:      datastore.NamespaceWatchCursor{Epoch: bounds.Epoch, Sequence: bounds.HighWater},
+			ring:        make([]datastore.NamespaceWatchEvent, 0, s.liveRingSize()),
+			subscribers: make(map[*liveSubscriber]struct{}),
+		}
+		s.live = tailer
+		go s.runTailer(tailer)
+	}
+
+	replayHighWater := bounds.HighWater
+	if tailer.cursor.Sequence > replayHighWater {
+		replayHighWater = tailer.cursor.Sequence
+	}
+	if replayHighWater-cursor.Sequence > uint64(s.cfg.MaxReplayEvents) {
+		return nil, 0, s.expired(ReasonReplayLimit, "resume exceeds replay limit")
+	}
+	live := &liveSubscriber{
+		tailer: tailer,
+		ready:  make(chan struct{}, 1),
+		errors: make(chan error, 1),
+	}
+	tailer.subscribers[live] = struct{}{}
+	return live, replayHighWater, nil
+}
+
+func (s *Subscriber) unregisterLive(live *liveSubscriber) {
+	if live == nil {
+		return
+	}
+	s.mu.Lock()
+	tailer := live.tailer
+	delete(tailer.subscribers, live)
+	if s.live == tailer && len(tailer.subscribers) == 0 {
+		s.live = nil
+		tailer.cancel()
+	}
+	s.mu.Unlock()
+}
+
+func (s *Subscriber) liveRingSize() int {
+	size := s.cfg.ReadBatchSize * 2
+	if size < s.cfg.BufferSize {
+		size = s.cfg.BufferSize
+	}
+	return max(1, size)
+}
+
+func (s *Subscriber) runTailer(tailer *journalTailer) {
+	delay := s.cfg.PollMin
+	for {
+		s.mu.Lock()
+		if s.live != tailer {
+			s.mu.Unlock()
+			return
+		}
+		cursor := tailer.cursor
+		s.mu.Unlock()
+
+		batch, err := s.store.ReadAfter(tailer.ctx, cursor, s.cfg.ReadBatchSize)
+		if err != nil {
+			if tailer.ctx.Err() == nil {
+				s.failTailer(tailer, subscriberReadError(err))
+			}
+			return
+		}
+		if len(batch) == 0 {
+			select {
+			case <-tailer.ctx.Done():
+				return
+			case <-time.After(delay):
+			}
+			bounds, boundsErr := s.store.Bounds(tailer.ctx)
+			if boundsErr != nil {
+				if tailer.ctx.Err() == nil {
+					s.failTailer(tailer, unavailable(boundsErr))
+				}
+				return
+			}
+			if s.cfg.Metrics != nil {
+				s.cfg.Metrics.SetBounds(bounds, time.Now())
+			}
+			if bounds.Epoch != cursor.Epoch {
+				s.failTailer(tailer, expired(ReasonEpochMismatch, errors.New("journal epoch changed")))
+				return
+			}
+			if s.cfg.MaxMaterializerLag > 0 && (bounds.ProgressAt.IsZero() || time.Since(bounds.ProgressAt) > s.cfg.MaxMaterializerLag) {
+				s.failTailer(tailer, unavailable(errors.New("materializer lag exceeds readiness bound")))
+				return
+			}
+			delay *= 2
+			if delay > s.cfg.PollMax {
+				delay = s.cfg.PollMax
+			}
+			continue
+		}
+		delay = s.cfg.PollMin
+		if err := s.publishLiveBatch(tailer, batch); err != nil {
+			s.failTailer(tailer, err)
+			return
+		}
+	}
+}
+
+func (s *Subscriber) publishLiveBatch(tailer *journalTailer, batch []datastore.NamespaceWatchEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.live != tailer {
+		return context.Canceled
+	}
+	for _, event := range batch {
+		if event.Sequence != tailer.cursor.Sequence+1 {
+			return expired(ReasonJournalDiscontinuity, errors.New("missing journal sequence"))
+		}
+		tailer.cursor.Sequence = event.Sequence
+		tailer.ring = append(tailer.ring, event)
+		if overflow := len(tailer.ring) - s.liveRingSize(); overflow > 0 {
+			copy(tailer.ring, tailer.ring[overflow:])
+			tailer.ring = tailer.ring[:len(tailer.ring)-overflow]
+		}
+		for subscriber := range tailer.subscribers {
+			select {
+			case subscriber.ready <- struct{}{}:
+			default:
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Subscriber) liveBatch(live *liveSubscriber, cursor datastore.NamespaceWatchCursor) ([]datastore.NamespaceWatchEvent, uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tailer := live.tailer
+	if tailer.cursor.Epoch != cursor.Epoch {
+		return nil, 0, expired(ReasonEpochMismatch, errors.New("journal epoch changed"))
+	}
+	if cursor.Sequence >= tailer.cursor.Sequence {
+		return nil, 0, nil
+	}
+	if len(tailer.ring) == 0 || cursor.Sequence+1 < tailer.ring[0].Sequence {
+		return nil, tailer.cursor.Sequence, nil
+	}
+	start := 0
+	for start < len(tailer.ring) && tailer.ring[start].Sequence <= cursor.Sequence {
+		start++
+	}
+	if start == len(tailer.ring) {
+		return nil, tailer.cursor.Sequence, nil
+	}
+	batch := append([]datastore.NamespaceWatchEvent(nil), tailer.ring[start:]...)
+	return batch, 0, nil
+}
+
+func (s *Subscriber) failTailer(tailer *journalTailer, err error) {
+	s.mu.Lock()
+	if s.live != tailer {
+		s.mu.Unlock()
+		return
+	}
+	s.live = nil
+	tailer.cancel()
+	subscribers := make([]*liveSubscriber, 0, len(tailer.subscribers))
+	for subscriber := range tailer.subscribers {
+		subscribers = append(subscribers, subscriber)
+	}
+	s.mu.Unlock()
+	for _, subscriber := range subscribers {
+		select {
+		case subscriber.errors <- err:
+		default:
+		}
+	}
+}

--- a/gitstore-api/internal/watchjournal/subscriber_tailer_test.go
+++ b/gitstore-api/internal/watchjournal/subscriber_tailer_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package watchjournal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/google/uuid"
+)
+
+func TestSharedTailerPollsOnceForManyLiveSubscribers(t *testing.T) {
+	epoch := uuid.NewString()
+	now := time.Now().UTC()
+	journal := &subscriberJournal{bounds: datastore.NamespaceWatchBounds{
+		Epoch: epoch, UpdatedAt: now, ProgressAt: now,
+	}}
+	subscriber := NewSubscriber(journal, SubscriberConfig{
+		ReadBatchSize: 16, MaxReplayEvents: 1000, BufferSize: 8,
+		PollMin: time.Millisecond, PollMax: 5 * time.Millisecond,
+	})
+
+	const subscriberCount = 100
+	streams := make([]*Stream, 0, subscriberCount)
+	cancels := make([]context.CancelFunc, 0, subscriberCount)
+	for range subscriberCount {
+		ctx, cancel := context.WithCancel(context.Background())
+		stream, err := subscriber.Subscribe(ctx, "")
+		if err != nil {
+			cancel()
+			t.Fatalf("Subscribe() error = %v", err)
+		}
+		streams = append(streams, stream)
+		cancels = append(cancels, cancel)
+	}
+	defer func() {
+		for _, cancel := range cancels {
+			cancel()
+		}
+	}()
+
+	journal.mu.Lock()
+	journal.limits = nil
+	journal.events = append(journal.events, datastore.NamespaceWatchEvent{
+		Epoch: epoch, Sequence: 1, Type: datastore.NamespaceWatchAdded, At: now,
+	})
+	journal.bounds.HighWater = 1
+	journal.bounds.UpdatedAt = now
+	journal.bounds.ProgressAt = now
+	journal.mu.Unlock()
+
+	for index, stream := range streams {
+		select {
+		case event := <-stream.Events:
+			if event.Sequence != 1 {
+				t.Fatalf("subscriber %d sequence = %d, want 1", index, event.Sequence)
+			}
+		case err := <-stream.Errors:
+			t.Fatalf("subscriber %d terminal error: %v", index, err)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("subscriber %d timed out", index)
+		}
+	}
+
+	journal.mu.Lock()
+	readCalls := len(journal.limits)
+	journal.mu.Unlock()
+	if readCalls >= subscriberCount/2 {
+		t.Fatalf("ReadAfter calls = %d for %d live subscribers; polling scaled with subscribers", readCalls, subscriberCount)
+	}
+}
+
+func TestSharedTailerPreservesReplayToLiveOrdering(t *testing.T) {
+	epoch := uuid.NewString()
+	now := time.Now().UTC()
+	journal := &subscriberJournal{bounds: datastore.NamespaceWatchBounds{
+		Epoch: epoch, UpdatedAt: now, ProgressAt: now,
+	}}
+	subscriber := NewSubscriber(journal, SubscriberConfig{
+		ReadBatchSize: 4, MaxReplayEvents: 100, BufferSize: 4,
+		PollMin: time.Millisecond, PollMax: 5 * time.Millisecond,
+	})
+
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	defer cancelFirst()
+	first, err := subscriber.Subscribe(firstCtx, "")
+	if err != nil {
+		t.Fatalf("first Subscribe() error = %v", err)
+	}
+	appendSubscriberJournalEvent(journal, datastore.NamespaceWatchEvent{
+		Epoch: epoch, Sequence: 1, Type: datastore.NamespaceWatchAdded, At: now,
+	})
+	requireSequence(t, first, 1)
+
+	secondCtx, cancelSecond := context.WithCancel(context.Background())
+	defer cancelSecond()
+	second, err := subscriber.Subscribe(secondCtx, EncodeCursor(epoch, 0))
+	if err != nil {
+		t.Fatalf("second Subscribe() error = %v", err)
+	}
+	requireSequence(t, second, 1)
+
+	appendSubscriberJournalEvent(journal, datastore.NamespaceWatchEvent{
+		Epoch: epoch, Sequence: 2, Type: datastore.NamespaceWatchModified, At: now,
+	})
+	requireSequence(t, first, 2)
+	requireSequence(t, second, 2)
+}
+
+func TestSharedTailerIsolatesSlowSubscriberOverflow(t *testing.T) {
+	epoch := uuid.NewString()
+	now := time.Now().UTC()
+	journal := &subscriberJournal{bounds: datastore.NamespaceWatchBounds{
+		Epoch: epoch, UpdatedAt: now, ProgressAt: now,
+	}}
+	subscriber := NewSubscriber(journal, SubscriberConfig{
+		ReadBatchSize: 4, MaxReplayEvents: 100, BufferSize: 1,
+		PollMin: time.Millisecond, PollMax: 5 * time.Millisecond,
+		BackpressureTimeout: 20 * time.Millisecond,
+	})
+
+	slowCtx, cancelSlow := context.WithCancel(context.Background())
+	defer cancelSlow()
+	slow, err := subscriber.Subscribe(slowCtx, "")
+	if err != nil {
+		t.Fatalf("slow Subscribe() error = %v", err)
+	}
+	healthyCtx, cancelHealthy := context.WithCancel(context.Background())
+	defer cancelHealthy()
+	healthy, err := subscriber.Subscribe(healthyCtx, "")
+	if err != nil {
+		t.Fatalf("healthy Subscribe() error = %v", err)
+	}
+
+	for sequence := uint64(1); sequence <= 5; sequence++ {
+		appendSubscriberJournalEvent(journal, datastore.NamespaceWatchEvent{
+			Epoch: epoch, Sequence: sequence, Type: datastore.NamespaceWatchModified, At: now,
+		})
+	}
+	for sequence := uint64(1); sequence <= 5; sequence++ {
+		requireSequence(t, healthy, sequence)
+	}
+	select {
+	case terminal := <-slow.Errors:
+		assertTerminalReason(t, terminal, CodeExpired, ReasonSubscriberOverflow)
+	case <-time.After(time.Second):
+		t.Fatal("slow subscriber did not expire")
+	}
+}
+
+func appendSubscriberJournalEvent(journal *subscriberJournal, event datastore.NamespaceWatchEvent) {
+	journal.mu.Lock()
+	defer journal.mu.Unlock()
+	journal.events = append(journal.events, event)
+	journal.bounds.HighWater = event.Sequence
+	journal.bounds.UpdatedAt = event.At
+	journal.bounds.ProgressAt = event.At
+}
+
+func requireSequence(t *testing.T, stream *Stream, want uint64) {
+	t.Helper()
+	select {
+	case event := <-stream.Events:
+		if event.Sequence != want {
+			t.Fatalf("sequence = %d, want %d", event.Sequence, want)
+		}
+	case err := <-stream.Errors:
+		t.Fatalf("unexpected terminal error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for sequence %d", want)
+	}
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,25 @@
 
 Utility scripts for GitStore development and demonstration.
 
+## run-capacity.sh
+
+Runs a named profile from `tests/capacity/profiles/` with pinned k6 and writes
+structured evidence beneath `.gitstore/capacity/`. Invoke it through the root
+Makefile:
+
+```bash
+make capacity CAPACITY_PROFILE=api-readiness CAPACITY_BASE_URL=http://localhost:4000
+```
+
+## run-chaos.sh
+
+Runs an explicitly confirmed, allowlisted Pumba fault profile against one
+GitStore container and records before/after inspection evidence:
+
+```bash
+make chaos CHAOS_PROFILE=api-pause-5s CHAOS_TARGET=gitstore-api CHAOS_CONFIRM=1
+```
+
 For normal repository checks, run the licence scripts through the root Make target:
 
 ```bash

--- a/scripts/run-capacity.sh
+++ b/scripts/run-capacity.sh
@@ -57,7 +57,7 @@ jq -n \
   --arg run_id "${run_id}" \
   --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --arg git_revision "$(git -C "${repo_root}" rev-parse HEAD)" \
-  --arg git_dirty "$(if git -C "${repo_root}" diff --quiet && git -C "${repo_root}" diff --cached --quiet; then echo false; else echo true; fi)" \
+  --arg git_dirty "$(if [[ -z "$(git -C "${repo_root}" status --porcelain --untracked-files=normal)" ]]; then echo false; else echo true; fi)" \
   --arg k6_image "${k6_image}" \
   --arg config_digest "$(if [[ -f "${evidence_dir}/config.json" ]]; then shasum -a 256 "${evidence_dir}/config.json" | awk '{print $1}'; fi)" \
   --arg environment_digest "$(if [[ -f "${evidence_dir}/environment.json" ]]; then shasum -a 256 "${evidence_dir}/environment.json" | awk '{print $1}'; fi)" \
@@ -126,13 +126,21 @@ if [[ -n "${chaos_pid}" ]]; then
   fi
 fi
 
-verifier_status=0
 verifier="${repo_root}/tests/capacity/verifiers/${profile}.sh"
+verifier_required=false
+if [[ "${profile}" != "api-readiness" && "${CAPACITY_MODE:-gate}" == "gate" ]]; then
+  verifier_required=true
+fi
+
+verifier_status=0
 if [[ -x "${verifier}" ]]; then
   set +e
   "${verifier}" "${evidence_dir}" 2>&1 | tee "${evidence_dir}/verifier.log"
   verifier_status=${PIPESTATUS[0]}
   set -e
+elif [[ "${verifier_required}" == "true" ]]; then
+  echo "gate profile requires an executable domain verifier: ${verifier}" | tee "${evidence_dir}/verifier.log" >&2
+  verifier_status=2
 fi
 
 if (( status == 0 && chaos_status != 0 )); then
@@ -147,7 +155,8 @@ jq \
   --argjson exit_code "${status}" \
   --argjson chaos_exit_code "${chaos_status}" \
   --argjson verifier_exit_code "${verifier_status}" \
-  '. + {completedAt:$completed_at, exitCode:$exit_code, chaosExitCode:$chaos_exit_code, verifierExitCode:$verifier_exit_code, passed:($exit_code == 0)}' \
+  --argjson verifier_required "${verifier_required}" \
+  '. + {completedAt:$completed_at, exitCode:$exit_code, chaosExitCode:$chaos_exit_code, verifierRequired:$verifier_required, verifierExitCode:$verifier_exit_code, passed:($exit_code == 0)}' \
   "${metadata}" >"${metadata}.tmp"
 mv "${metadata}.tmp" "${metadata}"
 

--- a/scripts/run-capacity.sh
+++ b/scripts/run-capacity.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 GitStore contributors
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -n "${CAPACITY_TOKEN_FILE:-}" ]]; then
+  if [[ ! -r "${CAPACITY_TOKEN_FILE}" ]]; then
+    echo "CAPACITY_TOKEN_FILE is not readable" >&2
+    exit 2
+  fi
+  CAPACITY_TOKEN="$(<"${CAPACITY_TOKEN_FILE}")"
+  export CAPACITY_TOKEN
+fi
+profile="${1:-${CAPACITY_PROFILE:-}}"
+if [[ -z "${profile}" ]]; then
+  echo "usage: make capacity CAPACITY_PROFILE=<profile>" >&2
+  exit 2
+fi
+if [[ ! "${profile}" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+  echo "capacity profile must contain only lowercase letters, digits, and hyphens" >&2
+  exit 2
+fi
+
+script="${repo_root}/tests/capacity/profiles/${profile}.js"
+if [[ ! -f "${script}" ]]; then
+  echo "unknown capacity profile: ${profile}" >&2
+  exit 2
+fi
+
+k6_image="${K6_IMAGE:-grafana/k6:2.1.0}"
+run_id="${CAPACITY_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+evidence_root="${CAPACITY_EVIDENCE_DIR:-${repo_root}/.gitstore/capacity}"
+evidence_dir="${evidence_root}/${profile}/${run_id}"
+mkdir -p "${evidence_dir}"
+
+for manifest_kind in config environment; do
+  case "${manifest_kind}" in
+    config) variable_name="CAPACITY_CONFIG_MANIFEST" ;;
+    environment) variable_name="CAPACITY_ENVIRONMENT_MANIFEST" ;;
+  esac
+  manifest_path="${!variable_name:-}"
+  if [[ -n "${manifest_path}" ]]; then
+    if [[ ! -r "${manifest_path}" ]] || ! jq empty "${manifest_path}"; then
+      echo "${variable_name} must identify a readable JSON document" >&2
+      exit 2
+    fi
+    jq -S . "${manifest_path}" >"${evidence_dir}/${manifest_kind}.json"
+  fi
+done
+
+metadata="${evidence_dir}/metadata.json"
+jq -n \
+  --arg schema_version "1" \
+  --arg profile "${profile}" \
+  --arg run_id "${run_id}" \
+  --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg git_revision "$(git -C "${repo_root}" rev-parse HEAD)" \
+  --arg git_dirty "$(if git -C "${repo_root}" diff --quiet && git -C "${repo_root}" diff --cached --quiet; then echo false; else echo true; fi)" \
+  --arg k6_image "${k6_image}" \
+  --arg config_digest "$(if [[ -f "${evidence_dir}/config.json" ]]; then shasum -a 256 "${evidence_dir}/config.json" | awk '{print $1}'; fi)" \
+  --arg environment_digest "$(if [[ -f "${evidence_dir}/environment.json" ]]; then shasum -a 256 "${evidence_dir}/environment.json" | awk '{print $1}'; fi)" \
+  '{schemaVersion:($schema_version|tonumber), profile:$profile, runId:$run_id, startedAt:$started_at, gitRevision:$git_revision, gitDirty:($git_dirty=="true"), loadGenerator:{name:"k6", image:$k6_image}} + (if $config_digest == "" then {} else {configDigest:$config_digest} end) + (if $environment_digest == "" then {} else {environmentDigest:$environment_digest} end)' \
+  >"${metadata}"
+
+export CAPACITY_EVIDENCE_DIR="${evidence_dir}"
+export CAPACITY_RUN_ID="${run_id}"
+
+preflight="${repo_root}/tests/capacity/preflight/${profile}.sh"
+if [[ -x "${preflight}" ]]; then
+  "${preflight}" "${evidence_dir}" 2>&1 | tee "${evidence_dir}/preflight.log"
+fi
+
+chaos_pid=""
+if [[ -n "${CAPACITY_CHAOS_PROFILE:-}" ]]; then
+  if [[ -z "${CAPACITY_CHAOS_TARGET:-}" || "${CAPACITY_CHAOS_CONFIRM:-0}" != "1" ]]; then
+    echo "integrated chaos requires CAPACITY_CHAOS_TARGET and CAPACITY_CHAOS_CONFIRM=1" >&2
+    exit 2
+  fi
+  (
+    sleep "${CAPACITY_CHAOS_DELAY:-30s}"
+    CHAOS_PROFILE="${CAPACITY_CHAOS_PROFILE}" \
+      CHAOS_TARGET="${CAPACITY_CHAOS_TARGET}" \
+      CHAOS_CONFIRM=1 \
+      CHAOS_EVIDENCE_DIR="${evidence_dir}/chaos" \
+      "${repo_root}/scripts/run-chaos.sh" "${CAPACITY_CHAOS_PROFILE}"
+  ) >"${evidence_dir}/chaos-runner.log" 2>&1 &
+  chaos_pid=$!
+fi
+
+set +e
+if [[ -n "${K6_BIN:-}" ]]; then
+  "${K6_BIN}" run --summary-export "${evidence_dir}/summary.json" "${script}" 2>&1 | tee "${evidence_dir}/k6.log"
+  status=${PIPESTATUS[0]}
+elif command -v k6 >/dev/null 2>&1; then
+  k6 run --summary-export "${evidence_dir}/summary.json" "${script}" 2>&1 | tee "${evidence_dir}/k6.log"
+  status=${PIPESTATUS[0]}
+else
+  docker_args=(run --rm --network "${CAPACITY_DOCKER_NETWORK:-host}" -v "${repo_root}:/workspace:ro" -v "${evidence_dir}:/evidence" -w /workspace)
+  if [[ -n "${CAPACITY_ENV_FILE:-}" ]]; then
+    docker_args+=(--env-file "${CAPACITY_ENV_FILE}")
+  fi
+  while IFS='=' read -r name _; do
+    case "${name}" in
+      CAPACITY_*|K6_*) docker_args+=(-e "${name}") ;;
+    esac
+  done < <(env)
+  docker "${docker_args[@]}" "${k6_image}" run --summary-export /evidence/summary.json "/workspace/tests/capacity/profiles/${profile}.js" 2>&1 | tee "${evidence_dir}/k6.log"
+  status=${PIPESTATUS[0]}
+fi
+set -e
+
+chaos_status=0
+if [[ -n "${chaos_pid}" ]]; then
+  if kill -0 "${chaos_pid}" 2>/dev/null; then
+    kill "${chaos_pid}" 2>/dev/null || true
+    wait "${chaos_pid}" 2>/dev/null || true
+    echo "configured chaos delay exceeded the load duration; no fault was injected" | tee -a "${evidence_dir}/chaos-runner.log"
+    chaos_status=124
+  else
+  set +e
+  wait "${chaos_pid}"
+  chaos_status=$?
+  set -e
+  fi
+fi
+
+verifier_status=0
+verifier="${repo_root}/tests/capacity/verifiers/${profile}.sh"
+if [[ -x "${verifier}" ]]; then
+  set +e
+  "${verifier}" "${evidence_dir}" 2>&1 | tee "${evidence_dir}/verifier.log"
+  verifier_status=${PIPESTATUS[0]}
+  set -e
+fi
+
+if (( status == 0 && chaos_status != 0 )); then
+  status=${chaos_status}
+fi
+if (( status == 0 && verifier_status != 0 )); then
+  status=${verifier_status}
+fi
+
+jq \
+  --arg completed_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson exit_code "${status}" \
+  --argjson chaos_exit_code "${chaos_status}" \
+  --argjson verifier_exit_code "${verifier_status}" \
+  '. + {completedAt:$completed_at, exitCode:$exit_code, chaosExitCode:$chaos_exit_code, verifierExitCode:$verifier_exit_code, passed:($exit_code == 0)}' \
+  "${metadata}" >"${metadata}.tmp"
+mv "${metadata}.tmp" "${metadata}"
+
+echo "capacity evidence: ${evidence_dir}"
+exit "${status}"

--- a/scripts/run-chaos.sh
+++ b/scripts/run-chaos.sh
@@ -34,7 +34,45 @@ evidence_root="${CHAOS_EVIDENCE_DIR:-${repo_root}/.gitstore/chaos}"
 evidence_dir="${evidence_root}/${profile}/${run_id}"
 mkdir -p "${evidence_dir}"
 
-docker inspect "${target}" >"${evidence_dir}/target-before.json"
+record_target_state() {
+  local output_file="$1"
+
+  docker inspect "${target}" | jq '[.[] | {
+    Id,
+    Name,
+    Image,
+    Created,
+    RestartCount,
+    Config: {Image: .Config.Image},
+    HostConfig: {
+      Memory: .HostConfig.Memory,
+      NanoCpus: .HostConfig.NanoCpus,
+      CpuPeriod: .HostConfig.CpuPeriod,
+      CpuQuota: .HostConfig.CpuQuota,
+      CpusetCpus: .HostConfig.CpusetCpus,
+      PidsLimit: .HostConfig.PidsLimit,
+      RestartPolicy: .HostConfig.RestartPolicy
+    },
+    State: {
+      Status: .State.Status,
+      Running: .State.Running,
+      Paused: .State.Paused,
+      Restarting: .State.Restarting,
+      OOMKilled: .State.OOMKilled,
+      Dead: .State.Dead,
+      ExitCode: .State.ExitCode,
+      Error: .State.Error,
+      StartedAt: .State.StartedAt,
+      FinishedAt: .State.FinishedAt,
+      Health: (if .State.Health == null then null else {
+        Status: .State.Health.Status,
+        FailingStreak: .State.Health.FailingStreak
+      } end)
+    }
+  }]' >"${output_file}"
+}
+
+record_target_state "${evidence_dir}/target-before.json"
 jq -n --arg profile "${profile}" --arg target "${target}" --arg action "${action}" \
   --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg image "${pumba_image}" \
   '{schemaVersion:1, profile:$profile, target:$target, action:$action, startedAt:$started_at, injector:{name:"pumba", image:$image}}' \
@@ -59,7 +97,7 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock "${pumba_image}" --
 status=${PIPESTATUS[0]}
 set -e
 
-docker inspect "${target}" >"${evidence_dir}/target-after.json" 2>/dev/null || true
+record_target_state "${evidence_dir}/target-after.json" 2>/dev/null || true
 jq --arg completed_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson exit_code "${status}" \
   '. + {completedAt:$completed_at, exitCode:$exit_code, injected:($exit_code == 0)}' \
   "${evidence_dir}/metadata.json" >"${evidence_dir}/metadata.json.tmp"

--- a/scripts/run-chaos.sh
+++ b/scripts/run-chaos.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 GitStore contributors
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+profile="${1:-${CHAOS_PROFILE:-}}"
+profile_file="${repo_root}/tests/chaos/profiles/${profile}.json"
+if [[ -z "${profile}" || ! "${profile}" =~ ^[a-z0-9][a-z0-9-]*$ || ! -f "${profile_file}" ]]; then
+  echo "usage: make chaos CHAOS_PROFILE=<profile> CHAOS_TARGET=<gitstore-container> CHAOS_CONFIRM=1" >&2
+  exit 2
+fi
+if [[ "${CHAOS_CONFIRM:-0}" != "1" ]]; then
+  echo "refusing fault injection without CHAOS_CONFIRM=1" >&2
+  exit 2
+fi
+
+target="${CHAOS_TARGET:-}"
+if [[ ! "${target}" =~ ^gitstore-[a-zA-Z0-9_.-]+$ ]]; then
+  echo "CHAOS_TARGET must be one explicit GitStore container name beginning with gitstore-" >&2
+  exit 2
+fi
+if ! docker inspect "${target}" >/dev/null 2>&1; then
+  echo "target container does not exist: ${target}" >&2
+  exit 2
+fi
+
+action="$(jq -er '.action' "${profile_file}")"
+duration="$(jq -r '.duration // empty' "${profile_file}")"
+pumba_image="${PUMBA_IMAGE:-ghcr.io/alexei-led/pumba:1.1.7}"
+run_id="${CHAOS_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+evidence_root="${CHAOS_EVIDENCE_DIR:-${repo_root}/.gitstore/chaos}"
+evidence_dir="${evidence_root}/${profile}/${run_id}"
+mkdir -p "${evidence_dir}"
+
+docker inspect "${target}" >"${evidence_dir}/target-before.json"
+jq -n --arg profile "${profile}" --arg target "${target}" --arg action "${action}" \
+  --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg image "${pumba_image}" \
+  '{schemaVersion:1, profile:$profile, target:$target, action:$action, startedAt:$started_at, injector:{name:"pumba", image:$image}}' \
+  >"${evidence_dir}/metadata.json"
+
+case "${action}" in
+  restart)
+    command_args=(restart "${target}")
+    ;;
+  pause)
+    [[ -n "${duration}" ]] || { echo "pause profile requires duration" >&2; exit 2; }
+    command_args=(pause --duration "${duration}" "${target}")
+    ;;
+  *)
+    echo "unsupported safe chaos action: ${action}" >&2
+    exit 2
+    ;;
+esac
+
+set +e
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock "${pumba_image}" --log-level info "${command_args[@]}" 2>&1 | tee "${evidence_dir}/pumba.log"
+status=${PIPESTATUS[0]}
+set -e
+
+docker inspect "${target}" >"${evidence_dir}/target-after.json" 2>/dev/null || true
+jq --arg completed_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson exit_code "${status}" \
+  '. + {completedAt:$completed_at, exitCode:$exit_code, injected:($exit_code == 0)}' \
+  "${evidence_dir}/metadata.json" >"${evidence_dir}/metadata.json.tmp"
+mv "${evidence_dir}/metadata.json.tmp" "${evidence_dir}/metadata.json"
+
+echo "chaos evidence: ${evidence_dir}"
+exit "${status}"

--- a/specs/050-namespace-watch-contract/plan.md
+++ b/specs/050-namespace-watch-contract/plan.md
@@ -29,9 +29,9 @@ and mutation outcomes are inputs and are not reopened.
 **Performance Goals**: 10 sustained Namespace transitions/s with 100/s bursts and 1,000 concurrent subscriptions across two API replicas; event visibility p95 ≤1 s and p99 ≤3 s; 10,000-event replay p95 ≤5 s; recovery after replica replacement ≤30 s; internal errors <0.1%; zero missing acknowledged transitions  
 **Constraints**: Additive GraphQL evolution; preserve generic path; seven-day bounded journal; 14-day CDC TTL; at-least-once/idempotent delivery; one per-kind order; no cross-kind order; explicit `WATCH_EXPIRED` on continuity loss; `FORBIDDEN` before cursor disclosure; no change to spec-047 mutation behavior  
 **Scale/Scope**: Cluster-scoped Namespace stream only. Product/category/file watches retain their current backends pending their own migration specs. Namespace volume is low relative to the 5,000,000-product catalogue, but infrastructure is tested under sustained push/admission traffic and 1,000 subscribers.  
-**Replica/Scaling Model**: Every API replica reads one shared journal epoch/cursor space. A Scylla-LWT lease/fencing token bounds CDC materialization to one active writer; overlap may duplicate but cannot lose events or permit stale progress. Any replica can register/replay a subscription.  
+**Replica/Scaling Model**: Every API replica reads one shared journal epoch/cursor space. A Scylla-LWT lease/fencing token bounds CDC materialization to one active writer; overlap may duplicate but cannot lose events or permit stale progress. Any replica can register/replay a subscription. Live delivery uses one bounded durable-journal tailer per API replica, so datastore polling scales with replicas rather than WebSocket count.
 **Authentication/Authorization**: Both typed and generic Namespace watches require cluster-scoped `namespace.watch` before cursor parsing, journal reads, or replay. Existing pluggable AuthN/AuthZ providers and decision logging remain the enforcement boundary.  
-**Load/Backpressure Model**: Journal buckets 4,096 events; read batches 256; subscriber channel 64; maximum resume 100,000 events; bounded 30 s delivery backpressure; 100 ms journal poll with capped 2 s idle backoff; 30 s durable bookmark; 30 s materializer lease renewed every 10 s; sustained overflow/retention/discontinuity fail closed.
+**Load/Backpressure Model**: Journal buckets 4,096 events; read batches 256; a bounded 512-event default shared live ring; subscriber channel 64; maximum resume 100,000 events; bounded 30 s delivery backpressure; one 100 ms journal poll per API replica with capped 2 s idle backoff; 30 s durable bookmark; 30 s materializer lease renewed every 10 s; lagging subscribers catch up durably and sustained overflow/retention/discontinuity fail closed.
 
 ## Constitution Check
 
@@ -261,8 +261,11 @@ BOOKMARK at captured high water before the client lists. The client holds the
 subscription open, pages Namespaces, replaces its local snapshot, then drains
 queued rows after the cursor.
 
-A subscriber reads at most 256 rows per query, buffers 64 events with bounded
-delivery backpressure, and replays at most 100,000. Any condition that prevents continuity returns `WATCH_EXPIRED`
+A subscriber replays or catches up at most 256 durable rows per query, buffers
+64 output events with bounded delivery backpressure, and replays at most
+100,000. Live subscribers share one bounded journal tailer per API replica;
+healthy sockets drain its recent-event ring without issuing their own Scylla
+polls. Any condition that prevents continuity returns `WATCH_EXPIRED`
 with a bounded reason; infrastructure unavailable before registration returns
 `WATCH_UNAVAILABLE`.
 

--- a/specs/050-namespace-watch-contract/quickstart.md
+++ b/specs/050-namespace-watch-contract/quickstart.md
@@ -237,6 +237,62 @@ Pass thresholds:
 - retained-memory growth <10%;
 - no normal stream closure after overflow/discontinuity.
 
+Run offered load through the repository harness and attach sanitized effective
+configuration/environment manifests:
+
+```bash
+make capacity CAPACITY_PROFILE=namespace-admission \
+  CAPACITY_API_A=http://api-a:4000/graphql \
+  CAPACITY_API_B=http://api-b:4000/graphql \
+  CAPACITY_TOKEN_FILE=/absolute/path/to/token \
+  CAPACITY_CONFIG_MANIFEST=/absolute/path/to/effective-config.json \
+  CAPACITY_ENVIRONMENT_MANIFEST=/absolute/path/to/environment.json \
+  CAPACITY_API_REPLICAS=2 \
+  CAPACITY_SCYLLA_NODES=3 \
+  CAPACITY_SCYLLA_SMP=2 \
+  CAPACITY_GIT_SERVICE_BUILD=release
+```
+
+### Current gate status
+
+The production capacity gate remains **not passed**. Diagnostic runs found:
+
+- the former in-process load scheduler dropped 34,481 of 41,899 scheduled
+  transitions and admitted only 4,101 of 7,418 attempted transitions;
+- its external replacement watcher lacked Docker permission, so the recorded
+  replacement failure was an orchestration failure rather than valid recovery
+  evidence;
+- the reusable k6 profile passed a three-second 1 transition/s smoke with zero
+  drops and approximately 474 ms p95 mutation latency;
+- a 30-second 10 transitions/s diagnostic exhausted 120 VUs, dropped 181
+  iterations, failed all 120 issued mutations, and measured approximately
+  48.5 s p95; and
+- that environment used `target/debug/git-service`, while every GraphQL
+  Namespace mutation takes the per-repository write lock to commit into the
+  shared system repository. Debug-artifact results cannot establish production
+  capacity.
+
+The 2026-09-01 clean release-artifact attempt prepared 10,000 acknowledged
+transitions in 3m19.7s and caught the durable journal up in 1.04s. A short
+10 transitions/s gate smoke admitted 100/100 with zero conflicts, errors, or
+drops (approximately 46 ms p95 and 52 ms p99). The full 60-minute run still
+failed: of 41,899 offered transitions, 32,814 entered the bounded queue,
+31,550 were admitted and acknowledged, 1,264 attempts failed, and 9,085 were
+backpressured. Pumba successfully restarted API A; its 500 subscribers resumed,
+it reacquired the materializer lease, and observed CDC lag returned below one
+second. Five minutes later the three-node local Scylla cluster suffered gossip
+timeouts and connection resets; node 3 was OOM-killed and restarted. This is
+environment-capacity failure evidence, not support for increasing application
+timeouts or buffers.
+
+Before rerunning the unchanged 60-minute workload, provision fixed and
+explicitly recorded per-node Scylla memory/CPU, require zero OOM kills and
+unexpected datastore restarts, retain release artifacts and the clean isolated
+keyspace/Git directory, and repeat the short stepped preflight. Only after that
+environment passes should a three-repetition, one-variable-at-a-time matrix be
+used to choose application defaults. Only a clean run satisfying every
+threshold may complete task T061.
+
 ## Documentation and final gate
 
 Update:

--- a/specs/050-namespace-watch-contract/research.md
+++ b/specs/050-namespace-watch-contract/research.md
@@ -147,25 +147,31 @@ cross-table transactions.
   at-least-once and cross-partition dedup/sequence transactions add complexity
   without improving controller correctness.
 
-## R5: Tail the durable journal from every API replica
+## R5: Tail the durable journal once per API replica
 
 **Decision**: Replace direct Namespace subscriptions to the local event bus with
 a `WatchJournal` interface. Each subscription captures the journal high-water
-cursor atomically, optionally replays after a supplied cursor, then tails
-bounded batches from the shared journal. All API replicas read the same cursor
-space. The existing local event bus remains unchanged for other resource kinds
-until their own migration specifications.
+cursor atomically and optionally replays after a supplied cursor. One shared,
+bounded tailer per API replica reads later batches from the durable journal and
+fans them out to local subscriptions; a subscriber that falls behind the
+tailer's bounded ring catches up from the durable journal before continuing.
+All API replicas read the same cursor space. The existing local event bus
+remains unchanged for other resource kinds until their own migration
+specifications.
 
 **Rationale**: This limits infrastructure expansion to Namespace as requested,
-allows a cursor issued by replica A to resume through replica B, and avoids
-reopening Category/Product/File contracts.
+allows a cursor issued by replica A to resume through replica B, keeps Scylla
+as the source of truth across process replacement, bounds local memory, and
+reduces steady journal polling from O(subscribers) to O(API replicas). It also
+avoids reopening Category/Product/File contracts.
 
 **Alternatives considered**:
 
 - Replace every resource watch in feature 050: rejected as unrelated scope.
-- One shared API-level consumer that fans out locally: rejected because a new
-  replica still needs durable replay and local fan-out is not the source of
-  truth.
+- Use only an ephemeral API-level consumer/event bus: rejected because a new
+  replica still needs durable replay and local fan-out cannot be the source of
+  truth. The selected shared tailer is only a bounded read optimization over
+  the durable journal, never a replacement for it.
 
 ## R6: Use bootstrap bookmark, then list, then drain
 

--- a/tests/capacity/README.md
+++ b/tests/capacity/README.md
@@ -1,0 +1,93 @@
+# GitStore capacity profiles
+
+Capacity profiles use k6 for reproducible offered load and threshold decisions.
+Run them only through the root Makefile:
+
+```bash
+make capacity CAPACITY_PROFILE=api-readiness \
+  CAPACITY_BASE_URL=http://localhost:4000
+```
+
+The default runner uses the pinned container image declared in the Makefile.
+Set `K6_BIN` to an explicit executable when container networking is unsuitable,
+or `CAPACITY_ENV_FILE` to an absolute, untracked environment file. Never put
+tokens in profile source or committed evidence.
+For a file containing only a bearer token, use `CAPACITY_TOKEN_FILE`; the
+runner exports it without printing or recording the value.
+
+Gate runs also supply sanitized JSON through `CAPACITY_CONFIG_MANIFEST` and
+`CAPACITY_ENVIRONMENT_MANIFEST`. The runner canonicalizes and hashes both into
+the evidence bundle. The config manifest records effective non-secret knobs,
+not merely source-file defaults; the environment manifest records CPU, memory,
+architecture, runtime, replica counts, datastore topology, and optimized build
+identity. See `examples/` for the minimum shape. Do not include credentials,
+secret references whose names are sensitive, or raw environment dumps.
+For datastore-backed profiles, record per-node memory limits, CPU/shards,
+restart counts, OOM state, and authentication mode. A gate fails if a node is
+OOM-killed, unexpectedly restarts, or leaves cluster membership during load.
+
+## Adding a profile
+
+1. Add `profiles/<name>.js`; import reusable helpers from `lib/`.
+2. Use an arrival-rate executor for a throughput contract. Treat
+   `dropped_iterations` as a failing threshold unless the specification
+   explicitly defines overload shedding as the expected result.
+3. Tag requests by stable operation name and define p95, p99, error-rate, and
+   correctness-check thresholds.
+4. Fail fast when required topology, dataset, or credential inputs are absent.
+5. Add a domain verifier for invariants k6 cannot prove, and store its output
+   in the same evidence directory identified by `CAPACITY_EVIDENCE_DIR`.
+6. Run declared `make chaos` profiles while the load is active and require the
+   recovery verifier to pass.
+
+An executable `preflight/<profile>.sh` runs before k6 and must fail when the
+declared topology or dataset scale is absent. An executable
+`verifiers/<profile>.sh` runs after k6 and decides domain correctness. Both
+receive the evidence directory as their first argument and store structured
+results there.
+
+To inject a reviewed fault during load, configure the integrated runner:
+
+```bash
+make capacity CAPACITY_PROFILE=<profile> \
+  CAPACITY_CHAOS_PROFILE=api-restart \
+  CAPACITY_CHAOS_TARGET=gitstore-capacity-api-a \
+  CAPACITY_CHAOS_DELAY=30m \
+  CAPACITY_CHAOS_CONFIRM=1
+```
+
+The overall run fails if k6 thresholds, fault injection, or the domain verifier
+fails. Pumba's successful exit means only that the fault was injected; recovery
+is always a verifier responsibility.
+
+A k6 exit code alone is not a production capacity pass. The evidence must also
+identify the deployed revision, topology, dataset scale, fault schedule, and
+domain-verifier result.
+
+## Choosing application defaults
+
+Default changes require a configuration matrix, not one successful run. Hold
+the workload, dataset, topology, and hardware manifest constant; vary one
+bounded group of related knobs; run at least three repetitions per candidate;
+and compare throughput, p95/p99, errors, recovery, CPU, retained memory,
+goroutines, queue depth, and datastore pressure. Select the smallest setting
+that meets the envelope with documented headroom and safe overload behavior.
+Record the chosen evidence run IDs beside the config change. Never promote a
+diagnostic run, a debug build, or a fault run without successful rollback into
+a default.
+
+## Included profiles
+
+- `api-readiness` is a non-mutating runner smoke test.
+- `namespace-admission` drives unique Namespace creates at a fixed arrival
+  rate, alternates across two replicas, and fails on dropped iterations,
+  GraphQL errors, or latency/error threshold violations. It is the offered-load
+  component of Namespace capacity validation; the existing Go watch verifier
+  remains authoritative for replay, completeness, duplicates, and cursor
+  recovery until its external-load mode is completed.
+
+The Namespace profile defaults to gate mode and refuses to run unless evidence
+declares at least two API replicas, three Scylla nodes with at least two shards
+each, and a release Git-service build. Use `CAPACITY_MODE=diagnostic` only for
+short bottleneck discovery; diagnostic results can never be cited as a capacity
+pass.

--- a/tests/capacity/README.md
+++ b/tests/capacity/README.md
@@ -44,7 +44,8 @@ An executable `preflight/<profile>.sh` runs before k6 and must fail when the
 declared topology or dataset scale is absent. An executable
 `verifiers/<profile>.sh` runs after k6 and decides domain correctness. Both
 receive the evidence directory as their first argument and store structured
-results there.
+results there. Gate-mode profiles other than the non-mutating `api-readiness`
+smoke test fail closed when their verifier is absent or not executable.
 
 To inject a reviewed fault during load, configure the integrated runner:
 
@@ -84,7 +85,9 @@ a default.
   GraphQL errors, or latency/error threshold violations. It is the offered-load
   component of Namespace capacity validation; the existing Go watch verifier
   remains authoritative for replay, completeness, duplicates, and cursor
-  recovery until its external-load mode is completed.
+  recovery until its external-load mode is completed. Consequently, this
+  profile cannot produce passing gate evidence until that verifier is wired in;
+  use `CAPACITY_MODE=diagnostic` for offered-load-only investigation.
 
 The Namespace profile defaults to gate mode and refuses to run unless evidence
 declares at least two API replicas, three Scylla nodes with at least two shards

--- a/tests/capacity/examples/config-manifest.json
+++ b/tests/capacity/examples/config-manifest.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "services": {
+    "api": {
+      "replicas": 2,
+      "watch": {
+        "pollInterval": "100ms",
+        "idleBackoffMax": "2s",
+        "readBatch": 256,
+        "liveRing": 512,
+        "subscriberBuffer": 64
+      }
+    },
+    "gitService": {
+      "build": "release"
+    },
+    "scylla": {
+      "nodes": 3,
+      "smpPerNode": 2
+    }
+  }
+}

--- a/tests/capacity/examples/environment-manifest.json
+++ b/tests/capacity/examples/environment-manifest.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "runtime": "docker",
+  "architecture": "arm64",
+  "host": {
+    "logicalCPUs": 10,
+    "memoryBytes": 17179869184
+  },
+  "topology": {
+    "apiReplicas": 2,
+    "gitServiceReplicas": 1,
+    "scyllaNodes": 3
+  }
+}

--- a/tests/capacity/lib/config.js
+++ b/tests/capacity/lib/config.js
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+function env(name, fallback = '') {
+  const value = __ENV[name] || fallback;
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function integer(name, fallback, minimum = 1) {
+  const value = Number.parseInt(__ENV[name] || `${fallback}`, 10);
+  if (!Number.isInteger(value) || value < minimum) {
+    throw new Error(`${name} must be an integer >= ${minimum}`);
+  }
+  return value;
+}
+
+export { env, integer };

--- a/tests/capacity/lib/graphql.js
+++ b/tests/capacity/lib/graphql.js
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+import http from 'k6/http';
+
+export function graphql(url, token, query, variables, tags = {}) {
+  const response = http.post(url, JSON.stringify({ query, variables }), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    tags,
+  });
+  let body;
+  try {
+    body = response.json();
+  } catch (_) {
+    body = { errors: [{ message: 'non-JSON GraphQL response' }] };
+  }
+  return { response, body };
+}

--- a/tests/capacity/preflight/namespace-admission.sh
+++ b/tests/capacity/preflight/namespace-admission.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 GitStore contributors
+
+set -euo pipefail
+
+evidence_dir="$1"
+mode="${CAPACITY_MODE:-gate}"
+api_replicas="${CAPACITY_API_REPLICAS:-0}"
+scylla_nodes="${CAPACITY_SCYLLA_NODES:-0}"
+scylla_smp="${CAPACITY_SCYLLA_SMP:-0}"
+git_build="${CAPACITY_GIT_SERVICE_BUILD:-unknown}"
+
+if [[ "${mode}" != "gate" && "${mode}" != "diagnostic" ]]; then
+  echo "CAPACITY_MODE must be gate or diagnostic" >&2
+  exit 2
+fi
+if [[ "${mode}" == "gate" ]]; then
+  [[ -n "${CAPACITY_CONFIG_MANIFEST:-}" ]] || { echo "capacity gate requires CAPACITY_CONFIG_MANIFEST" >&2; exit 2; }
+  [[ -n "${CAPACITY_ENVIRONMENT_MANIFEST:-}" ]] || { echo "capacity gate requires CAPACITY_ENVIRONMENT_MANIFEST" >&2; exit 2; }
+  (( api_replicas >= 2 )) || { echo "capacity gate requires CAPACITY_API_REPLICAS>=2" >&2; exit 2; }
+  (( scylla_nodes >= 3 )) || { echo "capacity gate requires CAPACITY_SCYLLA_NODES>=3" >&2; exit 2; }
+  (( scylla_smp >= 2 )) || { echo "capacity gate requires CAPACITY_SCYLLA_SMP>=2" >&2; exit 2; }
+  [[ "${git_build}" == "release" ]] || { echo "capacity gate requires CAPACITY_GIT_SERVICE_BUILD=release" >&2; exit 2; }
+fi
+
+preflight_file="${evidence_dir}/preflight-environment.json"
+jq -n \
+  --arg mode "${mode}" \
+  --argjson api_replicas "${api_replicas}" \
+  --argjson scylla_nodes "${scylla_nodes}" \
+  --argjson scylla_smp "${scylla_smp}" \
+  --arg git_service_build "${git_build}" \
+  '{schemaVersion:1, mode:$mode, topology:{apiReplicas:$api_replicas, scyllaNodes:$scylla_nodes, scyllaSmpPerNode:$scylla_smp}, builds:{gitService:$git_service_build}}' \
+  >"${preflight_file}"
+
+if [[ "${mode}" == "diagnostic" ]]; then
+  echo "diagnostic mode: topology/build floors are recorded but not enforced"
+fi

--- a/tests/capacity/profiles/api-readiness.js
+++ b/tests/capacity/profiles/api-readiness.js
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+import http from 'k6/http';
+import { check } from 'k6';
+import { env, integer } from '../lib/config.js';
+
+const baseURL = env('CAPACITY_BASE_URL');
+const rate = integer('CAPACITY_RATE', 10);
+
+export const options = {
+  scenarios: {
+    readiness: {
+      executor: 'constant-arrival-rate',
+      rate,
+      timeUnit: '1s',
+      duration: __ENV.CAPACITY_DURATION || '1m',
+      preAllocatedVUs: integer('CAPACITY_PREALLOCATED_VUS', 10),
+      maxVUs: integer('CAPACITY_MAX_VUS', 100),
+    },
+  },
+  thresholds: {
+    checks: ['rate==1'],
+    dropped_iterations: ['count==0'],
+    http_req_failed: ['rate<0.001'],
+    http_req_duration: ['p(95)<1000', 'p(99)<3000'],
+  },
+};
+
+export default function () {
+  const health = http.get(`${baseURL}/health`, { tags: { operation: 'health' } });
+  const ready = http.get(`${baseURL}/ready`, { tags: { operation: 'ready' } });
+  check(health, { 'health is 2xx': (response) => response.status >= 200 && response.status < 300 });
+  check(ready, { 'ready is 2xx': (response) => response.status >= 200 && response.status < 300 });
+}

--- a/tests/capacity/profiles/namespace-admission.js
+++ b/tests/capacity/profiles/namespace-admission.js
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+import exec from 'k6/execution';
+import { check, sleep } from 'k6';
+import { Counter, Rate } from 'k6/metrics';
+import { env, integer } from '../lib/config.js';
+import { graphql } from '../lib/graphql.js';
+
+const apiA = env('CAPACITY_API_A');
+const apiB = env('CAPACITY_API_B');
+const token = env('CAPACITY_TOKEN');
+const runID = env('CAPACITY_RUN_ID').toLowerCase().replace(/[^a-z0-9]/g, '').slice(-20);
+const rate = integer('CAPACITY_RATE', 10);
+const burstRounds = integer('CAPACITY_BURST_ROUNDS', 0, 0);
+const burstRate = integer('CAPACITY_BURST_RATE', 100);
+const burstIntervalSeconds = integer('CAPACITY_BURST_INTERVAL_SECONDS', 60);
+
+if (apiA === apiB) {
+  throw new Error('CAPACITY_API_A and CAPACITY_API_B must identify distinct replicas');
+}
+
+const mutation = `mutation($input: CreateNamespaceInput!) {
+  createNamespace(input: $input) { namespace { metadata { name } } }
+}`;
+
+const admitted = new Counter('gitstore_namespace_admitted');
+const graphqlFailures = new Rate('gitstore_namespace_graphql_failed');
+const conflicts = new Counter('gitstore_namespace_conflicts');
+const existenceQuery = `query($name: String!) { namespace(by: {identifier: $name}) { id } }`;
+
+const scenarios = {
+  sustained: {
+    executor: 'constant-arrival-rate',
+    rate,
+    timeUnit: '1s',
+    duration: __ENV.CAPACITY_DURATION || '10m',
+    preAllocatedVUs: integer('CAPACITY_PREALLOCATED_VUS', Math.max(20, rate * 2)),
+    maxVUs: integer('CAPACITY_MAX_VUS', Math.max(100, rate * 10)),
+  },
+};
+for (let round = 1; round <= burstRounds; round += 1) {
+  scenarios[`burst${round}`] = {
+    executor: 'constant-arrival-rate',
+    rate: burstRate,
+    timeUnit: '1s',
+    duration: '1s',
+    startTime: `${round * burstIntervalSeconds}s`,
+    preAllocatedVUs: integer('CAPACITY_BURST_PREALLOCATED_VUS', Math.max(50, burstRate)),
+    maxVUs: integer('CAPACITY_BURST_MAX_VUS', Math.max(200, burstRate * 3)),
+  };
+}
+
+export const options = {
+  scenarios,
+  thresholds: {
+    checks: ['rate==1'],
+    dropped_iterations: ['count==0'],
+    gitstore_namespace_graphql_failed: ['rate<0.001'],
+    http_req_failed: ['rate<0.001'],
+    // The feature's 1s/3s objective is watch visibility after mutation
+    // acknowledgement and is enforced by the domain verifier. Mutations may
+    // drain behind an accepted 100/s burst, but the drain remains bounded.
+    'http_req_duration{operation:createNamespace}': ['p(99)<30000'],
+  },
+};
+
+export function setup() {
+  for (const endpoint of [apiA, apiB]) {
+    const result = graphql(endpoint, token, 'query { __typename }', {}, { operation: 'preflight' });
+    if (result.response.status < 200 || result.response.status >= 300 || result.body.errors) {
+      throw new Error(`GraphQL preflight failed for ${endpoint}`);
+    }
+  }
+}
+
+export default function () {
+  const sequence = exec.scenario.iterationInTest;
+  const scenario = exec.scenario.name.toLowerCase().replace(/[^a-z0-9]/g, '').slice(-12);
+  const traffic = scenario.startsWith('burst') ? 'burst' : 'sustained';
+  const name = `nwk6-${runID}-${scenario}-${sequence}`;
+  const endpoints = sequence % 2 === 0 ? [apiA, apiB] : [apiB, apiA];
+  let result;
+  let acknowledged = false;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const endpoint = endpoints[attempt % endpoints.length];
+    result = graphql(endpoint, token, mutation, {
+      input: {
+        apiVersion: 'gitstore.dev/v1beta1',
+        kind: 'Namespace',
+        metadata: { name },
+        spec: { title: name, tier: 'USER' },
+      },
+    }, { operation: 'createNamespace', traffic, replica: endpoint === apiA ? 'a' : 'b' });
+    if (result.response.status >= 200 && result.response.status < 300 &&
+        (!result.body.errors || result.body.errors.length === 0) &&
+        result.body.data && result.body.data.createNamespace &&
+        result.body.data.createNamespace.namespace.metadata.name === name) {
+      acknowledged = true;
+      break;
+    }
+    const rawErrors = JSON.stringify(result.body.errors || []);
+    if (!rawErrors.includes('NAMESPACE_CONFLICT') && !rawErrors.includes('RESOURCE_VERSION_CONFLICT')) {
+      break;
+    }
+    conflicts.add(1);
+    for (const confirmEndpoint of endpoints) {
+      const confirmation = graphql(confirmEndpoint, token, existenceQuery, { name }, { operation: 'confirmNamespace' });
+      if (confirmation.body.data && confirmation.body.data.namespace && confirmation.body.data.namespace.id) {
+        acknowledged = true;
+        break;
+      }
+    }
+    if (acknowledged) {
+      break;
+    }
+    sleep(0.025 * (attempt + 1));
+  }
+
+  check({ result, acknowledged }, {
+    'createNamespace returned HTTP 2xx': ({ result: finalResult }) => finalResult.response.status >= 200 && finalResult.response.status < 300,
+    'createNamespace reached an acknowledged state': ({ acknowledged: finalAcknowledged }) => finalAcknowledged,
+  });
+  graphqlFailures.add(!acknowledged);
+  if (acknowledged) {
+    admitted.add(1);
+  }
+}

--- a/tests/chaos/README.md
+++ b/tests/chaos/README.md
@@ -1,0 +1,20 @@
+# GitStore chaos profiles
+
+Pumba provides repository-standard fault injection for Docker/Podman-based
+capacity environments. The wrapper is deliberately opt-in and narrowly scoped:
+
+```bash
+make chaos CHAOS_PROFILE=api-restart \
+  CHAOS_TARGET=gitstore-capacity-api-a \
+  CHAOS_CONFIRM=1
+```
+
+Only an explicit existing container beginning with `gitstore-` may be targeted.
+Every run records metadata, logs, and before/after container inspection under
+`.gitstore/chaos/`. Profiles must describe one bounded fault and its expected
+recovery; the capacity verifier—not Pumba—decides whether service correctness
+and the recovery objective passed.
+
+Lifecycle faults are enabled first. Network and resource faults require a new
+reviewed profile, a proven rollback on Docker Desktop and Linux, and a verifier
+that distinguishes intended unavailability from data loss or split brain.

--- a/tests/chaos/profiles/api-pause-5s.json
+++ b/tests/chaos/profiles/api-pause-5s.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "description": "Pause one explicitly selected GitStore API replica for five seconds.",
+  "action": "pause",
+  "duration": "5s",
+  "expectedRecovery": "30s"
+}

--- a/tests/chaos/profiles/api-restart.json
+++ b/tests/chaos/profiles/api-restart.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "description": "Restart one explicitly selected GitStore API replica.",
+  "action": "restart",
+  "expectedRecovery": "30s"
+}

--- a/tests/integration/namespace_watch_capacity_test.go
+++ b/tests/integration/namespace_watch_capacity_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,13 +123,13 @@ func TestNamespaceWatchDeploymentCapacity(t *testing.T) {
 	require.Greater(t, workload.attempted, 0)
 	require.False(t, workload.drainTimedOut, "mutation workers must drain within the bounded shutdown window")
 	require.Equal(t, workload.produced, workload.sustained+workload.bursts, "all produced work must be classified")
-	require.Zero(t, workload.backpressured, "configured load must not be dropped by the bounded worker queue")
-	require.Equal(t, workload.produced, workload.enqueued, "every produced transition must enter the bounded worker queue")
-	require.Equal(t, workload.enqueued, workload.attempted, "every enqueued transition must be attempted before shutdown")
-	require.Equal(t, workload.attempted, workload.admitted+workload.failed, "every attempt must be admitted or reported failed")
-	require.Equal(t, workload.admitted, workload.acknowledged.count(), "admitted transitions must match acknowledged transitions")
+	assert.Zero(t, workload.backpressured, "configured load must not be dropped by the bounded worker queue")
+	assert.Equal(t, workload.produced, workload.enqueued, "every produced transition must enter the bounded worker queue")
+	assert.Equal(t, workload.enqueued, workload.attempted, "every enqueued transition must be attempted before shutdown")
+	assert.Equal(t, workload.attempted, workload.admitted+workload.failed, "every attempt must be admitted or reported failed")
+	assert.Equal(t, workload.admitted, workload.acknowledged.count(), "admitted transitions must match acknowledged transitions")
 	errorRate := float64(workload.failed) / float64(workload.attempted)
-	require.Less(t, errorRate, .001, "internal GraphQL mutation error rate must remain below 0.1%%")
+	assert.Less(t, errorRate, .001, "internal GraphQL mutation error rate must remain below 0.1%%")
 	expectedSustained := int(cfg.duration/(100*time.Millisecond)) - 2
 	if expectedSustained > 0 {
 		require.GreaterOrEqual(t, workload.sustained, expectedSustained, "must schedule 10 sustained transitions/second")
@@ -183,7 +184,7 @@ func loadCapacityConfig(t *testing.T) capacityConfig {
 		apiA:                 strings.TrimSuffix(os.Getenv("NAMESPACE_WATCH_API_A"), "/"),
 		apiB:                 strings.TrimSuffix(os.Getenv("NAMESPACE_WATCH_API_B"), "/"),
 		replacement:          strings.TrimSuffix(os.Getenv("NAMESPACE_WATCH_API_REPLACEMENT"), "/"),
-		token:                os.Getenv("NAMESPACE_WATCH_TOKEN"),
+		token:                namespaceWatchToken(t),
 		replacementTrigger:   os.Getenv("NAMESPACE_WATCH_REPLACEMENT_TRIGGER_FILE"),
 		duration:             duration,
 		replacementDelay:     capacityEnvDuration(t, "NAMESPACE_WATCH_CAPACITY_REPLACEMENT_DELAY", duration/2),
@@ -204,7 +205,7 @@ func loadCapacityConfig(t *testing.T) capacityConfig {
 	require.NotEmpty(t, cfg.replacementTrigger, "NAMESPACE_WATCH_REPLACEMENT_TRIGGER_FILE is required for deployment-harness coordination")
 	_, triggerErr := os.Stat(cfg.replacementTrigger)
 	require.ErrorIs(t, triggerErr, os.ErrNotExist, "replacement trigger must not exist before the gate starts")
-	require.NotEmpty(t, cfg.token, "NAMESPACE_WATCH_TOKEN is required")
+	require.NotEmpty(t, cfg.token, "NAMESPACE_WATCH_TOKEN or NAMESPACE_WATCH_TOKEN_FILE is required")
 	require.Positive(t, cfg.duration)
 	require.Positive(t, cfg.replacementDelay)
 	require.Less(t, cfg.replacementDelay, cfg.duration)

--- a/tests/integration/namespace_watch_capacity_test.go
+++ b/tests/integration/namespace_watch_capacity_test.go
@@ -885,7 +885,9 @@ func capacityCreateRetryable(err error) bool {
 		return false
 	}
 	return strings.Contains(graphqlErr.raw, `"code":"NAMESPACE_CONFLICT"`) ||
-		strings.Contains(graphqlErr.raw, `"reason":"RESOURCE_VERSION_CONFLICT"`)
+		strings.Contains(graphqlErr.raw, `"reason":"RESOURCE_VERSION_CONFLICT"`) ||
+		(strings.Contains(graphqlErr.raw, "Cannot achieve consistency level") &&
+			strings.Contains(graphqlErr.raw, "potentially executed: false"))
 }
 
 func capacityCreateAmbiguous(err error) bool {
@@ -1033,6 +1035,11 @@ func TestCapacityReplayCreateRetriesOnlyConflicts(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, 1, primaryCalls.Load())
 		require.EqualValues(t, 1, peerCalls.Load())
+	})
+
+	t.Run("non-executed serial quorum error is retryable", func(t *testing.T) {
+		err := &capacityGraphQLErrors{raw: `{"message":"Cannot achieve consistency level for cl SERIAL. Requires 2, alive 1 (potentially executed: false)"}`}
+		require.True(t, capacityCreateRetryable(err))
 	})
 
 	t.Run("permanent GraphQL error is not retried", func(t *testing.T) {

--- a/tests/integration/namespace_watch_recovery_test.go
+++ b/tests/integration/namespace_watch_recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/websocket"
@@ -20,7 +21,7 @@ import (
 func TestNamespaceWatchRecoveryProbe(t *testing.T) {
 	apiA := os.Getenv("NAMESPACE_WATCH_API_A")
 	apiB := os.Getenv("NAMESPACE_WATCH_API_B")
-	token := os.Getenv("NAMESPACE_WATCH_TOKEN")
+	token := namespaceWatchToken(t)
 	if apiA == "" || apiB == "" || token == "" {
 		t.Skip("set NAMESPACE_WATCH_API_A, NAMESPACE_WATCH_API_B, and NAMESPACE_WATCH_TOKEN")
 	}
@@ -66,6 +67,20 @@ func TestNamespaceWatchRecoveryProbe(t *testing.T) {
 		}
 		requireNamespaceWatchWireError(t, watch, "WATCH_EXPIRED", "SUBSCRIBER_OVERFLOW")
 	})
+}
+
+func namespaceWatchToken(t *testing.T) string {
+	t.Helper()
+	if token := strings.TrimSpace(os.Getenv("NAMESPACE_WATCH_TOKEN")); token != "" {
+		return token
+	}
+	path := strings.TrimSpace(os.Getenv("NAMESPACE_WATCH_TOKEN_FILE"))
+	if path == "" {
+		return ""
+	}
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err, "read NAMESPACE_WATCH_TOKEN_FILE")
+	return strings.TrimSpace(string(contents))
 }
 
 func requireNamespaceWatchWireError(t *testing.T, conn *websocket.Conn, code, reason string) {


### PR DESCRIPTION
## Summary

- share the Scylla Namespace journal tailer across live subscribers and preserve replay-to-live ordering
- prevent disjoint Namespace commits from starving convergence under sustained writes
- add repository-wide pinned k6 capacity and Pumba chaos runners with evidence bundles, preflight gates, token-file support, and reusable profiles
- document evidence-driven configuration-default selection and fix valid Scylla Docker address options being logged as unknown

## Validation

- `make pr-ready`
- focused Namespace watch integration and resolver tests
- k6 readiness and Namespace admission diagnostics against two release API replicas and a clean three-node Scylla keyspace
- Pumba API restart fault injection and subscriber recovery

## Capacity status

The production capacity gate is **not passed**. The 60-minute run offered 41,899 transitions; 32,814 were attempted, 31,550 admitted/acknowledged, 9,085 backpressured, and 1,264 failed. API A restart recovery succeeded, but Scylla node 3 was OOM-killed/restarted and the cluster recorded gossip timeouts and connection resets. No application defaults are changed from this failed environment. The next gate must run unchanged with explicit fixed Scylla memory/CPU and zero datastore OOM/restart events before a repeated configuration matrix is used to select defaults.

Follow-up to #371.