### PR TITLE
fix(api): resolve Product watch bootstrap bug, namespace quarantine, and add resource JSON schemas

### DIFF
--- a/.agents/skills/speckit-analyze/SKILL.md
+++ b/.agents/skills/speckit-analyze/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: "speckit-analyze"
+description: "Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation."
+metadata:
+  argument-hint: "Optional focus areas for analysis"
+  compatibility: "Requires spec-kit project structure with .specify/ directory"
+  author: "github-spec-kit"
+  source: "templates/commands/analyze.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before analysis)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Goal.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Goal
+
+Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit-tasks` has successfully produced a complete `tasks.md`.
+
+## Operating Constraints
+
+**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit-analyze`.
+
+## Execution Steps
+
+### 1. Initialize Analysis Context
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+
+Abort with an error message if any required file is missing (instruct the user to run missing prerequisite command).
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Overview/Context
+- Functional Requirements
+- Success Criteria (measurable outcomes — e.g., performance, security, availability, user success, business impact)
+- User Stories
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices
+- Data Model references
+- Phases
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs
+- Descriptions
+- Phase grouping
+- Parallel markers [P]
+- Referenced file paths
+
+**From constitution:**
+
+- Load `.specify/memory/constitution.md` for principle validation
+
+### 3. Build Semantic Models
+
+Create internal representations (do not include raw artifacts in output):
+
+- **Requirements inventory**: For each Functional Requirement (FR-###) and Success Criterion (SC-###), record a stable key. Use the explicit FR-/SC- identifier as the primary key when present, and optionally also derive an imperative-phrase slug for readability (e.g., "User can upload file" → `user-can-upload-file`). Include only Success Criteria items that require buildable work (e.g., load-testing infrastructure, security audit tooling), and exclude post-launch outcome metrics and business KPIs (e.g., "Reduce support tickets by 50%").
+- **User story/action inventory**: Discrete user actions with acceptance criteria
+- **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
+- **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
+
+### 4. Detection Passes (Token-Efficient Analysis)
+
+Focus on high-signal findings. Limit to 50 findings total; aggregate remainder in overflow summary.
+
+#### A. Duplication Detection
+
+- Identify near-duplicate requirements
+- Mark lower-quality phrasing for consolidation
+
+#### B. Ambiguity Detection
+
+- Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
+- Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
+
+#### C. Underspecification
+
+- Requirements with verbs but missing object or measurable outcome
+- User stories missing acceptance criteria alignment
+- Tasks referencing files or components not defined in spec/plan
+
+#### D. Constitution Alignment
+
+- Any requirement or plan element conflicting with a MUST principle
+- Missing mandated sections or quality gates from constitution
+
+#### E. Coverage Gaps
+
+- Requirements with zero associated tasks
+- Tasks with no mapped requirement/story
+- Success Criteria requiring buildable work (performance, security, availability) not reflected in tasks
+
+#### F. Inconsistency
+
+- Terminology drift (same concept named differently across files)
+- Data entities referenced in plan but absent in spec (or vice versa)
+- Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
+- Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 5. Severity Assignment
+
+Use this heuristic to prioritize findings:
+
+- **CRITICAL**: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality
+- **HIGH**: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion
+- **MEDIUM**: Terminology drift, missing non-functional task coverage, underspecified edge case
+- **LOW**: Style/wording improvements, minor redundancy not affecting execution order
+
+### 6. Produce Compact Analysis Report
+
+Output a Markdown report (no file writes) with the following structure:
+
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| A1 | Duplication | HIGH | spec.md:L120-134 | Two similar requirements ... | Merge phrasing; keep clearer version |
+
+(Add one row per finding; generate stable IDs prefixed by category initial.)
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+
+**Constitution Alignment Issues:** (if any)
+
+**Unmapped Tasks:** (if any)
+
+**Metrics:**
+
+- Total Requirements
+- Total Tasks
+- Coverage % (requirements with >=1 task)
+- Ambiguity Count
+- Duplication Count
+- Critical Issues Count
+
+### 7. Provide Next Actions
+
+At end of report, output a concise Next Actions block:
+
+- If CRITICAL issues exist: Recommend resolving before `/speckit-implement`
+- If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
+- Provide explicit command suggestions: e.g., "Run /speckit-specify with refinement", "Run /speckit-plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+
+### 8. Offer Remediation
+
+Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+### 9. Check for extension hooks
+
+After reporting, check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Operating Principles
+
+### Context Efficiency
+
+- **Minimal high-signal tokens**: Focus on actionable findings, not exhaustive documentation
+- **Progressive disclosure**: Load artifacts incrementally; don't dump all content into analysis
+- **Token-efficient output**: Limit findings table to 50 rows; summarize overflow
+- **Deterministic results**: Rerunning without changes should produce consistent IDs and counts
+
+### Analysis Guidelines
+
+- **NEVER modify files** (this is read-only analysis)
+- **NEVER hallucinate missing sections** (if absent, report them accurately)
+- **Prioritize constitution violations** (these are always CRITICAL)
+- **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
+- **Report zero issues gracefully** (emit success report with coverage statistics)
+
+## Context
+
+$ARGUMENTS

--- a/.agents/skills/speckit-checklist/SKILL.md
+++ b/.agents/skills/speckit-checklist/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: "speckit-checklist"
+description: "Generate a custom checklist for the current feature based on user requirements."
+metadata:
+  argument-hint: "Domain or focus area for the checklist"
+  compatibility: "Requires spec-kit project structure with .specify/ directory"
+  author: "github-spec-kit"
+  source: "templates/commands/checklist.md"
+---
+
+
+## Checklist Purpose: "Unit Tests for English"
+
+**CRITICAL CONCEPT**: Checklists are **UNIT TESTS FOR REQUIREMENTS WRITING** - they validate the quality, clarity, and completeness of requirements in a given domain.
+
+**NOT for verification/testing**:
+
+- ❌ NOT "Verify the button clicks correctly"
+- ❌ NOT "Test error handling works"
+- ❌ NOT "Confirm the API returns 200"
+- ❌ NOT checking if code/implementation matches the spec
+
+**FOR requirements quality validation**:
+
+- ✅ "Are visual hierarchy requirements defined for all card types?" (completeness)
+- ✅ "Is 'prominent display' quantified with specific sizing/positioning?" (clarity)
+- ✅ "Are hover state requirements consistent across all interactive elements?" (consistency)
+- ✅ "Are accessibility requirements defined for keyboard navigation?" (coverage)
+- ✅ "Does the spec define what happens when logo image fails to load?" (edge cases)
+
+**Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before checklist generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Execution Steps.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+## Execution Steps
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+   - All file paths must be absolute.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+   - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
+   - Only ask about information that materially changes checklist content
+   - Be skipped individually if already unambiguous in `$ARGUMENTS`
+   - Prefer precision over breadth
+
+   Generation algorithm:
+   1. Extract signals: feature domain keywords (e.g., auth, latency, UX, API), risk indicators ("critical", "must", "compliance"), stakeholder hints ("QA", "review", "security team"), and explicit deliverables ("a11y", "rollback", "contracts").
+   2. Cluster signals into candidate focus areas (max 4) ranked by relevance.
+   3. Identify probable audience & timing (author, reviewer, QA, release) if not explicit.
+   4. Detect missing dimensions: scope breadth, depth/rigor, risk emphasis, exclusion boundaries, measurable acceptance criteria.
+   5. Formulate questions chosen from these archetypes:
+      - Scope refinement (e.g., "Should this include integration touchpoints with X and Y or stay limited to local module correctness?")
+      - Risk prioritization (e.g., "Which of these potential risk areas should receive mandatory gating checks?")
+      - Depth calibration (e.g., "Is this a lightweight pre-commit sanity list or a formal release gate?")
+      - Audience framing (e.g., "Will this be used by the author only or peers during PR review?")
+      - Boundary exclusion (e.g., "Should we explicitly exclude performance tuning items this round?")
+      - Scenario class gap (e.g., "No recovery flows detected—are rollback / partial failure paths in scope?")
+
+   Question formatting rules:
+   - If presenting options, generate a compact table with columns: Option | Candidate | Why It Matters
+   - Limit to A–E options maximum; omit table if a free-form answer is clearer
+   - Never ask the user to restate what they already said
+   - Avoid speculative categories (no hallucination). If uncertain, ask explicitly: "Confirm whether X belongs in scope."
+
+   Defaults when interaction impossible:
+   - Depth: Standard
+   - Audience: Reviewer (PR) if code-related; Author otherwise
+   - Focus: Top 2 relevance clusters
+
+   Output the questions (label Q1/Q2/Q3). After answers: if ≥2 scenario classes (Alternate / Exception / Recovery / Non-Functional domain) remain unclear, you MAY ask up to TWO more targeted follow‑ups (Q4/Q5) with a one-line justification each (e.g., "Unresolved recovery path risk"). Do not exceed five total questions. Skip escalation if user explicitly declines more.
+
+3. **Understand user request**: Combine `$ARGUMENTS` + clarifying answers:
+   - Derive checklist theme (e.g., security, review, deploy, ux)
+   - Consolidate explicit must-have items mentioned by user
+   - Map focus selections to category scaffolding
+   - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
+
+4. **Load feature context**: Read from FEATURE_DIR:
+   - spec.md: Feature requirements and scope
+   - plan.md (if exists): Technical details, dependencies
+   - tasks.md (if exists): Implementation tasks
+
+   **Context Loading Strategy**:
+   - Load only necessary portions relevant to active focus areas (avoid full-file dumping)
+   - Prefer summarizing long sections into concise scenario/requirement bullets
+   - Use progressive disclosure: add follow-on retrieval only if gaps detected
+   - If source docs are large, generate interim summary items instead of embedding raw text
+
+5. **Generate checklist** - Create "Unit Tests for Requirements":
+   - Create `FEATURE_DIR/checklists/` directory if it doesn't exist
+   - Generate unique checklist filename:
+     - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
+     - Format: `[domain].md`
+   - File handling behavior:
+     - If file does NOT exist: Create new file and number items starting from CHK001
+     - If file exists: Append new items to existing file, continuing from the last CHK ID (e.g., if last item is CHK015, start new items at CHK016)
+   - Never delete or replace existing checklist content - always preserve and append
+
+   **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
+   Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
+   - **Completeness**: Are all necessary requirements present?
+   - **Clarity**: Are requirements unambiguous and specific?
+   - **Consistency**: Do requirements align with each other?
+   - **Measurability**: Can requirements be objectively verified?
+   - **Coverage**: Are all scenarios/edge cases addressed?
+
+   **Category Structure** - Group items by requirement quality dimensions:
+   - **Requirement Completeness** (Are all necessary requirements documented?)
+   - **Requirement Clarity** (Are requirements specific and unambiguous?)
+   - **Requirement Consistency** (Do requirements align without conflicts?)
+   - **Acceptance Criteria Quality** (Are success criteria measurable?)
+   - **Scenario Coverage** (Are all flows/cases addressed?)
+   - **Edge Case Coverage** (Are boundary conditions defined?)
+   - **Non-Functional Requirements** (Performance, Security, Accessibility, etc. - are they specified?)
+   - **Dependencies & Assumptions** (Are they documented and validated?)
+   - **Ambiguities & Conflicts** (What needs clarification?)
+
+   **HOW TO WRITE CHECKLIST ITEMS - "Unit Tests for English"**:
+
+   ❌ **WRONG** (Testing implementation):
+   - "Verify landing page displays 3 episode cards"
+   - "Test hover states work on desktop"
+   - "Confirm logo click navigates home"
+
+   ✅ **CORRECT** (Testing requirements quality):
+   - "Are the exact number and layout of featured episodes specified?" [Completeness]
+   - "Is 'prominent display' quantified with specific sizing/positioning?" [Clarity]
+   - "Are hover state requirements consistent across all interactive elements?" [Consistency]
+   - "Are keyboard navigation requirements defined for all interactive UI?" [Coverage]
+   - "Is the fallback behavior specified when logo image fails to load?" [Edge Cases]
+   - "Are loading states defined for asynchronous episode data?" [Completeness]
+   - "Does the spec define visual hierarchy for competing UI elements?" [Clarity]
+
+   **ITEM STRUCTURE**:
+   Each item should follow this pattern:
+   - Question format asking about requirement quality
+   - Focus on what's WRITTEN (or not written) in the spec/plan
+   - Include quality dimension in brackets [Completeness/Clarity/Consistency/etc.]
+   - Reference spec section `[Spec §X.Y]` when checking existing requirements
+   - Use `[Gap]` marker when checking for missing requirements
+
+   **EXAMPLES BY QUALITY DIMENSION**:
+
+   Completeness:
+   - "Are error handling requirements defined for all API failure modes? [Gap]"
+   - "Are accessibility requirements specified for all interactive elements? [Completeness]"
+   - "Are mobile breakpoint requirements defined for responsive layouts? [Gap]"
+
+   Clarity:
+   - "Is 'fast loading' quantified with specific timing thresholds? [Clarity, Spec §NFR-2]"
+   - "Are 'related episodes' selection criteria explicitly defined? [Clarity, Spec §FR-5]"
+   - "Is 'prominent' defined with measurable visual properties? [Ambiguity, Spec §FR-4]"
+
+   Consistency:
+   - "Do navigation requirements align across all pages? [Consistency, Spec §FR-10]"
+   - "Are card component requirements consistent between landing and detail pages? [Consistency]"
+
+   Coverage:
+   - "Are requirements defined for zero-state scenarios (no episodes)? [Coverage, Edge Case]"
+   - "Are concurrent user interaction scenarios addressed? [Coverage, Gap]"
+   - "Are requirements specified for partial data loading failures? [Coverage, Exception Flow]"
+
+   Measurability:
+   - "Are visual hierarchy requirements measurable/testable? [Acceptance Criteria, Spec §FR-1]"
+   - "Can 'balanced visual weight' be objectively verified? [Measurability, Spec §FR-2]"
+
+   **Scenario Classification & Coverage** (Requirements Quality Focus):
+   - Check if requirements exist for: Primary, Alternate, Exception/Error, Recovery, Non-Functional scenarios
+   - For each scenario class, ask: "Are [scenario type] requirements complete, clear, and consistent?"
+   - If scenario class missing: "Are [scenario type] requirements intentionally excluded or missing? [Gap]"
+   - Include resilience/rollback when state mutation occurs: "Are rollback requirements defined for migration failures? [Gap]"
+
+   **Traceability Requirements**:
+   - MINIMUM: ≥80% of items MUST include at least one traceability reference
+   - Each item should reference: spec section `[Spec §X.Y]`, or use markers: `[Gap]`, `[Ambiguity]`, `[Conflict]`, `[Assumption]`
+   - If no ID system exists: "Is a requirement & acceptance criteria ID scheme established? [Traceability]"
+
+   **Surface & Resolve Issues** (Requirements Quality Problems):
+   Ask questions about the requirements themselves:
+   - Ambiguities: "Is the term 'fast' quantified with specific metrics? [Ambiguity, Spec §NFR-1]"
+   - Conflicts: "Do navigation requirements conflict between §FR-10 and §FR-10a? [Conflict]"
+   - Assumptions: "Is the assumption of 'always available podcast API' validated? [Assumption]"
+   - Dependencies: "Are external podcast API requirements documented? [Dependency, Gap]"
+   - Missing definitions: "Is 'visual hierarchy' defined with measurable criteria? [Gap]"
+
+   **Content Consolidation**:
+   - Soft cap: If raw candidate items > 40, prioritize by risk/impact
+   - Merge near-duplicates checking the same requirement aspect
+   - If >5 low-impact edge cases, create one item: "Are edge cases X, Y, Z addressed in requirements? [Coverage]"
+
+   **🚫 ABSOLUTELY PROHIBITED** - These make it an implementation test, not a requirements test:
+   - ❌ Any item starting with "Verify", "Test", "Confirm", "Check" + implementation behavior
+   - ❌ References to code execution, user actions, system behavior
+   - ❌ "Displays correctly", "works properly", "functions as expected"
+   - ❌ "Click", "navigate", "render", "load", "execute"
+   - ❌ Test cases, test plans, QA procedures
+   - ❌ Implementation details (frameworks, APIs, algorithms)
+
+   **✅ REQUIRED PATTERNS** - These test requirements quality:
+   - ✅ "Are [requirement type] defined/specified/documented for [scenario]?"
+   - ✅ "Is [vague term] quantified/clarified with specific criteria?"
+   - ✅ "Are requirements consistent between [section A] and [section B]?"
+   - ✅ "Can [requirement] be objectively measured/verified?"
+   - ✅ "Are [edge cases/scenarios] addressed in requirements?"
+   - ✅ "Does the spec define [missing aspect]?"
+
+6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+
+7. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
+   - Focus areas selected
+   - Depth level
+   - Actor/timing
+   - Any explicit user-specified must-have items incorporated
+
+**Important**: Each `/speckit-checklist` command invocation uses a short, descriptive checklist filename and either creates a new file or appends to an existing one. This allows:
+
+- Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
+- Simple, memorable filenames that indicate checklist purpose
+- Easy identification and navigation in the `checklists/` folder
+
+To avoid clutter, use descriptive types and clean up obsolete checklists when done.
+
+## Example Checklist Types & Sample Items
+
+**UX Requirements Quality:** `ux.md`
+
+Sample items (testing the requirements, NOT the implementation):
+
+- "Are visual hierarchy requirements defined with measurable criteria? [Clarity, Spec §FR-1]"
+- "Is the number and positioning of UI elements explicitly specified? [Completeness, Spec §FR-1]"
+- "Are interaction state requirements (hover, focus, active) consistently defined? [Consistency]"
+- "Are accessibility requirements specified for all interactive elements? [Coverage, Gap]"
+- "Is fallback behavior defined when images fail to load? [Edge Case, Gap]"
+- "Can 'prominent display' be objectively measured? [Measurability, Spec §FR-4]"
+
+**API Requirements Quality:** `api.md`
+
+Sample items:
+
+- "Are error response formats specified for all failure scenarios? [Completeness]"
+- "Are rate limiting requirements quantified with specific thresholds? [Clarity]"
+- "Are authentication requirements consistent across all endpoints? [Consistency]"
+- "Are retry/timeout requirements defined for external dependencies? [Coverage, Gap]"
+- "Is versioning strategy documented in requirements? [Gap]"
+
+**Performance Requirements Quality:** `performance.md`
+
+Sample items:
+
+- "Are performance requirements quantified with specific metrics? [Clarity]"
+- "Are performance targets defined for all critical user journeys? [Coverage]"
+- "Are performance requirements under different load conditions specified? [Completeness]"
+- "Can performance requirements be objectively measured? [Measurability]"
+- "Are degradation requirements defined for high-load scenarios? [Edge Case, Gap]"
+
+**Security Requirements Quality:** `security.md`
+
+Sample items:
+
+- "Are authentication requirements specified for all protected resources? [Coverage]"
+- "Are data protection requirements defined for sensitive information? [Completeness]"
+- "Is the threat model documented and requirements aligned to it? [Traceability]"
+- "Are security requirements consistent with compliance obligations? [Consistency]"
+- "Are security failure/breach response requirements defined? [Gap, Exception Flow]"
+
+## Anti-Examples: What NOT To Do
+
+**❌ WRONG - These test implementation, not requirements:**
+
+```markdown
+- [ ] CHK001 - Verify landing page displays 3 episode cards [Spec §FR-001]
+- [ ] CHK002 - Test hover states work correctly on desktop [Spec §FR-003]
+- [ ] CHK003 - Confirm logo click navigates to home page [Spec §FR-010]
+- [ ] CHK004 - Check that related episodes section shows 3-5 items [Spec §FR-005]
+```
+
+**✅ CORRECT - These test requirements quality:**
+
+```markdown
+- [ ] CHK001 - Are the number and layout of featured episodes explicitly specified? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Are hover state requirements consistently defined for all interactive elements? [Consistency, Spec §FR-003]
+- [ ] CHK003 - Are navigation requirements clear for all clickable brand elements? [Clarity, Spec §FR-010]
+- [ ] CHK004 - Is the selection criteria for related episodes documented? [Gap, Spec §FR-005]
+- [ ] CHK005 - Are loading state requirements defined for asynchronous episode data? [Gap]
+- [ ] CHK006 - Can "visual hierarchy" requirements be objectively measured? [Measurability, Spec §FR-001]
+```
+
+**Key Differences:**
+
+- Wrong: Tests if the system works correctly
+- Correct: Tests if the requirements are written correctly
+- Wrong: Verification of behavior
+- Correct: Validation of requirement quality
+- Wrong: "Does it do X?"
+- Correct: "Is X clearly specified?"
+
+## Post-Execution Checks
+
+**Check for extension hooks (after checklist generation)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-clarify/SKILL.md
+++ b/.agents/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: "speckit-clarify"
+description: "Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec."
+metadata:
+  argument-hint: "Optional areas to clarify in the spec"
+  compatibility: "Requires spec-kit project structure with .specify/ directory"
+  author: "github-spec-kit"
+  source: "templates/commands/clarify.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before clarification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+## Outline
+
+Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
+
+Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit-plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
+
+Execution steps:
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+   - `FEATURE_DIR`
+   - `FEATURE_SPEC`
+   - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
+   - If JSON parsing fails, abort and instruct user to re-run `/speckit-specify` or verify feature branch environment.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+
+   Functional Scope & Behavior:
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+   Domain & Data Model:
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+   - Data volume / scale assumptions
+
+   Interaction & UX Flow:
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+   Non-Functional Quality Attributes:
+   - Performance (latency, throughput targets)
+   - Scalability (horizontal/vertical, limits)
+   - Reliability & availability (uptime, recovery expectations)
+   - Observability (logging, metrics, tracing signals)
+   - Security & privacy (authN/Z, data protection, threat assumptions)
+   - Compliance / regulatory constraints (if any)
+
+   Integration & External Dependencies:
+   - External services/APIs and failure modes
+   - Data import/export formats
+   - Protocol/versioning assumptions
+
+   Edge Cases & Failure Handling:
+   - Negative scenarios
+   - Rate limiting / throttling
+   - Conflict resolution (e.g., concurrent edits)
+
+   Constraints & Tradeoffs:
+   - Technical constraints (language, storage, hosting)
+   - Explicit tradeoffs or rejected alternatives
+
+   Terminology & Consistency:
+   - Canonical glossary terms
+   - Avoided synonyms / deprecated terms
+
+   Completion Signals:
+   - Acceptance criteria testability
+   - Measurable Definition of Done style indicators
+
+   Misc / Placeholders:
+   - TODO markers / unresolved decisions
+   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
+
+   For each category with Partial or Missing status, add a candidate question opportunity unless:
+   - Clarification would not materially change implementation or validation strategy
+   - Information is better deferred to planning phase (note internally)
+
+3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+    - Maximum of 5 total questions across the whole session.
+    - Each question must be answerable with EITHER:
+       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
+    - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
+    - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
+    - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
+    - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
+    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+
+4. Sequential questioning loop (interactive):
+    - Present EXACTLY ONE question at a time.
+    - For multiple‑choice questions:
+       - **Analyze all options** and determine the **most suitable option** based on:
+          - Best practices for the project type
+          - Common patterns in similar implementations
+          - Risk reduction (security, performance, maintainability)
+          - Alignment with any explicit project goals or constraints visible in the spec
+       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - Format as: `**Recommended:** Option [X] - <reasoning>`
+       - Then render all options as a Markdown table:
+
+       | Option | Description |
+       |--------|-------------|
+       | A | <Option A description> |
+       | B | <Option B description> |
+       | C | <Option C description> (add D/E as needed up to 5) |
+       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
+       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+    - For short‑answer style (no meaningful discrete options):
+       - Provide your **suggested answer** based on best practices and context.
+       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
+       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
+    - After the user answers:
+       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
+       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+    - Stop asking further questions when:
+       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
+       - User signals completion ("done", "good", "no more"), OR
+       - You reach 5 asked questions.
+    - Never reveal future queued questions in advance.
+    - If no valid questions exist at start, immediately report no critical ambiguities.
+
+5. Integration after EACH accepted answer (incremental update approach):
+    - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
+    - For the first integrated answer in this session:
+       - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
+       - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
+    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply the clarification to the most appropriate section(s):
+       - Functional ambiguity → Update or add a bullet in Functional Requirements.
+       - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
+       - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
+       - Non-functional constraint → Add/modify measurable criteria in Success Criteria > Measurable Outcomes (convert vague adjective to metric or explicit target).
+       - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
+       - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
+    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
+    - Keep each inserted clarification minimal and testable (avoid narrative drift).
+
+6. Validation (performed after EACH write plus final pass):
+   - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
+   - Total asked (accepted) questions ≤ 5.
+   - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
+   - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
+   - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
+   - Terminology consistency: same canonical term used across all updated sections.
+
+7. Write the updated spec back to `FEATURE_SPEC`.
+
+8. Report completion (after questioning loop ends or early termination):
+   - Number of questions asked & answered.
+   - Path to updated spec.
+   - Sections touched (list names).
+   - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+   - If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit-plan` or run `/speckit-clarify` again later post-plan.
+   - Suggested next command.
+
+Behavior rules:
+
+- If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
+- If spec file missing, instruct user to run `/speckit-specify` first (do not create a new spec here).
+- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Avoid speculative tech stack questions unless the absence blocks functional clarity.
+- Respect user early termination signals ("stop", "done", "proceed").
+- If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
+- If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+
+Context for prioritization: $ARGUMENTS
+
+## Post-Execution Checks
+
+**Check for extension hooks (after clarification)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-constitution/SKILL.md
+++ b/.agents/skills/speckit-constitution/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: "speckit-constitution"
+description: "Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync."
+metadata:
+  argument-hint: "Principles or values for the project constitution"
+  compatibility: "Requires spec-kit project structure with .specify/ directory"
+  author: "github-spec-kit"
+  source: "templates/commands/constitution.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before constitution update)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+
+Follow this execution flow:
+
+1. Load the existing constitution at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+## Post-Execution Checks
+
+**Check for extension hooks (after constitution update)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-converge/SKILL.md
+++ b/.agents/skills/speckit-converge/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: "speckit-converge"
+description: "Assess the current codebase against the feature's spec, plan, and tasks, then append any remaining unbuilt work as new tasks to tasks.md so implement can complete it."
+metadata:
+  compatibility: "Requires spec-kit project structure with .specify/ directory"
+  author: "github-spec-kit"
+  source: "templates/commands/converge.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before convergence)**:
+
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_converge` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing command invocations from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+
+    ```text
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+  - **Mandatory hook** (`optional: false`):
+
+    ```text
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Goal.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+## Goal
+
+Close the gap between what a feature's specification, plan, and tasks call for and what the
+codebase currently implements. Read `spec.md`, `plan.md`, and `tasks.md` as the **sole
+source of intent** (with the constitution as governing constraints), assess the current
+state of the code, determine which requirements, acceptance criteria, plan decisions, and
+existing tasks are unmet, incomplete, or only partially satisfied, and **append each piece
+of remaining work as a new, traceable task** at the bottom of `tasks.md` so that
+`/speckit-implement` can complete it. This command MUST run only after
+`/speckit-implement` has run on the current `tasks.md`, and after `/speckit-tasks` has produced a complete `tasks.md`.
+
+This is **not** a diff tool and does **not** track changes. It assesses the present state
+of the code relative to the feature's artifacts — no git, no branch comparison, no history.
+
+## Operating Constraints
+
+**APPEND-ONLY, NEVER REWRITE**: The command's **only** write is appending a new
+`## Phase N: Convergence` section to `tasks.md`. It MUST NOT:
+
+- modify `spec.md` or `plan.md` in any way;
+- rewrite, renumber, reorder, or delete any existing task (including tasks from a prior
+  Convergence phase);
+- modify, create, or delete any application code — completing the appended tasks is the
+  job of `/speckit-implement`.
+
+When the codebase already satisfies everything, the command MUST leave `tasks.md`
+**byte-for-byte unchanged** (no empty Convergence header) and report a clean result.
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is
+**non-negotiable**. Code that violates a MUST principle is the highest-severity finding and
+produces a corresponding remediation task. If the constitution is an unfilled template,
+skip constitution checks gracefully rather than failing.
+
+## Execution Steps
+
+### 1. Initialize Convergence Context
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+- CONSTITUTION = `.specify/memory/constitution.md` (if present)
+If `spec.md`, `plan.md`, or `tasks.md` is missing, STOP with a clear, actionable message naming the
+prerequisite command to run (`/speckit-specify` for a missing spec, `/speckit-plan` for a missing plan,
+`/speckit-tasks` for missing tasks). Do not produce partial output.
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Functional Requirements (FR-###)
+- Success Criteria (SC-###) — include only items requiring buildable work; exclude
+  post-launch outcome metrics and business KPIs
+- User Stories and their Acceptance Scenarios
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices and technical decisions
+- Data Model references
+- Phases and named touch-points (files/components the plan says will be created or edited)
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs (to compute the next ID and next phase number)
+- Descriptions, phase grouping, and referenced file paths
+
+**From constitution (if not an unfilled template):**
+
+- Principle names and MUST/SHOULD normative statements
+
+### 3. Build the Intent Inventory
+
+Create an internal model (do not echo raw artifacts):
+
+- **Requirements inventory**: one stable key per FR-### / SC-### / user-story acceptance
+  scenario (e.g. `US1/AC2`), plus the plan decisions and constitution principles that
+  impose buildable obligations.
+- **Code-scope map**: from the file paths named in `plan.md` and `tasks.md`, plus a keyword
+  search for the concepts each requirement describes, derive the set of source files and
+  components in scope for assessment. Bound the assessment to these — do **not** infer
+  scope beyond what the artifacts define.
+
+### 4. Assess the Codebase and Classify Findings
+
+For each item in the intent inventory, inspect the current code in scope and produce a
+`Finding` only where there is a gap. Classify every finding by **gap type**:
+
+- **`missing`**: the required work is absent from the code entirely.
+- **`partial`**: the work exists but does not yet fully satisfy the requirement /
+  acceptance criterion / plan decision.
+- **`contradicts`**: the code does something that conflicts with stated intent or a
+  constitution MUST principle.
+- **`unrequested`**: the code contains work not called for by the spec, plan, or tasks
+  (surfaced for awareness — converge does **not** delete code, it only appends a task to
+  review/justify or remove it).
+
+Each `Finding` records: a stable id, the `source-ref` it traces to, the `gap-type`, a
+severity, and a short human-readable description with the evidence (the file/area observed).
+
+**Edge cases:**
+
+- **Little or no code yet**: treat the entire specified scope as `missing` remaining work
+  rather than failing.
+- **Nothing remains**: produce zero findings and follow the converged branch in Step 7.
+
+### 5. Assign Severity
+
+- **CRITICAL**: violates a constitution MUST principle, or a `missing`/`contradicts` gap
+  that blocks baseline functionality of a P1 user story.
+- **HIGH**: a `missing` or `partial` gap on a core functional requirement or acceptance
+  criterion.
+- **MEDIUM**: a `partial` gap on a secondary requirement, or an `unrequested` addition with
+  unclear justification.
+- **LOW**: minor partial gaps, polish, or low-risk `unrequested` additions.
+
+### 6. Present the In-Session Findings Summary
+
+Before appending anything, output a compact, severity-graded summary (no file writes yet):
+
+## Convergence Findings
+
+| ID | Gap Type | Severity | Source | Evidence | Remaining Work |
+|----|----------|----------|--------|----------|----------------|
+| F1 | missing  | HIGH     | FR-008 | Example: no append-only guard detected in path/to/module.py when writing tasks.md | Add append-only enforcement |
+
+**Summary metrics:**
+
+- Requirements / acceptance criteria checked
+- Plan decisions checked
+- Constitution principles checked (or "skipped — template")
+- Findings by gap type (missing / partial / contradicts / unrequested)
+- Findings by severity
+
+### 7. Append Convergence Tasks (or report converged)
+
+**If there are one or more actionable findings** (`tasks_appended` outcome):
+
+Append to the **end** of `tasks.md`, per the append contract:
+
+1. Scan all existing task IDs; let `M` be the maximum. Determine the next phase number `N`
+   (highest existing phase + 1).
+2. Write a single new section header `## Phase N: Convergence`.
+3. Emit one checklist item per actionable finding, ordered CRITICAL/HIGH first, assigning
+   zero-padded IDs `T{M+1:03d}, T{M+2:03d}, …`:
+
+   ```markdown
+   - [ ] T042 <imperative description> per <source-ref> (<gap-type>)
+   ```
+
+   `<source-ref>` traces the task to its origin: e.g. `FR-003`, `SC-002`,
+   `US1/AC2`, `plan: storage decision`, `Constitution II`.
+
+   `<gap-type>` is one of `missing`, `partial`, `contradicts`, `unrequested`.
+
+   Constitution-violation tasks MUST be emitted first and described as
+   `CRITICAL`.
+4. Never reuse or renumber existing IDs. If a prior Convergence phase exists, add a new,
+   separately-numbered one below it — do not touch the old one.
+
+**If there are no actionable findings** (`converged` outcome):
+
+- Do **not** modify `tasks.md` at all — no empty phase header.
+- Report: **"✅ Converged — the implementation satisfies the spec, plan, and tasks."**
+- Include the summary counts of what was checked.
+
+### 8. Provide Next Actions (Handoff)
+
+- On `tasks_appended`: state how many tasks were appended under which phase, and recommend
+  running `/speckit-implement` to complete them; note that a follow-up converge
+  run will find fewer or no remaining items.
+- On `converged`: recommend proceeding to review / opening a PR. No further implement pass
+  is needed for this feature's specified scope.
+
+### 9. Check for extension hooks
+
+After producing the result, check if `.specify/extensions.yml` exists in the project root.
+
+- If it exists, read it and look for entries under the `hooks.after_converge` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- Report the convergence outcome (`converged` or `tasks_appended`) in-session before listing
+  any hooks, so users can decide whether to run optional follow-up commands.
+- When constructing command invocations from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+
+    ```text
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+  - **Mandatory hook** (`optional: false`):
+
+    ```text
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-git-commit/SKILL.md
+++ b/.agents/skills/speckit-git-commit/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: speckit-git-commit
 description: Auto-commit changes after a Spec Kit command completes
-compatibility: Requires spec-kit project structure with .specify/ directory
 metadata:
+  compatibility: Requires spec-kit project structure with .specify/ directory
   author: github-spec-kit
   source: git:commands/speckit.git.commit.md
 ---

--- a/.agents/skills/speckit-git-feature/SKILL.md
+++ b/.agents/skills/speckit-git-feature/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: speckit-git-feature
 description: Create a feature branch with sequential or timestamp numbering
-compatibility: Requires spec-kit project structure with .specify/ directory
 metadata:
+  compatibility: Requires spec-kit project structure with .specify/ directory
   author: github-spec-kit
   source: git:commands/speckit.git.feature.md
 ---

--- a/.agents/skills/speckit-git-initialize/SKILL.md
+++ b/.agents/skills/speckit-git-initialize/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: speckit-git-initialize
 description: Initialize a Git repository with an initial commit
-compatibility: Requires spec-kit project structure with .specify/ directory
 metadata:
+  compatibility: Requires spec-kit project structure with .specify/ directory
   author: github-spec-kit
   source: git:commands/speckit.git.initialize.md
 ---

--- a/.agents/skills/speckit-git-remote/SKILL.md
+++ b/.agents/skills/speckit-git-remote/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: speckit-git-remote
 description: Detect Git remote URL for GitHub integration
-compatibility: Requires spec-kit project structure with .specify/ directory
 metadata:
+  compatibility: Requires spec-kit project structure with .specify/ directory
   author: github-spec-kit
   source: git:commands/speckit.git.remote.md
 ---

--- a/.agents/skills/speckit-git-validate/SKILL.md
+++ b/.agents/skills/speckit-git-validate/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: speckit-git-validate
 description: Validate current branch follows feature branch naming conventions
-compatibility: Requires spec-kit project structure with .specify/ directory
 metadata:
+  compatibility: Requires spec-kit project structure with .specify/ directory
   author: github-spec-kit
   source: git:commands/speckit.git.validate.md
 ---

--- a/.agents/skills/speckit-implement/SKILL.md
+++ b/.agents/skills/speckit-implement/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: "speckit-implement"
+description: "Execute the implementation plan by processing and executing all tasks defined in tasks.md"
+metadata:
+  argument-hint: "Optional implementation guidance or task filter"
+  compatibility: "Requires spec-kit project structure with .specify/ directory"
+  author: "github-spec-kit"
+  source: "templates/commands/implement.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before implementation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_implement` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read .specify/memory/constitution.md for governance constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+   - Report final status with summary of completed work
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit-tasks` first to regenerate the task list.
+
+10. **Check for extension hooks**: After completion validation, check if `.specify/extensions.yml` exists in the project root.
+    - If it exists, read it and look for entries under the `hooks.after_implement` key
+    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+    - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+    - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+      - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+      - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+    - When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+    - For each executable hook, output the following based on its `optional` flag:
+      - **Optional hook** (`optional: true`):
+        ```
+        ## Extension Hooks
+
+        **Optional Hook**: {extension}
+        Command: `/{command}`
+        Description: {description}
+
+        Prompt: {prompt}
+        To execute: `/{command}`
+        ```
+      - **Mandatory hook** (`optional: false`):
+        ```
+        ## Extension Hooks
+
+        **Automatic Hook**: {extension}
+        Executing: `/{command}`
+        EXECUTE_COMMAND: {command}
+        ```
+    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-plan/SKILL.md
+++ b/.agents/skills/speckit-plan/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: "speckit-plan"
+description: "Execute the implementation planning workflow using the plan template to generate design artifacts."
+metadata:
+  argument-hint: "Optional guidance for the planning phase"
+  compatibility: "Requires spec-kit project structure with .specify/ directory"
+  author: "github-spec-kit"
+  source: "templates/commands/plan.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before planning)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_plan` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+5. **Check for extension hooks**: After reporting, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_plan` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Define interface contracts** (if project has external interfaces) → `/contracts/`:
+   - Identify what interfaces the project exposes to users or other systems
+   - Document the contract format appropriate for the project type
+   - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
+   - Skip if project is purely internal (build scripts, one-off tools, etc.)
+
+3. **Agent context update**:
+   - Update the plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `CLAUDE.md` to point to the plan file created in step 1 (the IMPL_PLAN path)
+
+**Output**: data-model.md, /contracts/*, quickstart.md, updated agent context file
+
+## Key rules
+
+- Use absolute paths for filesystem operations; use project-relative paths for references in documentation and agent context files
+- ERROR on gate failures or unresolved clarifications

--- a/.agents/skills/speckit-specify/SKILL.md
+++ b/.agents/skills/speckit-specify/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: "speckit-specify"
+description: "Create or update the feature specification from a natural language feature description."
+metadata:
+  argument-hint: "Describe the feature you want to specify"
+  compatibility: "Requires spec-kit project structure with .specify/ directory"
+  author: "github-spec-kit"
+  source: "templates/commands/specify.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before specification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_specify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+The text the user typed after `/speckit-specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the feature:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Branch creation** (optional, via hook):
+
+   If a `before_specify` hook ran successfully in the Pre-Execution Checks above, it will have created/switched to a git branch and output JSON containing `BRANCH_NAME` and `FEATURE_NUM`. Note these values for reference, but the branch name does **not** dictate the spec directory name.
+
+   If the user explicitly provided `GIT_BRANCH_NAME`, pass it through to the hook so the branch script uses the exact value as the branch name (bypassing all prefix/suffix generation).
+
+3. **Create the spec feature directory**:
+
+   Specs live under the default `specs/` directory unless the user explicitly provides `SPECIFY_FEATURE_DIRECTORY`.
+
+   **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
+   1. If the user explicitly provided `SPECIFY_FEATURE_DIRECTORY` (e.g., via environment variable, argument, or configuration), use it as-is
+   2. Otherwise, auto-generate it under `specs/`:
+      - Check `.specify/init-options.json` for `branch_numbering`
+      - If `"timestamp"`: prefix is `YYYYMMDD-HHMMSS` (current timestamp)
+      - If `"sequential"` or absent: prefix is `NNN` (next available 3-digit number after scanning existing directories in `specs/`)
+      - Construct the directory name: `<prefix>-<short-name>` (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+      - Set `SPECIFY_FEATURE_DIRECTORY` to `specs/<directory-name>`
+
+   **Create the directory and spec file**:
+   - `mkdir -p SPECIFY_FEATURE_DIRECTORY`
+   - Copy `.specify/templates/spec-template.md` to `SPECIFY_FEATURE_DIRECTORY/spec.md` as the starting point
+   - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
+   - Persist the resolved path to `.specify/feature.json`:
+     ```json
+     {
+       "feature_directory": "<resolved feature dir>"
+     }
+     ```
+     Write the actual resolved directory path value (for example, `specs/003-user-auth`), not the literal string `SPECIFY_FEATURE_DIRECTORY`.
+     This allows downstream commands (`/speckit-plan`, `/speckit-tasks`, etc.) to locate the feature directory without relying on git branch name conventions.
+
+   **IMPORTANT**:
+   - You must only create one feature per `/speckit-specify` invocation
+   - The spec directory name and the git branch name are independent — they may be the same but that is the user's choice
+   - The spec directory and file are always created by this command, never by the hook
+
+4. Load `.specify/templates/spec-template.md` to understand required sections.
+
+5. Follow this execution flow:
+    1. Parse user description from arguments
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+6. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `SPECIFY_FEATURE_DIRECTORY/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+      
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+      
+      ## Content Quality
+      
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+      
+      ## Requirement Completeness
+      
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+      
+      ## Feature Readiness
+      
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+      
+      ## Notes
+      
+      - Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to step 8
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+           
+           **Context**: [Quote relevant spec section]
+           
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+           
+           **Suggested Answers**:
+           
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+           
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. **CRITICAL - Table Formatting**: Ensure markdown tables are properly formatted:
+           - Use consistent spacing with pipes aligned
+           - Each cell should have spaces around content: `| Content |` not `|Content|`
+           - Header separator must have at least 3 dashes: `|--------|`
+           - Test that the table renders correctly in markdown preview
+        5. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        6. Present all questions together before waiting for responses
+        7. Wait for user to respond with their choices for all questions (e.g., "Q1: A, Q2: Custom - [details], Q3: B")
+        8. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        9. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+8. **Report completion** to the user with:
+   - `SPECIFY_FEATURE_DIRECTORY` — the feature directory path
+   - `SPEC_FILE` — the spec file path
+   - Checklist results summary
+   - Readiness for the next phase (`/speckit-clarify` or `/speckit-plan`)
+
+9. **Check for extension hooks**: After reporting completion, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_specify` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+**NOTE:** Branch creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command.
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: Use project-appropriate patterns (REST/GraphQL for web services, function calls for libraries, CLI args for tools, etc.)
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)

--- a/.agents/skills/speckit-tasks/SKILL.md
+++ b/.agents/skills/speckit-tasks/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: "speckit-tasks"
+description: "Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts."
+metadata:
+  argument-hint: "Optional task generation constraints"
+  compatibility: "Requires spec-kit project structure with .specify/ directory"
+  author: "github-spec-kit"
+  source: "templates/commands/tasks.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_tasks` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/setup-tasks.sh --json` from repo root and parse FEATURE_DIR, TASKS_TEMPLATE, and AVAILABLE_DOCS list. `FEATURE_DIR` and `TASKS_TEMPLATE` must be absolute paths when provided. `AVAILABLE_DOCS` is a list of document names/relative paths available under `FEATURE_DIR` (for example `research.md` or `contracts/`). For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (interface contracts), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map interface contracts to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Read the tasks template from TASKS_TEMPLATE (from the JSON output above) and use it as structure. If TASKS_TEMPLATE is empty, fall back to `.specify/templates/tasks-template.md`. Fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+5. **Report**: Output path to generated tasks.md and summary:
+   - Total task count
+   - Task count per user story
+   - Parallel opportunities identified
+   - Independent test criteria for each story
+   - Suggested MVP scope (typically just User Story 1)
+   - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+6. **Check for extension hooks**: After tasks.md is generated, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_tasks` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label  
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Interfaces/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each interface contract → to the user story it serves
+   - If tests requested: Each interface contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns

--- a/.agents/skills/speckit-taskstoissues/SKILL.md
+++ b/.agents/skills/speckit-taskstoissues/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: "speckit-taskstoissues"
+description: "Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts."
+metadata:
+  argument-hint: "Optional filter or label for GitHub issues"
+  compatibility: "Requires spec-kit project structure with .specify/ directory"
+  author: "github-spec-kit"
+  source: "templates/commands/taskstoissues.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks-to-issues conversion)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. From the executed script, extract the path to **tasks**.
+1. Get the Git remote by running:
+
+```bash
+git config --get remote.origin.url
+```
+
+> [!CAUTION]
+> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+
+1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+
+> [!CAUTION]
+> UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL
+
+## Post-Execution Checks
+
+**Check for extension hooks (after tasks-to-issues conversion)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,14 @@ USERS_FILE ?= $(AUTH_CONFIG_DIR)/users.yaml
 LOCAL_COMPOSE = CONFIG_FILE="$(abspath $(CONFIG_FILE))" COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose --profile local -f compose.yml -f compose.local.yml
 LIFECYCLE_COMPOSE = $(LOCAL_COMPOSE) -f compose.scylla.yml -f compose.scylla.cluster.yml -f compose.admin.yml
 GIT_DATA_DIR ?= $(ROOT)/.gitstore/repos
+CONTROLLER_CHECKPOINT_DIR ?= $(ROOT)/.gitstore/checkpoints
+CONTROLLER_SECRET_DIR ?= $(ROOT)/.gitstore/secrets
+CONTROLLER_SECRET_NAME ?= controller-manager
+CONTROLLER_SECRET_KEY ?= privateKey
+CONTROLLER_SERVICEACCOUNT_NAMESPACE ?= controllers
+CONTROLLER_SERVICEACCOUNT_NAME ?= gitstore-controller-manager
+CONTROLLER_SERVICEACCOUNT_KEY_ID ?= controller-key
+CONTROLLER_SERVICEACCOUNT_UID ?= local-controller
 DIFF_BASE ?= origin/main
 
 COMPOSE_BAKE ?= true
@@ -100,6 +108,8 @@ help: ## Show available targets and common variables.
 	@printf "  SCYLLA_CLUSTER_SMP=%s     CPU shards per Scylla node for PROFILE=cluster\n" "$(SCYLLA_CLUSTER_SMP)"
 	@printf "  SCYLLA_CLUSTER_MAX_NETWORKING_IO_CONTROL_BLOCKS=%s  Networking AIO blocks per cluster node\n" "$(SCYLLA_CLUSTER_MAX_NETWORKING_IO_CONTROL_BLOCKS)"
 	@printf "  GIT_DATA_DIR=%s\n" "$(GIT_DATA_DIR)"
+	@printf "  CONTROLLER_CHECKPOINT_DIR=%s\n" "$(CONTROLLER_CHECKPOINT_DIR)"
+	@printf "  CONTROLLER_SECRET_DIR=%s\n" "$(CONTROLLER_SECRET_DIR)"
 	@printf "  CONFIG_FILE=%s        Shared local-profile configuration\n" "$(CONFIG_FILE)"
 	@printf "  API_URL=%s\n" "$(API_URL)"
 	@printf "  ADMIN_USERNAME=%s\n" "$(ADMIN_USERNAME)"
@@ -126,7 +136,23 @@ git: ## Run gitstore-git-service locally in the foreground.
 	@cd "$(GIT_SERVICE_DIR)" && GITSTORE_GIT__DATA_DIR="$(GIT_DATA_DIR)" cargo run --bin git-service
 
 controller: ## Run gitstore-controller-manager locally in the foreground.
-	@cd "$(CONTROLLER_MANAGER_DIR)" && go run ./cmd/controller
+	@mkdir -p "$(CONTROLLER_CHECKPOINT_DIR)"
+	@test -f "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)" || { \
+		echo "Missing controller signing key at $(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)"; \
+		echo "Generate one with: cd $(API_DIR) && go run ./cmd/gitctl generate-serviceaccount-key --private-key-path $(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)"; \
+		exit 2; \
+	}
+	@cd "$(CONTROLLER_MANAGER_DIR)" && \
+		GITSTORE_CONTROLLER__CHECKPOINT_DIR="$(CONTROLLER_CHECKPOINT_DIR)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__NAMESPACE="$(CONTROLLER_SERVICEACCOUNT_NAMESPACE)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__NAME="$(CONTROLLER_SERVICEACCOUNT_NAME)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_ID="$(CONTROLLER_SERVICEACCOUNT_KEY_ID)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__UID="$(CONTROLLER_SERVICEACCOUNT_UID)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KIND="SecretRef" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__NAME="$(CONTROLLER_SECRET_NAME)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KEY="$(CONTROLLER_SECRET_KEY)" \
+		GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__BASE_PATH="$(CONTROLLER_SECRET_DIR)" \
+		go run ./cmd/controller
 
 api: ## Run gitstore-api locally in the foreground.
 	@cd "$(API_DIR)" && go run ./cmd/server
@@ -134,9 +160,14 @@ api: ## Run gitstore-api locally in the foreground.
 dev: ## Run local git service and API together in the foreground.
 	@set -u; \
 	mkdir -p "$(GIT_DATA_DIR)"; \
+	mkdir -p "$(CONTROLLER_CHECKPOINT_DIR)"; \
 	tmp=$$(mktemp -d); \
 	fifo="$$tmp/done"; \
 	mkfifo "$$fifo"; \
+	if [ ! -f "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)" ]; then \
+		mkdir -p "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)"; \
+		( cd "$(API_DIR)" && go run ./cmd/gitctl generate-serviceaccount-key --private-key-path "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)" ); \
+	fi; \
 	cleanup() { \
 		trap - INT TERM EXIT; \
 		[ -n "$${git_pid:-}" ] && kill "$$git_pid" 2>/dev/null || true; \
@@ -166,6 +197,15 @@ dev: ## Run local git service and API together in the foreground.
 	) & api_pid=$$!; \
 	( set +e; \
 		cd "$(CONTROLLER_MANAGER_DIR)" || { printf 'controller 1\n' > "$$fifo"; exit 0; }; \
+		GITSTORE_CONTROLLER__CHECKPOINT_DIR="$(CONTROLLER_CHECKPOINT_DIR)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__NAMESPACE="$(CONTROLLER_SERVICEACCOUNT_NAMESPACE)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__NAME="$(CONTROLLER_SERVICEACCOUNT_NAME)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_ID="$(CONTROLLER_SERVICEACCOUNT_KEY_ID)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__UID="$(CONTROLLER_SERVICEACCOUNT_UID)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KIND="SecretRef" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__NAME="$(CONTROLLER_SECRET_NAME)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KEY="$(CONTROLLER_SECRET_KEY)" \
+		GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__BASE_PATH="$(CONTROLLER_SECRET_DIR)" \
 		go run ./cmd/controller & child=$$!; \
 		trap 'kill "$$child" 2>/dev/null; wait "$$child" 2>/dev/null; exit 143' INT TERM; \
 		wait "$$child"; status=$$?; \

--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,7 @@ dev: ## Run local git service and API together in the foreground.
 		done; \
 		exec 3<&- 2>/dev/null || true; \
 		exec 3>&- 2>/dev/null || true; \
+		GITSTORE_AUTH__AUTHN__CHAIN="static-users,serviceaccount-assertion,serviceaccount-jwt,anonymous" \
 		GITSTORE_AUTH__SERVICEACCOUNT__SIGNING_KEY="$$(cat "$(API_SERVICEACCOUNT_SIGNING_KEY_PATH)")" \
 		go run ./cmd/server & child=$$!; \
 		trap 'kill "$$child" 2>/dev/null; wait "$$child" 2>/dev/null; exit 143' INT TERM; \

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,28 @@ CONTROLLER_CHECKPOINT_DIR ?= $(ROOT)/.gitstore/checkpoints
 CONTROLLER_SECRET_DIR ?= $(ROOT)/.gitstore/secrets
 CONTROLLER_SECRET_NAME ?= controller-manager
 CONTROLLER_SECRET_KEY ?= privateKey
+# API_SERVICEACCOUNT_SIGNING_KEY_PATH is the API's own ServiceAccount token
+# issuer/verifier key (distinct from the controller-manager's enrollment
+# key above). Required whenever auth.authn.chain includes
+# serviceaccount-jwt/serviceaccount-assertion (see gitstore-api's
+# validateServiceAccountSigningKeySource) — it must be supplied via the
+# GITSTORE_AUTH__SERVICEACCOUNT__SIGNING_KEY env var, never via config.toml.
+API_SERVICEACCOUNT_SIGNING_KEY_PATH ?= $(ROOT)/.gitstore/secrets/api-issuer/privateKey
 CONTROLLER_SERVICEACCOUNT_NAMESPACE ?= controllers
 CONTROLLER_SERVICEACCOUNT_NAME ?= gitstore-controller-manager
 CONTROLLER_SERVICEACCOUNT_KEY_ID ?= controller-key
-CONTROLLER_SERVICEACCOUNT_UID ?= local-controller
+# CONTROLLER_SERVICEACCOUNT_UID is intentionally left unset by default: the
+# real UID is assigned by the API at enrollment time (see the `dev`/`controller`
+# targets' auto-enrollment step) and is not a value operators should hardcode.
+CONTROLLER_SERVICEACCOUNT_UID ?=
+# DEV_ADMIN_USERNAME/DEV_ADMIN_PASSWORD are used only to auto-enroll the
+# controller-manager's ServiceAccount against a locally running API in the
+# `dev`/`controller` targets. They default to the admin fixture already
+# checked into config/users.yaml for local development and must not be used
+# against any non-local environment (use ADMIN_USERNAME/ADMIN_PASSWORD with
+# the bootstrap-* targets for that).
+DEV_ADMIN_USERNAME ?= admin
+DEV_ADMIN_PASSWORD ?= admin123
 DIFF_BASE ?= origin/main
 
 COMPOSE_BAKE ?= true
@@ -42,6 +60,7 @@ DETACH_FLAG := $(if $(filter 1 true yes,$(DETACH)),-d,)
 SERVICE ?=
 
 API_URL ?= http://localhost:4000/graphql
+API_HEALTH_URL ?= $(patsubst %/graphql,%/health,$(API_URL))
 ADMIN_USERNAME ?= admin
 ADMIN_PASSWORD ?=
 BOOTSTRAP_TOKEN ?=
@@ -136,6 +155,31 @@ git: ## Run gitstore-git-service locally in the foreground.
 	@mkdir -p "$(GIT_DATA_DIR)"
 	@cd "$(GIT_SERVICE_DIR)" && GITSTORE_GIT__DATA_DIR="$(GIT_DATA_DIR)" cargo run --bin git-service
 
+# enroll-controller-serviceaccount registers the controller-manager's signing
+# key with a running API and resolves the real, API-assigned ServiceAccount
+# UID (there is no valid hardcoded default for this value — it is created by
+# the enrollment mutation). Safe to re-run: --replace-existing-key makes it
+# idempotent. Requires the API to already be listening on API_URL's host:port.
+CONTROLLER_SERVICEACCOUNT_IDENTITY_FILE ?= $(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/serviceaccount.env
+
+enroll-controller-serviceaccount:
+	@mkdir -p "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)"
+	@test -f "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)" || { \
+		echo "Missing controller signing key at $(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)"; \
+		echo "Generate one with: cd $(API_DIR) && go run ./cmd/gitctl generate-serviceaccount-key --private-key-path $(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)"; \
+		exit 2; \
+	}
+	@cd "$(API_DIR)" && go run ./cmd/gitctl enroll-serviceaccount \
+		--api-url "$(API_URL)" \
+		--admin-username "$(DEV_ADMIN_USERNAME)" \
+		--admin-password "$(DEV_ADMIN_PASSWORD)" \
+		--namespace "$(CONTROLLER_SERVICEACCOUNT_NAMESPACE)" \
+		--name "$(CONTROLLER_SERVICEACCOUNT_NAME)" \
+		--key-id "$(CONTROLLER_SERVICEACCOUNT_KEY_ID)" \
+		--replace-existing-key \
+		--private-key-path "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)" \
+		--identity-output-path "$(CONTROLLER_SERVICEACCOUNT_IDENTITY_FILE)"
+
 controller: ## Run gitstore-controller-manager locally in the foreground.
 	@mkdir -p "$(CONTROLLER_CHECKPOINT_DIR)"
 	@test -f "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)" || { \
@@ -143,12 +187,22 @@ controller: ## Run gitstore-controller-manager locally in the foreground.
 		echo "Generate one with: cd $(API_DIR) && go run ./cmd/gitctl generate-serviceaccount-key --private-key-path $(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)"; \
 		exit 2; \
 	}
-	@cd "$(CONTROLLER_MANAGER_DIR)" && \
+	@set -u; \
+	resolved_uid="$(CONTROLLER_SERVICEACCOUNT_UID)"; \
+	if [ -z "$$resolved_uid" ]; then \
+		test -f "$(CONTROLLER_SERVICEACCOUNT_IDENTITY_FILE)" || { \
+			echo "No enrolled ServiceAccount UID found. Run: make enroll-controller-serviceaccount"; \
+			exit 2; \
+		}; \
+		resolved_uid=$$(sed -n 's/^GITSTORE_CONTROLLER__SERVICEACCOUNT__UID=//p' "$(CONTROLLER_SERVICEACCOUNT_IDENTITY_FILE)"); \
+		test -n "$$resolved_uid" || { echo "Enrolled ServiceAccount identity file is missing a UID."; exit 2; }; \
+	fi; \
+	cd "$(CONTROLLER_MANAGER_DIR)" && \
 		GITSTORE_CONTROLLER__CHECKPOINT_DIR="$(CONTROLLER_CHECKPOINT_DIR)" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__NAMESPACE="$(CONTROLLER_SERVICEACCOUNT_NAMESPACE)" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__NAME="$(CONTROLLER_SERVICEACCOUNT_NAME)" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_ID="$(CONTROLLER_SERVICEACCOUNT_KEY_ID)" \
-		GITSTORE_CONTROLLER__SERVICEACCOUNT__UID="$(CONTROLLER_SERVICEACCOUNT_UID)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__UID="$$resolved_uid" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KIND="SecretRef" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__NAME="$(CONTROLLER_SECRET_NAME)" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KEY="$(CONTROLLER_SECRET_KEY)" \
@@ -156,7 +210,12 @@ controller: ## Run gitstore-controller-manager locally in the foreground.
 		go run ./cmd/controller
 
 api: ## Run gitstore-api locally in the foreground.
-	@cd "$(API_DIR)" && go run ./cmd/server
+	@mkdir -p "$$(dirname "$(API_SERVICEACCOUNT_SIGNING_KEY_PATH)")"
+	@test -f "$(API_SERVICEACCOUNT_SIGNING_KEY_PATH)" || \
+		( cd "$(API_DIR)" && go run ./cmd/gitctl generate-serviceaccount-key --private-key-path "$(API_SERVICEACCOUNT_SIGNING_KEY_PATH)" )
+	@cd "$(API_DIR)" && \
+		GITSTORE_AUTH__SERVICEACCOUNT__SIGNING_KEY="$$(cat "$(API_SERVICEACCOUNT_SIGNING_KEY_PATH)")" \
+		go run ./cmd/server
 
 dev: ## Run local git service and API together in the foreground.
 	@set -u; \
@@ -168,6 +227,10 @@ dev: ## Run local git service and API together in the foreground.
 	if [ ! -f "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)" ]; then \
 		mkdir -p "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)"; \
 		( cd "$(API_DIR)" && go run ./cmd/gitctl generate-serviceaccount-key --private-key-path "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)" ); \
+	fi; \
+	if [ ! -f "$(API_SERVICEACCOUNT_SIGNING_KEY_PATH)" ]; then \
+		mkdir -p "$$(dirname "$(API_SERVICEACCOUNT_SIGNING_KEY_PATH)")"; \
+		( cd "$(API_DIR)" && go run ./cmd/gitctl generate-serviceaccount-key --private-key-path "$(API_SERVICEACCOUNT_SIGNING_KEY_PATH)" ); \
 	fi; \
 	cleanup() { \
 		trap - INT TERM EXIT; \
@@ -203,18 +266,47 @@ dev: ## Run local git service and API together in the foreground.
 		done; \
 		exec 3<&- 2>/dev/null || true; \
 		exec 3>&- 2>/dev/null || true; \
+		GITSTORE_AUTH__SERVICEACCOUNT__SIGNING_KEY="$$(cat "$(API_SERVICEACCOUNT_SIGNING_KEY_PATH)")" \
 		go run ./cmd/server & child=$$!; \
 		trap 'kill "$$child" 2>/dev/null; wait "$$child" 2>/dev/null; exit 143' INT TERM; \
 		wait "$$child"; status=$$?; \
 		printf 'api %s\n' "$$status" > "$$fifo"; \
 	) & api_pid=$$!; \
+	echo "controller: waiting for API health at $(API_HEALTH_URL)..."; \
+	waited=0; \
+	until curl --silent --fail --output /dev/null "$(API_HEALTH_URL)" 2>/dev/null; do \
+		waited=$$((waited + 1)); \
+		if [ "$$waited" -ge 120 ]; then \
+			echo "controller: timed out waiting for API health at $(API_HEALTH_URL)" >&2; \
+			break; \
+		fi; \
+		sleep 0.5; \
+	done; \
+	resolved_uid="$(CONTROLLER_SERVICEACCOUNT_UID)"; \
+	if [ -z "$$resolved_uid" ]; then \
+		echo "controller: enrolling ServiceAccount with the API..."; \
+		if ( cd "$(API_DIR)" && go run ./cmd/gitctl enroll-serviceaccount \
+			--api-url "$(API_URL)" \
+			--admin-username "$(DEV_ADMIN_USERNAME)" \
+			--admin-password "$(DEV_ADMIN_PASSWORD)" \
+			--namespace "$(CONTROLLER_SERVICEACCOUNT_NAMESPACE)" \
+			--name "$(CONTROLLER_SERVICEACCOUNT_NAME)" \
+			--key-id "$(CONTROLLER_SERVICEACCOUNT_KEY_ID)" \
+			--replace-existing-key \
+			--private-key-path "$(CONTROLLER_SECRET_DIR)/$(CONTROLLER_SECRET_NAME)/$(CONTROLLER_SECRET_KEY)" \
+			--identity-output-path "$(CONTROLLER_SERVICEACCOUNT_IDENTITY_FILE)" ); then \
+			resolved_uid=$$(sed -n 's/^GITSTORE_CONTROLLER__SERVICEACCOUNT__UID=//p' "$(CONTROLLER_SERVICEACCOUNT_IDENTITY_FILE)"); \
+		else \
+			echo "controller: enrollment failed; the controller-manager will not be able to authenticate" >&2; \
+		fi; \
+	fi; \
 	( set +e; \
 		cd "$(CONTROLLER_MANAGER_DIR)" || { printf 'controller 1\n' > "$$fifo"; exit 0; }; \
 		GITSTORE_CONTROLLER__CHECKPOINT_DIR="$(CONTROLLER_CHECKPOINT_DIR)" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__NAMESPACE="$(CONTROLLER_SERVICEACCOUNT_NAMESPACE)" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__NAME="$(CONTROLLER_SERVICEACCOUNT_NAME)" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_ID="$(CONTROLLER_SERVICEACCOUNT_KEY_ID)" \
-		GITSTORE_CONTROLLER__SERVICEACCOUNT__UID="$(CONTROLLER_SERVICEACCOUNT_UID)" \
+		GITSTORE_CONTROLLER__SERVICEACCOUNT__UID="$$resolved_uid" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KIND="SecretRef" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__NAME="$(CONTROLLER_SECRET_NAME)" \
 		GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KEY="$(CONTROLLER_SECRET_KEY)" \

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ USERS_FILE ?= $(AUTH_CONFIG_DIR)/users.yaml
 LOCAL_COMPOSE = CONFIG_FILE="$(abspath $(CONFIG_FILE))" COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose --profile local -f compose.yml -f compose.local.yml
 LIFECYCLE_COMPOSE = $(LOCAL_COMPOSE) -f compose.scylla.yml -f compose.scylla.cluster.yml -f compose.admin.yml
 GIT_DATA_DIR ?= $(ROOT)/.gitstore/repos
+GIT_GRPC_PORT ?= 50051
 CONTROLLER_CHECKPOINT_DIR ?= $(ROOT)/.gitstore/checkpoints
 CONTROLLER_SECRET_DIR ?= $(ROOT)/.gitstore/secrets
 CONTROLLER_SECRET_NAME ?= controller-manager
@@ -190,6 +191,18 @@ dev: ## Run local git service and API together in the foreground.
 	) & git_pid=$$!; \
 	( set +e; \
 		cd "$(API_DIR)" || { printf 'api 1\n' > "$$fifo"; exit 0; }; \
+		echo "api: waiting for git-service grpc on 127.0.0.1:$(GIT_GRPC_PORT)..."; \
+		waited=0; \
+		until (exec 3<>/dev/tcp/127.0.0.1/$(GIT_GRPC_PORT)) 2>/dev/null; do \
+			waited=$$((waited + 1)); \
+			if [ "$$waited" -ge 120 ]; then \
+				echo "api: timed out waiting for git-service grpc on 127.0.0.1:$(GIT_GRPC_PORT)" >&2; \
+				break; \
+			fi; \
+			sleep 0.5; \
+		done; \
+		exec 3<&- 2>/dev/null || true; \
+		exec 3>&- 2>/dev/null || true; \
 		go run ./cmd/server & child=$$!; \
 		trap 'kill "$$child" 2>/dev/null; wait "$$child" 2>/dev/null; exit 143' INT TERM; \
 		wait "$$child"; status=$$?; \

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -1,9 +1,9 @@
 services:
   git-service:
     profiles: [local]
-    command: ["/app/git-service", "--config-file", "/config/gitstore.toml"]
+    command: ["/app/git-service", "--config-file", "/etc/gitstore/gitstore.toml"]
     volumes:
-      - ${CONFIG_FILE:-./config/config.toml}:/config/gitstore.toml:ro
+      - ${CONFIG_FILE:-./config/config.toml}:/etc/gitstore/gitstore.toml:ro
 
   api:
     profiles: [local]
@@ -16,11 +16,11 @@ services:
         if [ -f /run/secrets/serviceaccount-signing-key ]; then
           export GITSTORE_AUTH__SERVICEACCOUNT__SIGNING_KEY="$$(cat /run/secrets/serviceaccount-signing-key)"
         fi
-        exec /app/api --config-file /config/gitstore.toml
+        exec /app/api --config-file /etc/gitstore/gitstore.toml
     volumes:
-      - ${CONFIG_FILE:-./config/config.toml}:/config/gitstore.toml:ro
-      - ./config/policy.yaml:/config/policy.yaml:ro
-      - ./config/users.yaml:/config/users.yaml:ro
+      - ${CONFIG_FILE:-./config/config.toml}:/etc/gitstore/gitstore.toml:ro
+      - ./config/policy.yaml:/etc/gitstore/policy.yaml:ro
+      - ./config/users.yaml:/etc/gitstore/users.yaml:ro
       - api-serviceaccount-issuer-key:/run/secrets:ro
     depends_on:
       credential-bootstrap:
@@ -35,10 +35,10 @@ services:
         serviceaccount_uid="$$(sed -n 's/^GITSTORE_CONTROLLER__SERVICEACCOUNT__UID=//p' /run/controller-bootstrap/serviceaccount.env)"
         test -n "$$serviceaccount_uid"
         export GITSTORE_CONTROLLER__SERVICEACCOUNT__UID="$$serviceaccount_uid"
-        exec /app/controller-manager --config-file /config/gitstore.toml
+        exec /app/controller-manager --config-file /etc/gitstore/gitstore.toml
     volumes:
-      - ${CONFIG_FILE:-./config/config.toml}:/config/gitstore.toml:ro
-      - controller-checkpoints:/data/checkpoints
+      - ${CONFIG_FILE:-./config/config.toml}:/etc/gitstore/gitstore.toml:ro
+      - controller-checkpoints:/var/lib/gitstore/checkpoints
       - controller-serviceaccount-secrets:/run/secrets:ro
       - controller-serviceaccount-identity:/run/controller-bootstrap:ro
     depends_on:

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "${GITSTORE_HOST_GIT_GRPC_PORT:-50051}:50051"  # gRPC
     volumes:
-      - git-repo-data-root:/data/repos
+      - git-repo-data-root:/var/lib/gitstore/repos
     networks:
       - gitstore-network
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -8,7 +8,7 @@
 port = 50051
 
 [git]
-data_dir = "/data/repos"
+data_dir = "/var/lib/gitstore/repos"
 
 [git.repo]
 max_file_size = 52428800
@@ -47,7 +47,7 @@ uri = "dns:///git-service:50051"
 backend = "memdb"
 
 [auth.staticusers]
-users_file = "/config/users.yaml"
+users_file = "/etc/gitstore/users.yaml"
 
 [auth.jwt]
 secret = "local-development-jwt-secret-at-least-32-characters"
@@ -74,7 +74,7 @@ provider = "rbac-local"
 provider = "static-users"
 
 [auth.rbac]
-policy_file = "/config/policy.yaml"
+policy_file = "/etc/gitstore/policy.yaml"
 
 [controller]
 port = 5001
@@ -89,7 +89,7 @@ serviceaccount_access_token_audience = "gitstore-api"
 secret_provider_bootstrap = { type = "file", base_path = "/run/secrets" }
 default_max_attempts = 5
 default_stall_threshold = "5m"
-checkpoint_dir = "/data/checkpoints"
+checkpoint_dir = "/var/lib/gitstore/checkpoints"
 checkpoint_flush_interval_events = 100
 max_watch_backoff = "30s"
 

--- a/docker/git-service.Dockerfile
+++ b/docker/git-service.Dockerfile
@@ -76,7 +76,7 @@ FROM alpine:3
 RUN apk add --no-cache \
     ca-certificates \
     libgcc && \
-    mkdir -p /data/repos
+    mkdir -p /var/lib/gitstore/repos
 
 WORKDIR /app
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,12 +22,23 @@ explicit path is required to exist and be readable. Without the flag, the Go
 services retain optional `config.toml` discovery and the Git service retains
 optional `gitstore.toml` discovery in the working directory.
 
+For production-friendly local templates, copy the per-service example files in
+this repo:
+
+- `../gitstore-git-service/config.toml.example`
+- `../gitstore-api/config.toml.example`
+- `../gitstore-controller-manager/config.toml.example`
+
+These are intended to be copied to `/etc/gitstore/...` or another deployment
+managed config directory and tuned per environment.
+
 ## Shared Local Compose Configuration
 
 `make compose` activates the Compose `local` profile and mounts
-`config/config.toml` read-only into all three core containers. The API also
-receives the development RBAC policy at `config/policy.yaml`. Select another
-host-side file explicitly with:
+`config/config.toml` read-only into all three core containers at
+`/etc/gitstore/gitstore.toml`. The API also receives the development RBAC
+policy at `/etc/gitstore/policy.yaml`. Select another host-side file explicitly
+with:
 
 ```bash
 make compose CONFIG_FILE=./config/config.stage.toml
@@ -277,15 +288,15 @@ Secrets in the users file and `auth.jwt.secret` must remain outside committed op
 
 ### Core
 
-| Key                            | Env Var                                   | Type   | Default                 | Required | Sensitive | Description                                       |
-|--------------------------------|-------------------------------------------|--------|-------------------------|----------|-----------|---------------------------------------------------|
-| `grpc.port`                    | `GITSTORE_GRPC__PORT`                     | u16    | `50051`                 | No       | No        | GitService gRPC server port                       |
-| `git.data_dir`                 | `GITSTORE_GIT__DATA_DIR`                  | string | `/data/repos`           | No       | No        | Bare repository storage directory                 |
-| `git.repo.max_file_size`       | `GITSTORE_GIT__REPO__MAX_FILE_SIZE`       | u64    | `52428800`              | No       | No        | Max file size in bytes                            |
-| `git.repo.max_pack_size_bytes` | `GITSTORE_GIT__REPO__MAX_PACK_SIZE_BYTES` | u64    | `52428800`              | No       | No        | Max pack size in bytes                            |
-| `catalog_service.uri`          | `GITSTORE_CATALOG_SERVICE__URI`           | string | `http://localhost:6000` | No       | No        | gitstore-api CatalogService gRPC endpoint         |
-| `log.level`                    | `GITSTORE_LOG__LEVEL`                     | string | `info`                  | No       | No        | `trace` \| `debug` \| `info` \| `warn` \| `error` |
-| `log.format`                   | `GITSTORE_LOG__FORMAT`                    | string | `json`                  | No       | No        | `json` \| `text`                                  |
+| Key                            | Env Var                                   | Type   | Default                   | Required | Sensitive | Description                                       |
+|--------------------------------|-------------------------------------------|--------|---------------------------|----------|-----------|---------------------------------------------------|
+| `grpc.port`                    | `GITSTORE_GRPC__PORT`                     | u16    | `50051`                   | No       | No        | GitService gRPC server port                       |
+| `git.data_dir`                 | `GITSTORE_GIT__DATA_DIR`                  | string | `/var/lib/gitstore/repos` | No       | No        | Bare repository storage directory                 |
+| `git.repo.max_file_size`       | `GITSTORE_GIT__REPO__MAX_FILE_SIZE`       | u64    | `52428800`                | No       | No        | Max file size in bytes                            |
+| `git.repo.max_pack_size_bytes` | `GITSTORE_GIT__REPO__MAX_PACK_SIZE_BYTES` | u64    | `52428800`                | No       | No        | Max pack size in bytes                            |
+| `catalog_service.uri`          | `GITSTORE_CATALOG_SERVICE__URI`           | string | `http://localhost:6000`   | No       | No        | gitstore-api CatalogService gRPC endpoint         |
+| `log.level`                    | `GITSTORE_LOG__LEVEL`                     | string | `info`                    | No       | No        | `trace` \| `debug` \| `info` \| `warn` \| `error` |
+| `log.format`                   | `GITSTORE_LOG__FORMAT`                    | string | `json`                    | No       | No        | `json` \| `text`                                  |
 
 ### Hook Phase Toggles
 
@@ -323,7 +334,7 @@ Nested hook keys may be set in `gitstore.toml`. Environment variable overrides u
 port = 50051
 
 [git]
-data_dir = "/data/repos"
+data_dir = "/var/lib/gitstore/repos"
 
 [git.repo]
 max_file_size = 52428800
@@ -364,29 +375,29 @@ uri = "http://localhost:6000"
 **`.env` file**: `.env` (optional, current working directory)
 **Env var prefix**: `GITSTORE_`
 
-| Key                                  | Env Var                                        | Type     | Default                         | Required | Sensitive | Description                                                 |
-|--------------------------------------|------------------------------------------------|----------|---------------------------------|----------|-----------|-------------------------------------------------------------|
-| `controller.port`                    | `GITSTORE_CONTROLLER__PORT`                    | integer  | `5001`                          | No       | No        | HTTP port for `/health`, `/metrics`, and `/controller/v1/*` |
-| `controller.api_uri`                 | `GITSTORE_CONTROLLER__API_URI`                 | string   | `http://localhost:4000/graphql` | No       | No        | GraphQL API URI used by reconcilers                         |
-| `controller.serviceaccount_namespace` | `GITSTORE_CONTROLLER__SERVICEACCOUNT__NAMESPACE` | string | (empty) | **Yes** | No | Enrolled ServiceAccount namespace |
-| `controller.serviceaccount_name` | `GITSTORE_CONTROLLER__SERVICEACCOUNT__NAME` | string | `gitstore-controller-manager` | **Yes** | No | Enrolled ServiceAccount name |
-| `controller.serviceaccount_key_id` | `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_ID` | string | (empty) | **Yes** | No | Enrolled public-key ID (`kid`) for controller assertions |
-| `controller.serviceaccount_uid` | `GITSTORE_CONTROLLER__SERVICEACCOUNT__UID` | string | (empty) | **Yes** | No | Enrolled ServiceAccount UID; prevents identity reuse after deletion |
-| `controller.serviceaccount_key_ref.kind` | `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KIND` | string | (empty) | **Yes** | No | Must be `SecretRef` |
-| `controller.serviceaccount_key_ref.name` | `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__NAME` | string | (empty) | **Yes** | No | Logical bootstrap-secret name, not a filesystem path |
-| `controller.serviceaccount_key_ref.key` | `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KEY` | string | (empty) | **Yes** | No | Logical key name in the bootstrap secret |
-| `controller.serviceaccount_assertion_audience` | `GITSTORE_CONTROLLER__SERVICEACCOUNT__ASSERTION_AUDIENCE` | string | `gitstore-api/serviceaccount-token` | **Yes** | No | Audience for the signed assertion used to exchange a token |
-| `controller.serviceaccount_access_token_audience` | `GITSTORE_CONTROLLER__SERVICEACCOUNT__ACCESS_TOKEN_AUDIENCE` | string | `gitstore-api` | **Yes** | No | Audience requested for the exchanged access token |
-| `controller.secret_provider_bootstrap.type` | `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__TYPE` | string | `file` | No | No | Bootstrap resolver type: `file` or `env` |
-| `controller.secret_provider_bootstrap.base_path` | `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__BASE_PATH` | string | `/run/secrets` | With `type=file` | No | Directory containing controller-only mounted bootstrap secrets |
-| `controller.secret_provider_bootstrap.env_prefix` | `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__ENV_PREFIX` | string | `GITSTORE_SECRET__` | With `type=env` | No | Prefix used to resolve bootstrap-secret environment variables |
-| `controller.default_max_attempts`    | `GITSTORE_CONTROLLER__DEFAULT_MAX_ATTEMPTS`    | integer  | `5`                             | No       | No        | Retry limit before quarantine                               |
-| `controller.default_stall_threshold` | `GITSTORE_CONTROLLER__DEFAULT_STALL_THRESHOLD` | duration | `5m`                            | No       | No        | Worker stall threshold                                      |
-| `controller.checkpoint_dir`          | `GITSTORE_CONTROLLER__CHECKPOINT_DIR`          | string   | `.gitstore/checkpoints`         | No       | No        | Directory for the filesystem checkpoint store (one file per kind) |
-| `controller.checkpoint_flush_interval_events` | `GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS` | integer | `100` | No | No | Watch events between checkpoint persists |
-| `controller.max_watch_backoff`       | `GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF`       | duration | `30s`                           | No       | No        | Cap on exponential backoff between watch-stream reconnect attempts |
-| `log.level`                          | `GITSTORE_LOG__LEVEL`                          | string   | `info`                          | No       | No        | `debug` \| `info` \| `warn` \| `error`                      |
-| `log.format`                         | `GITSTORE_LOG__FORMAT`                         | string   | `json`                          | No       | No        | `json` \| `text`                                            |
+| Key                                               | Env Var                                                      | Type     | Default                             | Required         | Sensitive | Description                                                         |
+|---------------------------------------------------|--------------------------------------------------------------|----------|-------------------------------------|------------------|-----------|---------------------------------------------------------------------|
+| `controller.port`                                 | `GITSTORE_CONTROLLER__PORT`                                  | integer  | `5001`                              | No               | No        | HTTP port for `/health`, `/metrics`, and `/controller/v1/*`         |
+| `controller.api_uri`                              | `GITSTORE_CONTROLLER__API_URI`                               | string   | `http://localhost:4000/graphql`     | No               | No        | GraphQL API URI used by reconcilers                                 |
+| `controller.serviceaccount_namespace`             | `GITSTORE_CONTROLLER__SERVICEACCOUNT__NAMESPACE`             | string   | (empty)                             | **Yes**          | No        | Enrolled ServiceAccount namespace                                   |
+| `controller.serviceaccount_name`                  | `GITSTORE_CONTROLLER__SERVICEACCOUNT__NAME`                  | string   | `gitstore-controller-manager`       | **Yes**          | No        | Enrolled ServiceAccount name                                        |
+| `controller.serviceaccount_key_id`                | `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_ID`                | string   | (empty)                             | **Yes**          | No        | Enrolled public-key ID (`kid`) for controller assertions            |
+| `controller.serviceaccount_uid`                   | `GITSTORE_CONTROLLER__SERVICEACCOUNT__UID`                   | string   | (empty)                             | **Yes**          | No        | Enrolled ServiceAccount UID; prevents identity reuse after deletion |
+| `controller.serviceaccount_key_ref.kind`          | `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KIND`         | string   | (empty)                             | **Yes**          | No        | Must be `SecretRef`                                                 |
+| `controller.serviceaccount_key_ref.name`          | `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__NAME`         | string   | (empty)                             | **Yes**          | No        | Logical bootstrap-secret name, not a filesystem path                |
+| `controller.serviceaccount_key_ref.key`           | `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KEY`          | string   | (empty)                             | **Yes**          | No        | Logical key name in the bootstrap secret                            |
+| `controller.serviceaccount_assertion_audience`    | `GITSTORE_CONTROLLER__SERVICEACCOUNT__ASSERTION_AUDIENCE`    | string   | `gitstore-api/serviceaccount-token` | **Yes**          | No        | Audience for the signed assertion used to exchange a token          |
+| `controller.serviceaccount_access_token_audience` | `GITSTORE_CONTROLLER__SERVICEACCOUNT__ACCESS_TOKEN_AUDIENCE` | string   | `gitstore-api`                      | **Yes**          | No        | Audience requested for the exchanged access token                   |
+| `controller.secret_provider_bootstrap.type`       | `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__TYPE`       | string   | `file`                              | No               | No        | Bootstrap resolver type: `file` or `env`                            |
+| `controller.secret_provider_bootstrap.base_path`  | `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__BASE_PATH`  | string   | `/run/secrets`                      | With `type=file` | No        | Directory containing controller-only mounted bootstrap secrets      |
+| `controller.secret_provider_bootstrap.env_prefix` | `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__ENV_PREFIX` | string   | `GITSTORE_SECRET__`                 | With `type=env`  | No        | Prefix used to resolve bootstrap-secret environment variables       |
+| `controller.default_max_attempts`                 | `GITSTORE_CONTROLLER__DEFAULT_MAX_ATTEMPTS`                  | integer  | `5`                                 | No               | No        | Retry limit before quarantine                                       |
+| `controller.default_stall_threshold`              | `GITSTORE_CONTROLLER__DEFAULT_STALL_THRESHOLD`               | duration | `5m`                                | No               | No        | Worker stall threshold                                              |
+| `controller.checkpoint_dir`                       | `GITSTORE_CONTROLLER__CHECKPOINT_DIR`                        | string   | `/var/lib/gitstore/checkpoints`     | No               | No        | Directory for the filesystem checkpoint store (one file per kind)   |
+| `controller.checkpoint_flush_interval_events`     | `GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS`      | integer  | `100`                               | No               | No        | Watch events between checkpoint persists                            |
+| `controller.max_watch_backoff`                    | `GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF`                     | duration | `30s`                               | No               | No        | Cap on exponential backoff between watch-stream reconnect attempts  |
+| `log.level`                                       | `GITSTORE_LOG__LEVEL`                                        | string   | `info`                              | No               | No        | `debug` \| `info` \| `warn` \| `error`                              |
+| `log.format`                                      | `GITSTORE_LOG__FORMAT`                                       | string   | `json`                              | No               | No        | `json` \| `text`                                                    |
 
 Example:
 
@@ -402,7 +413,7 @@ serviceaccount_assertion_audience = "gitstore-api/serviceaccount-token"
 serviceaccount_access_token_audience = "gitstore-api"
 default_max_attempts = 5
 default_stall_threshold = "5m"
-checkpoint_dir = ".gitstore/checkpoints"
+checkpoint_dir = "/var/lib/gitstore/checkpoints"
 checkpoint_flush_interval_events = 100
 max_watch_backoff = "30s"
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -474,33 +474,33 @@ Use Conventional Commits.
 | Env var                             | Default                 | Purpose                   |
 |-------------------------------------|-------------------------|---------------------------|
 | `GITSTORE_GRPC__PORT`               | `50051`                 | GitService gRPC port      |
-| `GITSTORE_GIT__DATA_DIR`            | `/data/repos`           | Bare repository root      |
+| `GITSTORE_GIT__DATA_DIR`            | `/var/lib/gitstore/repos` | Bare repository root    |
 | `GITSTORE_GIT__REPO__MAX_FILE_SIZE` | `52428800`              | Per-file limit            |
 | `GITSTORE_CATALOG_SERVICE__URI`     | `http://localhost:6000` | API CatalogService target |
 
 ### Controller Manager
 
-| Env var                                        | Default                         | Purpose                         |
-|------------------------------------------------|---------------------------------|---------------------------------|
-| `GITSTORE_CONTROLLER__PORT`                    | `5001`                          | HTTP management port            |
-| `GITSTORE_CONTROLLER__API_URI`                 | `http://localhost:4000/graphql` | API endpoint for reconciliation |
-| `GITSTORE_CONTROLLER__DEFAULT_MAX_ATTEMPTS`    | `5`                             | Retry limit before quarantine   |
-| `GITSTORE_CONTROLLER__DEFAULT_STALL_THRESHOLD` | `5m`                            | Worker stall threshold          |
-| `GITSTORE_CONTROLLER__CHECKPOINT_DIR`          | `.gitstore/checkpoints`         | Filesystem checkpoint store directory (one file per kind) |
-| `GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS` | `100`                  | Watch events between checkpoint persists |
-| `GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF`       | `30s`                           | Cap on watch-reconnect exponential backoff |
-| `GITSTORE_CONTROLLER__SERVICEACCOUNT__NAMESPACE` | unset | Enrolled service-account namespace |
-| `GITSTORE_CONTROLLER__SERVICEACCOUNT__NAME` | `gitstore-controller-manager` | Enrolled service-account name |
-| `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_ID` | unset | Enrolled public-key ID |
-| `GITSTORE_CONTROLLER__SERVICEACCOUNT__UID` | unset | Enrolled service-account UID |
-| `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KIND` | unset | Must be `SecretRef` |
-| `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__NAME` | unset | Logical controller-only secret name |
-| `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KEY` | unset | Logical private-key entry |
-| `GITSTORE_CONTROLLER__SERVICEACCOUNT__ASSERTION_AUDIENCE` | `gitstore-api/serviceaccount-token` | Signed assertion audience |
-| `GITSTORE_CONTROLLER__SERVICEACCOUNT__ACCESS_TOKEN_AUDIENCE` | `gitstore-api` | Exchanged access-token audience |
-| `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__TYPE` | `file` | Bootstrap secret provider |
-| `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__BASE_PATH` | `/run/secrets` | Controller-only secret directory |
-| `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__ENV_PREFIX` | `GITSTORE_SECRET__` | Bootstrap environment-secret prefix |
+| Env var                                                      | Default                             | Purpose                                                   |
+|--------------------------------------------------------------|-------------------------------------|-----------------------------------------------------------|
+| `GITSTORE_CONTROLLER__PORT`                                  | `5001`                              | HTTP management port                                      |
+| `GITSTORE_CONTROLLER__API_URI`                               | `http://localhost:4000/graphql`     | API endpoint for reconciliation                           |
+| `GITSTORE_CONTROLLER__DEFAULT_MAX_ATTEMPTS`                  | `5`                                 | Retry limit before quarantine                             |
+| `GITSTORE_CONTROLLER__DEFAULT_STALL_THRESHOLD`               | `5m`                                | Worker stall threshold                                    |
+| `GITSTORE_CONTROLLER__CHECKPOINT_DIR`                        | `/var/lib/gitstore/checkpoints`     | Filesystem checkpoint store directory (one file per kind) |
+| `GITSTORE_CONTROLLER__CHECKPOINT_FLUSH_INTERVAL_EVENTS`      | `100`                               | Watch events between checkpoint persists                  |
+| `GITSTORE_CONTROLLER__MAX_WATCH_BACKOFF`                     | `30s`                               | Cap on watch-reconnect exponential backoff                |
+| `GITSTORE_CONTROLLER__SERVICEACCOUNT__NAMESPACE`             | unset                               | Enrolled service-account namespace                        |
+| `GITSTORE_CONTROLLER__SERVICEACCOUNT__NAME`                  | `gitstore-controller-manager`       | Enrolled service-account name                             |
+| `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_ID`                | unset                               | Enrolled public-key ID                                    |
+| `GITSTORE_CONTROLLER__SERVICEACCOUNT__UID`                   | unset                               | Enrolled service-account UID                              |
+| `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KIND`         | unset                               | Must be `SecretRef`                                       |
+| `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__NAME`         | unset                               | Logical controller-only secret name                       |
+| `GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KEY`          | unset                               | Logical private-key entry                                 |
+| `GITSTORE_CONTROLLER__SERVICEACCOUNT__ASSERTION_AUDIENCE`    | `gitstore-api/serviceaccount-token` | Signed assertion audience                                 |
+| `GITSTORE_CONTROLLER__SERVICEACCOUNT__ACCESS_TOKEN_AUDIENCE` | `gitstore-api`                      | Exchanged access-token audience                           |
+| `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__TYPE`       | `file`                              | Bootstrap secret provider                                 |
+| `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__BASE_PATH`  | `/run/secrets`                      | Controller-only secret directory                          |
+| `GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__ENV_PREFIX` | `GITSTORE_SECRET__`                 | Bootstrap environment-secret prefix                       |
 
 See [configuration.md](configuration.md) for the operator reference.
 

--- a/docs/namespace/namespace-spec.md
+++ b/docs/namespace/namespace-spec.md
@@ -70,9 +70,9 @@ spec:
 ```
 
 Omitted nested defaults mean that the Namespace supplies no override. Authors must omit `metadata.uid`, `metadata.resourceVersion`, `metadata.generation`,
-`metadata.creationTimestamp`, `metadata.revision`,
-`metadata.ownerReferences`, and `metadata.finalizers`. An authored top-level
-`status` block is ignored for Namespace manifests and never persisted.
+`metadata.creationTimestamp`, `metadata.revision`, `metadata.ownerReferences`,
+`metadata.finalizers`, and `status`. Status is controller/system-owned and is
+written only through the status path.
 
 ## Ownership and mutability
 

--- a/docs/runbooks/docker-troubleshooting.md
+++ b/docs/runbooks/docker-troubleshooting.md
@@ -87,7 +87,7 @@ docker inspect gitstore-git-service | jq '.[0].Mounts'
 List repository data inside the Git service container:
 
 ```bash
-docker compose exec git-service ls -la /data/repos
+docker compose exec git-service ls -la /var/lib/gitstore/repos
 ```
 
 The exact repository storage path is generated from the repository identity and is exposed on the `Repository.storagePath` GraphQL field:

--- a/gitstore-api/.env.example
+++ b/gitstore-api/.env.example
@@ -29,9 +29,14 @@ GITSTORE_AUTH__JWT__REFRESH_GRACE=60s     # duration — window after expiry dur
 
 # Auth provider chain (031-pluggable-authn-authz)
 # Comma-separated list of AuthN providers tried in order; first Allow wins.
-# Available today: static-users, anonymous
+# Available today: static-users, serviceaccount-assertion, serviceaccount-jwt, anonymous
+# serviceaccount-assertion/serviceaccount-jwt are required for
+# gitstore-controller-manager (and any other enrolled ServiceAccount) to
+# authenticate against this API — omitting them makes every controller watch
+# request fail with "invalid or expired credentials" even after a successful
+# `make enroll-controller-serviceaccount`/`gitctl enroll-serviceaccount`.
 # The anonymous provider must always be last.
-GITSTORE_AUTH__AUTHN__CHAIN=static-users,anonymous  # default
+GITSTORE_AUTH__AUTHN__CHAIN=static-users,serviceaccount-assertion,serviceaccount-jwt,anonymous  # default
 
 # AuthZ provider — controls access-control decisions.
 # Available: allow-all (dev), rbac-local (file-based RBAC)

--- a/gitstore-api/config.toml.example
+++ b/gitstore-api/config.toml.example
@@ -1,0 +1,54 @@
+# gitstore-api example config
+# Copy to /etc/gitstore/gitstore-api.toml and adjust for your deployment.
+
+[api]
+port = 4000
+git_port = 9000
+grpc_port = 6000
+rate_limit_per_second = 50
+rate_limit_burst = 100
+
+[git.grpc]
+uri = "dns:///localhost:50051"
+
+[auth.staticusers]
+users_file = "/etc/gitstore/users.yaml"
+
+[auth.jwt]
+secret = "replace-with-strong-random-secret-at-least-32-chars"
+duration = "24h"
+issuer = "gitstore"
+refresh_grace = "60s"
+
+[auth.grpc]
+hmac_secret = "replace-with-shared-hmac-secret"
+
+[auth.authn]
+chain = ["static-users", "anonymous"]
+
+[auth.authz]
+provider = "allow-all"
+
+[auth.userdir]
+provider = "static-users"
+
+[auth.rbac]
+policy_file = "/etc/gitstore/policy.yaml"
+
+[datastore]
+backend = "memdb"
+
+[features]
+namespace_repository_fence = "auto"
+
+[log]
+level = "info"
+format = "json"
+
+# Optional Scylla configuration when datastore.backend = "scylla"
+# [datastore.scylla]
+# hosts = ["localhost:9042"]
+# keyspace = "gitstore"
+# username = ""
+# password = ""
+# tls = false

--- a/gitstore-api/internal/config/config.go
+++ b/gitstore-api/internal/config/config.go
@@ -305,50 +305,6 @@ func load(path string) (*Config, error) {
 	logger, _ := zap.NewProduction()
 	defer logger.Sync() //nolint:errcheck
 
-	// Warn about keys present in the config file that are not in the known schema.
-	knownKeys := map[string]bool{
-		"api.port": true, "api.git_port": true, "api.grpc_port": true,
-		"api.rate_limit_per_second": true, "api.rate_limit_burst": true,
-		"git.grpc.uri": true,
-		"log.level":    true, "log.format": true,
-		"auth.staticusers.users_file": true,
-		"auth.jwt.secret":             true, "auth.jwt.duration": true, "auth.jwt.issuer": true, "auth.jwt.refresh_grace": true,
-		"auth.grpc.hmac_secret": true,
-		"auth.authn.chain":      true, "auth.authz.provider": true,
-		"auth.userdir.provider": true, "auth.rbac.policy_file": true,
-		"auth.serviceaccount.issuer": true, "auth.serviceaccount.audience": true,
-		"auth.serviceaccount.assertion_audience": true, "auth.serviceaccount.signing_key": true,
-		"auth.serviceaccount.default_ttl": true, "auth.serviceaccount.max_ttl": true,
-		"auth.serviceaccount.clock_skew": true,
-		"datastore.backend":              true, "datastore.scylla.hosts": true,
-		"datastore.scylla.keyspace": true, "datastore.scylla.username": true,
-		"datastore.scylla.password": true, "datastore.scylla.tls": true,
-		"datastore.scylla.disable_shard_aware_port": true, "datastore.scylla.ignore_peer_addr": true,
-		"features.namespace_repository_fence": true,
-		"watch.namespace.readers_enabled":     true, "watch.namespace.materializer_enabled": true,
-		"watch.namespace.journal_retention_seconds": true, "watch.namespace.cdc_retention_seconds": true,
-		"watch.namespace.cdc_confidence_window_millis": true,
-		"watch.namespace.bucket_size":                  true, "watch.namespace.read_batch_size": true,
-		"watch.namespace.max_replay_events": true, "watch.namespace.subscriber_buffer": true,
-		"watch.namespace.subscriber_backpressure_millis": true,
-		"watch.namespace.poll_min_millis":                true, "watch.namespace.poll_max_millis": true,
-		"watch.namespace.bookmark_interval_seconds": true, "watch.namespace.lease_ttl_seconds": true,
-		"watch.namespace.lease_renew_interval_seconds": true, "watch.namespace.max_materializer_lag_seconds": true,
-	}
-	sharedServiceKey := func(k string) bool {
-		for _, prefix := range []string{"controller.", "grpc.", "hooks.", "schema_validation.", "admission_control.", "catalog_service."} {
-			if strings.HasPrefix(k, prefix) {
-				return true
-			}
-		}
-		return strings.HasPrefix(k, "git.") && !strings.HasPrefix(k, "git.grpc.")
-	}
-	for _, k := range v.AllKeys() {
-		if !knownKeys[k] && !sharedServiceKey(k) {
-			logger.Warn("unknown configuration key", zap.String("key", k))
-		}
-	}
-
 	logger.Info("Configuration loaded", zap.Object("config", &cfg))
 
 	return &cfg, nil
@@ -442,15 +398,16 @@ func validateServiceAccountAuthChainConfig(auth *AuthConfig) error {
 // User Story 3.
 // A var (not const) so tests can safely override it to a temp path instead
 // of writing to the real /config directory on the host.
-var sharedServiceConfigMountPath = "/config/gitstore.toml"
+var sharedServiceConfigMountPath = "/etc/gitstore/gitstore.toml"
 
 // validateServiceAccountSigningKeySource enforces FR-015c: refuses startup
 // if a service-account AuthN provider is chained in and its signing key was
 // sourced from fileSigningKey — the value read from the config file at path
 // before environment variables were applied. This specifically targets
-// compose.local.yml's shared /config/gitstore.toml mount; an env-var-sourced
-// key (even in a container that also mounts that shared file for other
-// settings) is unaffected, since the file itself never carries the secret.
+// compose.local.yml's shared /etc/gitstore/gitstore.toml mount; an
+// env-var-sourced key (even in a container that also mounts that shared file
+// for other settings) is unaffected, since the file itself never carries the
+// secret.
 func validateServiceAccountSigningKeySource(cfg *Config, path, fileSigningKey string) error {
 	if !chainRequiresServiceAccountSigningKey(cfg.Auth.AuthN.Chain) {
 		return nil

--- a/gitstore-api/internal/eventbus/eventbus.go
+++ b/gitstore-api/internal/eventbus/eventbus.go
@@ -20,6 +20,13 @@ const (
 	Added EventType = iota
 	Modified
 	Deleted
+	// Bookmark marks a synthetic cursor-only event with no real resource
+	// change (e.g. the bootstrap cursor SubscribeWithCursor returns before
+	// any real events exist). It must not be the enum's zero value —
+	// EventType's zero value is Added — otherwise a caller that forgets to
+	// set Type on a synthetic Event would silently be treated as a real
+	// Added event by any switch keyed on EventType.
+	Bookmark
 )
 
 // Event is a single change notification published after a successful

--- a/gitstore-api/internal/gitclient/authorization.go
+++ b/gitstore-api/internal/gitclient/authorization.go
@@ -5,11 +5,20 @@ package gitclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	gitv1 "github.com/gitstore-dev/gitstore/api/gen/gitstore/git/v1"
 	"github.com/gitstore-dev/gitstore/api/internal/auth"
 )
+
+// ErrAuthorizationDenied wraps every rejection RequestAuthorization makes on
+// its own defense-in-depth invariants (e.g. anonymous principals are never
+// approved for a write action, regardless of what the configured AuthZ
+// provider decided upstream). Callers use errors.Is against this sentinel to
+// distinguish an authorization denial — which should surface as 401 so Git
+// can prompt for credentials — from a genuine transport/service failure.
+var ErrAuthorizationDenied = errors.New("git service request authorization denied")
 
 // RequestAuthorization builds the non-secret authorization envelope carried by
 // GitService RPCs. Authentication credentials remain exclusively in gRPC
@@ -25,10 +34,10 @@ func RequestAuthorization(ctx context.Context, action, repositoryID string) (*gi
 	}
 	approvedAnonymous := principal.AuthMethod == "none" && auth.AuthorizedAnonymousFromContext(ctx)
 	if principal.Subject == "" || principal.AuthMethod == "" || (principal.AuthMethod == "none" && !approvedAnonymous) {
-		return nil, fmt.Errorf("git service request authorization requires an authenticated principal")
+		return nil, fmt.Errorf("%w: requires an authenticated principal", ErrAuthorizationDenied)
 	}
 	if approvedAnonymous && action != "repository.read.any" {
-		return nil, fmt.Errorf("git service request authorization permits anonymous actors only for repository.read.any")
+		return nil, fmt.Errorf("%w: permits anonymous actors only for repository.read.any", ErrAuthorizationDenied)
 	}
 	if action == "" || repositoryID == "" {
 		return nil, fmt.Errorf("git service request authorization requires action and repository ID")

--- a/gitstore-api/internal/githttp/handler.go
+++ b/gitstore-api/internal/githttp/handler.go
@@ -5,6 +5,7 @@ package githttp
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	gitv1 "github.com/gitstore-dev/gitstore/api/gen/gitstore/git/v1"
 	"github.com/gitstore-dev/gitstore/api/internal/auth"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
 	"github.com/gitstore-dev/gitstore/api/internal/middleware"
 	"github.com/gitstore-dev/gitstore/api/internal/middleware/security"
 	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
@@ -56,6 +58,22 @@ func (h *handler) gitPktLineError(w http.ResponseWriter, status int, msg string)
 	}
 }
 
+// writeGitClientError maps an error returned by the GitClient into an HTTP
+// response. A gitclient.ErrAuthorizationDenied means RequestAuthorization
+// rejected the request on its own invariants (e.g. anonymous principals are
+// never approved for a write action); that must surface as 401 with
+// WWW-Authenticate so Git retries the request with credentials instead of
+// giving up. Any other error is a genuine transport/service failure and is
+// reported as 503.
+func (h *handler) writeGitClientError(c *gin.Context, err error) {
+	if errors.Is(err, gitclient.ErrAuthorizationDenied) {
+		c.Header("WWW-Authenticate", `Basic realm="GitStore"`)
+		h.gitPktLineError(c.Writer, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	h.gitPktLineError(c.Writer, http.StatusServiceUnavailable, "service unavailable")
+}
+
 // infoRefsHandler handles GET /{namespace}/{repo}/info/refs?service=git-*
 func (h *handler) infoRefsHandler(c *gin.Context) {
 	svcParam := c.Query("service")
@@ -81,7 +99,7 @@ func (h *handler) infoRefsHandler(c *gin.Context) {
 	advertisement, _, err := h.git.InfoRefs(c.Request.Context(), repoID, service)
 	if err != nil {
 		h.log.Error("info_refs: git service error", zap.Error(err))
-		h.gitPktLineError(c.Writer, http.StatusServiceUnavailable, "service unavailable")
+		h.writeGitClientError(c, err)
 		return
 	}
 
@@ -107,7 +125,7 @@ func (h *handler) uploadPackHandler(c *gin.Context) {
 	reader, err := h.git.UploadPack(c.Request.Context(), repoID, body)
 	if err != nil {
 		h.log.Error("upload_pack: git service error", zap.Error(err))
-		h.gitPktLineError(c.Writer, http.StatusServiceUnavailable, "service unavailable")
+		h.writeGitClientError(c, err)
 		return
 	}
 
@@ -133,7 +151,7 @@ func (h *handler) receivePackHandler(c *gin.Context) {
 	reportStatus, err := h.git.ReceivePack(c.Request.Context(), repoID, c.Request.Body)
 	if err != nil {
 		h.log.Error("receive_pack: git service error", zap.Error(err))
-		h.gitPktLineError(c.Writer, http.StatusServiceUnavailable, "service unavailable")
+		h.writeGitClientError(c, err)
 		return
 	}
 

--- a/gitstore-api/internal/githttp/handler_test.go
+++ b/gitstore-api/internal/githttp/handler_test.go
@@ -375,17 +375,6 @@ func TestHandler_UnknownRepo_Returns404(t *testing.T) {
 	}
 }
 
-// stubAuthZProvider is a minimal AuthZProvider for tests.
-type stubAuthZProvider struct {
-	decision auth.Decision
-	err      error
-}
-
-func (s *stubAuthZProvider) Name() string { return "stub-authz" }
-func (s *stubAuthZProvider) Authorize(_ context.Context, _ *auth.Principal, _ string, _ auth.ResourceContext) (auth.Decision, error) {
-	return s.decision, s.err
-}
-
 // T021: RepoResolver returns 404 pkt-line for unknown namespace/repo.
 func TestRepoResolverNotFound(t *testing.T) {
 	store := &testutil.StubStore{} // both lookups return ErrNotFound by default
@@ -442,7 +431,7 @@ func TestRepoResolverSetsContext(t *testing.T) {
 			principal: &auth.Principal{Subject: "reader", AuthMethod: "basic"},
 			decision:  auth.Allow("stub-authn", "authenticated"),
 		}),
-		&stubAuthZProvider{decision: auth.Allow("stub-authz", "read granted")},
+		testutil.NewAllowAllAuthZ(),
 		nil,
 	)
 
@@ -475,7 +464,7 @@ func TestRepoResolverSetsContext(t *testing.T) {
 func TestGitHttpAuthorizerReadOnly(t *testing.T) {
 	readOnlyPrincipal := &auth.Principal{Subject: "reader", AuthMethod: "basic", Roles: []string{"reader"}}
 	stubAuthN := &stubAuthNProviderWithPrincipal{principal: readOnlyPrincipal, decision: auth.Allow("stub", "ok")}
-	stubAuthZ := &stubAuthZProvider{decision: auth.Deny("stub-authz", "no write permission"), err: nil}
+	stubAuthZ := testutil.NewDenyAllAuthZ(t)
 
 	registry := auth.NewProviderRegistry(
 		auth.NewChainedAuthN(stubAuthN),
@@ -518,7 +507,7 @@ func TestGitHttpAuthorizerReadOnly(t *testing.T) {
 func TestGitHttpAuthorizerAnonymousDenyChallengesForCredentials(t *testing.T) {
 	registry := auth.NewProviderRegistry(
 		auth.NewChainedAuthN(anonymous.New()),
-		&stubAuthZProvider{decision: auth.Deny("stub-authz", "authentication required")},
+		testutil.NewDenyAllAuthZ(t),
 		nil,
 	)
 
@@ -558,7 +547,7 @@ func TestGitHttpAuthorizerAnonymousDenyChallengesForCredentials(t *testing.T) {
 func TestGitHttpAuthorizerAnonymousReceivePackDiscoveryChallengesForCredentials(t *testing.T) {
 	registry := auth.NewProviderRegistry(
 		auth.NewChainedAuthN(anonymous.New()),
-		&stubAuthZProvider{decision: auth.Deny("stub-authz", "authentication required")},
+		testutil.NewDenyAllAuthZ(t),
 		nil,
 	)
 
@@ -589,7 +578,7 @@ func TestGitHttpAuthorizerAnonymousReceivePackDiscoveryChallengesForCredentials(
 func TestGitHttpAuthorizerMarksPolicyApprovedAnonymousRead(t *testing.T) {
 	registry := auth.NewProviderRegistry(
 		auth.NewChainedAuthN(anonymous.New()),
-		&stubAuthZProvider{decision: auth.Allow("stub-authz", "public read")},
+		testutil.NewAllowAllAuthZ(),
 		nil,
 	)
 	const wantRepoID = "01960000-0000-7000-8000-000000000001"
@@ -633,7 +622,7 @@ func TestGitHttpAuthorizerMarksPolicyApprovedAnonymousRead(t *testing.T) {
 func TestGitHttpAuthorizerAllowAllAnonymousWriteChallengesForCredentials(t *testing.T) {
 	registry := auth.NewProviderRegistry(
 		auth.NewChainedAuthN(anonymous.New()),
-		&stubAuthZProvider{decision: auth.Allow("allow-all", "allow-all provider permits everything")},
+		testutil.NewAllowAllAuthZ(),
 		nil,
 	)
 	const wantRepoID = "01960000-0000-7000-8000-000000000001"
@@ -678,7 +667,7 @@ func TestGitHttpAuthorizerAllowAllAnonymousWriteChallengesForCredentials(t *test
 func TestGitHttpAuthorizerWriteAllowed(t *testing.T) {
 	writePrincipal := &auth.Principal{Subject: "writer", AuthMethod: "basic", Roles: []string{"writer"}}
 	stubAuthN := &stubAuthNProviderWithPrincipal{principal: writePrincipal, decision: auth.Allow("stub", "ok")}
-	stubAuthZ := &stubAuthZProvider{decision: auth.Allow("stub-authz", "write granted"), err: nil}
+	stubAuthZ := testutil.NewAllowAllAuthZ()
 
 	registry := auth.NewProviderRegistry(
 		auth.NewChainedAuthN(stubAuthN),
@@ -727,7 +716,7 @@ func TestGitHttpAuthorizerWriteAllowed(t *testing.T) {
 // T025: GitHttpAuthorizer without RepoResolver having run returns 500.
 // This test exercises the middleware directly without RepoResolver in chain.
 func TestGitHttpAuthorizerMissingContext(t *testing.T) {
-	stubAuthZ := &stubAuthZProvider{decision: auth.Allow("stub-authz", "ok"), err: nil}
+	stubAuthZ := testutil.NewAllowAllAuthZ()
 	registry := auth.NewProviderRegistry(
 		auth.NewChainedAuthN(anonymous.New()),
 		stubAuthZ,
@@ -805,7 +794,7 @@ func TestReceivePackAttachesPushContext(t *testing.T) {
 
 	writePrincipal := &auth.Principal{Subject: "writer", AuthMethod: "basic", Roles: []string{"writer"}}
 	stubAuthN := &stubAuthNProviderWithPrincipal{principal: writePrincipal, decision: auth.Allow("stub", "ok")}
-	stubAuthZ := &stubAuthZProvider{decision: auth.Allow("stub-authz", "write ok"), err: nil}
+	stubAuthZ := testutil.NewAllowAllAuthZ()
 
 	registry := auth.NewProviderRegistry(
 		auth.NewChainedAuthN(stubAuthN),

--- a/gitstore-api/internal/githttp/handler_test.go
+++ b/gitstore-api/internal/githttp/handler_test.go
@@ -546,6 +546,46 @@ func TestGitHttpAuthorizerAnonymousDenyChallengesForCredentials(t *testing.T) {
 	assert.Equal(t, `Basic realm="GitStore"`, w.Header().Get("WWW-Authenticate"))
 }
 
+// TestGitHttpAuthorizerAnonymousReceivePackDiscoveryChallengesForCredentials
+// covers the info/refs discovery request for git-receive-pack (used by
+// `git push` before the actual push), which is disambiguated from
+// git-upload-pack discovery by the ?service= query param rather than the
+// URL path. An anonymous request must be classified as a write and receive
+// a 401 (so Git retries with embedded credentials), never a 503 — a
+// regression previously missed because existing coverage only exercised
+// anonymous-deny for the upload-pack (?service=git-upload-pack) discovery
+// path and the standalone infoRefsHandler in isolation from the authorizer.
+func TestGitHttpAuthorizerAnonymousReceivePackDiscoveryChallengesForCredentials(t *testing.T) {
+	registry := auth.NewProviderRegistry(
+		auth.NewChainedAuthN(anonymous.New()),
+		&stubAuthZProvider{decision: auth.Deny("stub-authz", "authentication required")},
+		nil,
+	)
+
+	store := &testutil.StubStore{
+		GetRepositoryFunc: func(_ context.Context, id string) (*datastore.Repository, error) {
+			return &datastore.Repository{UID: id, Name: "catalog", Namespace: "gitstore"}, nil
+		},
+		GetNamespaceByNameFunc: func(_ context.Context, id string) (*datastore.Namespace, error) {
+			return &datastore.Namespace{UID: "ns-id-1", Name: id}, nil
+		},
+		LookupRepositoryFunc: func(_ context.Context, _, _ string) (*datastore.NamespaceMapping, error) {
+			return &datastore.NamespaceMapping{RepositoryID: "01960000-0000-7000-8000-000000000001"}, nil
+		},
+	}
+
+	router := NewMuxWithStore(SmartHttpDeps{
+		GitClient: &mockGitClient{}, Store: store, Logger: zap.NewNop(),
+		Ids: apiruntime.NewSequenceIDGenerator(), Registry: registry,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/gitstore/catalog/info/refs?service=git-receive-pack", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, `Basic realm="GitStore"`, w.Header().Get("WWW-Authenticate"))
+}
+
 func TestGitHttpAuthorizerMarksPolicyApprovedAnonymousRead(t *testing.T) {
 	registry := auth.NewProviderRegistry(
 		auth.NewChainedAuthN(anonymous.New()),
@@ -578,6 +618,60 @@ func TestGitHttpAuthorizerMarksPolicyApprovedAnonymousRead(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/gitstore/catalog/info/refs?service=git-upload-pack", nil))
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestGitHttpAuthorizerAllowAllAnonymousWriteChallengesForCredentials reproduces
+// the scenario where the configured AuthZ provider is misconfigured (or
+// intentionally permissive, e.g. "allow-all" in local dev) and approves an
+// anonymous write at the GitHttpAuthorizer layer. gitclient.RequestAuthorization
+// enforces a defense-in-depth invariant that anonymous principals are never
+// approved for a write action regardless of that upstream decision, and the
+// resulting error must surface as 401 (prompting Git to retry with
+// credentials) rather than a blanket 503, or a plain `git push` against a
+// dev stack with an over-permissive AuthZ provider hangs on a 503 that Git
+// cannot recover from.
+func TestGitHttpAuthorizerAllowAllAnonymousWriteChallengesForCredentials(t *testing.T) {
+	registry := auth.NewProviderRegistry(
+		auth.NewChainedAuthN(anonymous.New()),
+		&stubAuthZProvider{decision: auth.Allow("allow-all", "allow-all provider permits everything")},
+		nil,
+	)
+	const wantRepoID = "01960000-0000-7000-8000-000000000001"
+	store := &testutil.StubStore{
+		GetRepositoryFunc: func(_ context.Context, id string) (*datastore.Repository, error) {
+			return &datastore.Repository{UID: id, Name: "catalog", Namespace: "gitstore"}, nil
+		},
+		GetNamespaceByNameFunc: func(_ context.Context, id string) (*datastore.Namespace, error) {
+			return &datastore.Namespace{UID: "ns-id-1", Name: id}, nil
+		},
+		LookupRepositoryFunc: func(_ context.Context, _, _ string) (*datastore.NamespaceMapping, error) {
+			return &datastore.NamespaceMapping{RepositoryID: wantRepoID}, nil
+		},
+	}
+	// Calls the real gitclient.RequestAuthorization so this test exercises the
+	// actual defense-in-depth invariant rather than a stubbed-out approximation.
+	client := &mockGitClient{
+		infoRefsFunc: func(ctx context.Context, repoID string, service gitv1.Service) ([]byte, gitv1.Service, error) {
+			action := "repository.read.any"
+			if service == gitv1.Service_SERVICE_GIT_RECEIVE_PACK {
+				action = "repository.write.any"
+			}
+			if _, err := gitclient.RequestAuthorization(ctx, action, repoID); err != nil {
+				return nil, gitv1.Service_SERVICE_UNSPECIFIED, err
+			}
+			return []byte("001e# service=git-receive-pack\n0000"), gitv1.Service_SERVICE_GIT_RECEIVE_PACK, nil
+		},
+	}
+	router := NewMuxWithStore(SmartHttpDeps{
+		GitClient: client, Store: store, Logger: zap.NewNop(),
+		Ids: apiruntime.NewSequenceIDGenerator(), Registry: registry,
+	})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/gitstore/catalog/info/refs?service=git-receive-pack", nil))
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, `Basic realm="GitStore"`, w.Header().Get("WWW-Authenticate"))
 }
 
 // T024: write-capable principal on receive-pack passes through.

--- a/gitstore-api/internal/graph/resolver/product.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/product.resolvers.go
@@ -162,7 +162,7 @@ func (r *subscriptionResolver) WatchProducts(ctx context.Context, namespace *str
 		defer close(out)
 		defer unsubscribe()
 		if bootstrap {
-			bookmark := toProductWatchEvent(eventbus.Event{Kind: "Product", Cursor: startCursor})
+			bookmark := toProductWatchEvent(eventbus.Event{Kind: "Product", Type: eventbus.Bookmark, Cursor: startCursor})
 			select {
 			case out <- bookmark:
 			case <-ctx.Done():

--- a/gitstore-api/internal/graph/resolver/watch.go
+++ b/gitstore-api/internal/graph/resolver/watch.go
@@ -59,6 +59,8 @@ func toWatchEventType(t eventbus.EventType) model.WatchEventType {
 		return model.WatchEventTypeModified
 	case eventbus.Deleted:
 		return model.WatchEventTypeDeleted
+	case eventbus.Bookmark:
+		return model.WatchEventTypeBookmark
 	default:
 		return model.WatchEventTypeBookmark
 	}

--- a/gitstore-api/internal/middleware/security/graphql.go
+++ b/gitstore-api/internal/middleware/security/graphql.go
@@ -235,6 +235,10 @@ func (a *Authorize) GraphQLFieldAuthorizer(ctx context.Context, next graphql.Res
 		})
 	}
 	if err := a.authorizeRepositoryField(ctx, fc, principal); err != nil {
+		var notFound *authFieldNotFoundError
+		if errors.As(err, &notFound) {
+			return nil, notFound.render()
+		}
 		return nil, err
 	}
 
@@ -520,6 +524,60 @@ func graphqlFieldRequiresAuthorization(fc *graphql.FieldContext) bool {
 	return false
 }
 
+// repositoryNotFoundError mirrors the resolver-layer convention (see
+// queryResolver.Repository in graph/resolver/repository.resolvers.go) so
+// that GraphQL clients — including gitstore-controller-manager's
+// isNotFoundError probe used by EnsureSystemRepository — see the same
+// "repository not found"/NOT_FOUND shape regardless of whether the
+// not-found outcome is detected here (at the authorization layer, before
+// the resolver runs) or inside the resolver itself. Without this, a raw
+// datastore.ErrNotFound ("datastore: not found") leaked straight past
+// authorization, which callers could not recognize as a normal not-found
+// response.
+func repositoryNotFoundError() *gqlerror.Error {
+	return &gqlerror.Error{
+		Message:    "repository not found",
+		Extensions: map[string]any{"code": "NOT_FOUND"},
+	}
+}
+
+// namespaceNotFoundError mirrors resolver.Service.GetNamespaceByName's
+// not-found shape (graph/resolver/service.go) for the same reason as
+// repositoryNotFoundError above.
+func namespaceNotFoundError(name string) *gqlerror.Error {
+	return &gqlerror.Error{
+		Message:    fmt.Sprintf("namespace %q not found", name),
+		Extensions: map[string]any{"code": "NOT_FOUND"},
+	}
+}
+
+// authFieldNotFoundError marks a datastore.ErrNotFound observed while
+// authorizing a GraphQL field, carrying the resolver-equivalent GraphQL
+// error shape to render once authorization finishes. Unwrap keeps
+// errors.Is(err, datastore.ErrNotFound) working for existing in-function
+// callers (e.g. the Query.nodes loop below) that need to distinguish
+// not-found from other failures before authorizeRepositoryField returns.
+type authFieldNotFoundError struct {
+	cause  error
+	render func() *gqlerror.Error
+}
+
+func (e *authFieldNotFoundError) Error() string { return e.cause.Error() }
+func (e *authFieldNotFoundError) Unwrap() error { return e.cause }
+
+// asAuthorizeFieldError normalizes a datastore.ErrNotFound into an
+// authFieldNotFoundError carrying the resolver-equivalent gqlerror shape;
+// any other error is returned unchanged.
+func asAuthorizeFieldError(err error, notFound func() *gqlerror.Error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, datastore.ErrNotFound) {
+		return &authFieldNotFoundError{cause: err, render: notFound}
+	}
+	return err
+}
+
 func (a *Authorize) authorizeRepositoryField(ctx context.Context, fc *graphql.FieldContext, principal *auth.Principal) error {
 	if fc == nil || a.store == nil {
 		return nil
@@ -535,11 +593,11 @@ func (a *Authorize) authorizeRepositoryField(ctx context.Context, fc *graphql.Fi
 		}
 		repo, err = a.store.GetRepository(ctx, rawID)
 		if err != nil {
-			return err
+			return asAuthorizeFieldError(err, repositoryNotFoundError)
 		}
 		ns, err := a.store.GetNamespaceByName(ctx, repo.Namespace)
 		if err != nil {
-			return err
+			return asAuthorizeFieldError(err, func() *gqlerror.Error { return namespaceNotFoundError(repo.Namespace) })
 		}
 		namespaces = append(namespaces, ns)
 		return nil
@@ -554,7 +612,7 @@ func (a *Authorize) authorizeRepositoryField(ctx context.Context, fc *graphql.Fi
 		}
 		ns, err := a.store.GetNamespaceByName(ctx, namespace)
 		if err != nil {
-			return err
+			return asAuthorizeFieldError(err, func() *gqlerror.Error { return namespaceNotFoundError(namespace) })
 		}
 		operation, namespaces, repo = "create", []*datastore.Namespace{ns}, &datastore.Repository{Name: name}
 	case "Mutation.renameRepository", "Mutation.deleteRepository":
@@ -585,7 +643,7 @@ func (a *Authorize) authorizeRepositoryField(ctx context.Context, fc *graphql.Fi
 		}
 		target, err := a.store.GetNamespace(ctx, targetID)
 		if err != nil {
-			return err
+			return asAuthorizeFieldError(err, func() *gqlerror.Error { return namespaceNotFoundError(targetID) })
 		}
 		operation, namespaces = "transfer", append(namespaces, target)
 	case "Query.repository":
@@ -601,15 +659,15 @@ func (a *Authorize) authorizeRepositoryField(ctx context.Context, fc *graphql.Fi
 			}
 			ns, err := a.store.GetNamespaceByName(ctx, namespace)
 			if err != nil {
-				return err
+				return asAuthorizeFieldError(err, func() *gqlerror.Error { return namespaceNotFoundError(namespace) })
 			}
 			mapping, err := a.store.LookupRepository(ctx, ns.Name, name)
 			if err != nil {
-				return err
+				return asAuthorizeFieldError(err, repositoryNotFoundError)
 			}
 			repo, err = a.store.GetRepository(ctx, mapping.RepositoryID)
 			if err != nil {
-				return err
+				return asAuthorizeFieldError(err, repositoryNotFoundError)
 			}
 			namespaces = []*datastore.Namespace{ns}
 		}
@@ -621,7 +679,7 @@ func (a *Authorize) authorizeRepositoryField(ctx context.Context, fc *graphql.Fi
 		}
 		ns, err := a.store.GetNamespaceByName(ctx, namespace)
 		if err != nil {
-			return err
+			return asAuthorizeFieldError(err, func() *gqlerror.Error { return namespaceNotFoundError(namespace) })
 		}
 		operation, namespaces, repo = "read", []*datastore.Namespace{ns}, &datastore.Repository{Name: namespace}
 	case "Query.node":

--- a/gitstore-api/internal/middleware/security/graphql_file_status_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_file_status_test.go
@@ -31,7 +31,7 @@ import (
 // isolation, which never matched what this middleware actually derives or
 // calls (spec 051 T041).
 func TestGraphQLFieldAuthorizerUpdateResourceStatusFileUsesFileStatusWriteAction(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	authz := testutil.NewAllowAllAuthZ()
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
@@ -56,9 +56,9 @@ func TestGraphQLFieldAuthorizerUpdateResourceStatusFileUsesFileStatusWriteAction
 	})
 	require.NoError(t, err)
 	assert.True(t, called)
-	assert.Equal(t, "file.status.write", authz.action)
-	assert.Equal(t, "File", authz.resource.Kind)
-	assert.Equal(t, "hero", authz.resource.Name)
+	assert.Equal(t, "file.status.write", authz.Action)
+	assert.Equal(t, "File", authz.Resource.Kind)
+	assert.Equal(t, "hero", authz.Resource.Name)
 }
 
 // TestGraphQLFieldAuthorizerUpdateResourceStatusFileDenyReturnsForbidden
@@ -67,7 +67,7 @@ func TestGraphQLFieldAuthorizerUpdateResourceStatusFileUsesFileStatusWriteAction
 // the File status-write resolver, surfaced as a FORBIDDEN GraphQL error
 // (spec 051 T041).
 func TestGraphQLFieldAuthorizerUpdateResourceStatusFileDenyReturnsForbidden(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "no controller role")}
+	authz := testutil.NewDenyAllAuthZ(t)
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
@@ -95,14 +95,14 @@ func TestGraphQLFieldAuthorizerUpdateResourceStatusFileDenyReturnsForbidden(t *t
 	var gqlErr *gqlerror.Error
 	require.True(t, errors.As(err, &gqlErr))
 	assert.Equal(t, "FORBIDDEN", gqlErr.Extensions["code"])
-	assert.Equal(t, "file.status.write", authz.action)
+	assert.Equal(t, "file.status.write", authz.Action)
 }
 
 // TestGraphQLFieldAuthorizerRejectsUnauthorizedFileWatch proves the
 // subscription field cannot reach its resolver unless the caller has the
 // namespace-scoped file.watch permission.
 func TestGraphQLFieldAuthorizerRejectsUnauthorizedFileWatch(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "would deny if ever asked")}
+	authz := testutil.NewDenyAllAuthZ(t)
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
@@ -120,16 +120,16 @@ func TestGraphQLFieldAuthorizerRejectsUnauthorizedFileWatch(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.False(t, called)
-	assert.Equal(t, "file.watch", authz.action)
-	assert.Equal(t, "File", authz.resource.Kind)
-	assert.Equal(t, "acme-store", authz.resource.Attrs["namespace"])
+	assert.Equal(t, "file.watch", authz.Action)
+	assert.Equal(t, "File", authz.Resource.Kind)
+	assert.Equal(t, "acme-store", authz.Resource.Attrs["namespace"])
 	var gqlErr *gqlerror.Error
 	require.True(t, errors.As(err, &gqlErr))
 	assert.Equal(t, "FORBIDDEN", gqlErr.Extensions["code"])
 }
 
 func TestGraphQLFieldAuthorizerAuthorizesGenericFileWatch(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	authz := testutil.NewAllowAllAuthZ()
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
 	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "controller", AuthMethod: "bearer"})
@@ -146,12 +146,12 @@ func TestGraphQLFieldAuthorizerAuthorizesGenericFileWatch(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, called)
-	assert.Equal(t, "file.watch", authz.action)
-	assert.Equal(t, "acme-store", authz.resource.Attrs["namespace"])
+	assert.Equal(t, "file.watch", authz.Action)
+	assert.Equal(t, "acme-store", authz.Resource.Attrs["namespace"])
 }
 
 func TestGraphQLFieldAuthorizerLeavesExistingNonFileWatchesUnchanged(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "no new permission")}
+	authz := testutil.NewDenyAllAuthZ(t)
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
 	ctx := graphql.WithFieldContext(context.Background(), &graphql.FieldContext{
@@ -167,5 +167,5 @@ func TestGraphQLFieldAuthorizerLeavesExistingNonFileWatchesUnchanged(t *testing.
 	})
 	require.NoError(t, err)
 	assert.True(t, called)
-	assert.Empty(t, authz.action, "existing Product watch policy must not change in a File-scoped feature")
+	assert.Empty(t, authz.Action, "existing Product watch policy must not change in a File-scoped feature")
 }

--- a/gitstore-api/internal/middleware/security/graphql_namespace_watch_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_namespace_watch_test.go
@@ -28,7 +28,7 @@ func TestNamespaceWatchAuthorizationRunsBeforeResolverForBothEntryPoints(t *test
 		{name: "generic", field: "watchResources", args: map[string]any{"kind": "Namespace", "resourceVersion": "revealing-invalid-cursor"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "denied")}
+			authz := testutil.NewDenyAllAuthZ(t)
 			registry := auth.NewProviderRegistry(nil, authz, nil)
 			mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
 			ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "denied", AuthMethod: "bearer"})
@@ -45,10 +45,10 @@ func TestNamespaceWatchAuthorizationRunsBeforeResolverForBothEntryPoints(t *test
 			})
 			require.Error(t, err)
 			assert.False(t, called)
-			assert.Equal(t, "namespace.watch", authz.action)
-			assert.Equal(t, "Namespace", authz.resource.Kind)
-			assert.Empty(t, authz.resource.Name)
-			assert.Empty(t, authz.resource.Attrs)
+			assert.Equal(t, "namespace.watch", authz.Action)
+			assert.Equal(t, "Namespace", authz.Resource.Kind)
+			assert.Empty(t, authz.Resource.Name)
+			assert.Empty(t, authz.Resource.Attrs)
 			var gqlErr *gqlerror.Error
 			require.ErrorAs(t, err, &gqlErr)
 			assert.Equal(t, "FORBIDDEN", gqlErr.Extensions["code"])
@@ -58,7 +58,7 @@ func TestNamespaceWatchAuthorizationRunsBeforeResolverForBothEntryPoints(t *test
 }
 
 func TestNamespaceWatchAuthorizationAllowsPluggableProviderDecision(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "controller role")}
+	authz := testutil.NewAllowAllAuthZ()
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
 	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "controller", AuthMethod: "bearer"})
@@ -71,5 +71,5 @@ func TestNamespaceWatchAuthorizationAllowsPluggableProviderDecision(t *testing.T
 	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) { called = true; return "ok", nil })
 	require.NoError(t, err)
 	assert.True(t, called)
-	assert.Equal(t, "namespace.watch", authz.action)
+	assert.Equal(t, "namespace.watch", authz.Action)
 }

--- a/gitstore-api/internal/middleware/security/graphql_test.go
+++ b/gitstore-api/internal/middleware/security/graphql_test.go
@@ -404,22 +404,8 @@ func assertAnonymousOperationRejected(t *testing.T, opCtx *graphql.OperationCont
 	assert.Contains(t, resp.Errors[0].Message, "authentication required")
 }
 
-type stubAuthZProvider struct {
-	decision auth.Decision
-	err      error
-	action   string
-	resource auth.ResourceContext
-}
-
-func (s *stubAuthZProvider) Name() string { return "stub-authz" }
-func (s *stubAuthZProvider) Authorize(_ context.Context, _ *auth.Principal, action string, resource auth.ResourceContext) (auth.Decision, error) {
-	s.action = action
-	s.resource = resource
-	return s.decision, s.err
-}
-
 func TestGraphQLFieldAuthorizerCreateNamespaceOrganizationUsesPolicy(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	authz := testutil.NewAllowAllAuthZ()
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
@@ -444,7 +430,7 @@ func TestGraphQLFieldAuthorizerCreateNamespaceOrganizationUsesPolicy(t *testing.
 	})
 	require.NoError(t, err)
 	assert.True(t, called)
-	assert.Equal(t, "namespace.create.organization", authz.action)
+	assert.Equal(t, "namespace.create.organization", authz.Action)
 }
 
 func TestGraphQLFieldAuthorizerCreateNamespaceOrganizationFailsWithoutAuthZ(t *testing.T) {
@@ -475,7 +461,7 @@ func TestGraphQLFieldAuthorizerCreateNamespaceOrganizationFailsWithoutAuthZ(t *t
 }
 
 func TestGraphQLFieldAuthorizerDeleteNamespaceDenyFromPolicy(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "no access")}
+	authz := testutil.NewDenyAllAuthZ(t)
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 	store := &testutil.StubStore{
 		GetNamespaceByNameFunc: func(_ context.Context, name string) (*datastore.Namespace, error) {
@@ -500,7 +486,7 @@ func TestGraphQLFieldAuthorizerDeleteNamespaceDenyFromPolicy(t *testing.T) {
 	require.Error(t, err)
 	assert.False(t, called)
 	assert.Contains(t, err.Error(), "permission denied")
-	assert.Equal(t, "namespace.delete.any", authz.action)
+	assert.Equal(t, "namespace.delete.any", authz.Action)
 }
 
 func TestGraphQLFieldAuthorizerDeleteNamespaceDenialHidesDeletionDetails(t *testing.T) {
@@ -527,7 +513,7 @@ func TestGraphQLFieldAuthorizerDeleteNamespaceDenialHidesDeletionDetails(t *test
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "no access")}
+			authz := testutil.NewDenyAllAuthZ(t)
 			registry := auth.NewProviderRegistry(nil, authz, nil)
 			store := &testutil.StubStore{
 				GetNamespaceByNameFunc: func(_ context.Context, _ string) (*datastore.Namespace, error) {
@@ -560,7 +546,7 @@ func TestGraphQLFieldAuthorizerDeleteNamespaceDenialHidesDeletionDetails(t *test
 }
 
 func TestGraphQLFieldAuthorizerDeleteNamespacePassesAuthorizedRecord(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	authz := testutil.NewAllowAllAuthZ()
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 	authorized := &datastore.Namespace{ID: "namespace-id", Name: "acme", CreationActor: "alice"}
 	store := &testutil.StubStore{
@@ -585,11 +571,11 @@ func TestGraphQLFieldAuthorizerDeleteNamespacePassesAuthorizedRecord(t *testing.
 		return "ok", nil
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "namespace.delete.own", authz.action)
+	assert.Equal(t, "namespace.delete.own", authz.Action)
 }
 
 func TestGraphQLFieldAuthorizerUpdateCategoryStatusUsesPolicy(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	authz := testutil.NewAllowAllAuthZ()
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
@@ -613,11 +599,11 @@ func TestGraphQLFieldAuthorizerUpdateCategoryStatusUsesPolicy(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, called)
-	assert.Equal(t, "category.status.write", authz.action)
+	assert.Equal(t, "category.status.write", authz.Action)
 }
 
 func TestGraphQLFieldAuthorizerUpdateCategoryStatusDenyReturnsForbidden(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "no controller role")}
+	authz := testutil.NewDenyAllAuthZ(t)
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
@@ -647,7 +633,7 @@ func TestGraphQLFieldAuthorizerUpdateCategoryStatusDenyReturnsForbidden(t *testi
 }
 
 func TestGraphQLFieldAuthorizerUpdateProductStatusUsesPolicy(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	authz := testutil.NewAllowAllAuthZ()
 	mw := NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
 	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "controller", AuthMethod: "static-users"})
 	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{Object: "Mutation", Field: graphql.CollectedField{Field: &ast.Field{Name: "updateProductStatus"}}, Args: map[string]any{
@@ -657,11 +643,11 @@ func TestGraphQLFieldAuthorizerUpdateProductStatusUsesPolicy(t *testing.T) {
 	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) { called = true; return "ok", nil })
 	require.NoError(t, err)
 	assert.True(t, called)
-	assert.Equal(t, "product.status.write", authz.action)
+	assert.Equal(t, "product.status.write", authz.Action)
 }
 
 func TestGraphQLFieldAuthorizerDeleteCategoryUsesPersistedScope(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	authz := testutil.NewAllowAllAuthZ()
 	store := &testutil.StubStore{GetCategoryTaxonomyFunc: func(_ context.Context, uid string) (*datastore.CategoryTaxonomy, error) {
 		assert.Equal(t, "category-uid", uid)
 		return &datastore.CategoryTaxonomy{UID: uid, Name: "phones", Namespace: "shop", RepositoryID: "catalog-repo", CreationActor: "alice"}, nil
@@ -676,15 +662,15 @@ func TestGraphQLFieldAuthorizerDeleteCategoryUsesPersistedScope(t *testing.T) {
 	_, err := mw.GraphQLFieldAuthorizer(ctx, func(context.Context) (any, error) { called = true; return "ok", nil })
 	require.NoError(t, err)
 	assert.True(t, called)
-	assert.Equal(t, "category.delete", authz.action)
-	assert.Equal(t, "phones", authz.resource.Name)
-	assert.Equal(t, "alice", authz.resource.OwnerSub)
-	assert.Equal(t, "shop", authz.resource.Attrs["namespace"])
-	assert.Equal(t, "catalog-repo", authz.resource.Attrs["repositoryID"])
+	assert.Equal(t, "category.delete", authz.Action)
+	assert.Equal(t, "phones", authz.Resource.Name)
+	assert.Equal(t, "alice", authz.Resource.OwnerSub)
+	assert.Equal(t, "shop", authz.Resource.Attrs["namespace"])
+	assert.Equal(t, "catalog-repo", authz.Resource.Attrs["repositoryID"])
 }
 
 func TestGraphQLFieldAuthorizerUpdateResourceStatusUsesLowerCamelKindAction(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	authz := testutil.NewAllowAllAuthZ()
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
@@ -706,11 +692,11 @@ func TestGraphQLFieldAuthorizerUpdateResourceStatusUsesLowerCamelKindAction(t *t
 		return "ok", nil
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "backfillJob.status.write", authz.action)
+	assert.Equal(t, "backfillJob.status.write", authz.Action)
 }
 
 func TestGraphQLFieldAuthorizerConfinesAssertionPrincipalToTokenIssuance(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	authz := testutil.NewAllowAllAuthZ()
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
 	principal := &auth.Principal{
@@ -745,7 +731,7 @@ func TestGraphQLFieldAuthorizerConfinesAssertionPrincipalToTokenIssuance(t *test
 }
 
 func TestGraphQLFieldAuthorizerRequiresAssertionForTokenIssuance(t *testing.T) {
-	authz := &stubAuthZProvider{decision: auth.Allow("stub-authz", "allowed")}
+	authz := testutil.NewAllowAllAuthZ()
 	registry := auth.NewProviderRegistry(nil, authz, nil)
 	mw := NewAuthorizeWithStore(registry, &testutil.StubStore{}, zap.NewNop())
 	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{
@@ -780,7 +766,7 @@ func TestGraphQLFieldAuthorizerUsesPolicyForServiceAccountMutations(t *testing.T
 		{field: "deleteServiceAccount", action: "serviceaccount.delete"},
 	} {
 		t.Run(test.field, func(t *testing.T) {
-			authz := &stubAuthZProvider{decision: auth.Deny("stub-authz", "test deny")}
+			authz := testutil.NewDenyAllAuthZ(t)
 			mw := NewAuthorizeWithStore(auth.NewProviderRegistry(nil, authz, nil), &testutil.StubStore{}, zap.NewNop())
 			ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{Subject: "admin", AuthMethod: "static-admin"})
 			ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
@@ -794,7 +780,7 @@ func TestGraphQLFieldAuthorizerUsesPolicyForServiceAccountMutations(t *testing.T
 			})
 			require.Error(t, err)
 			assert.False(t, called)
-			assert.Equal(t, test.action, authz.action)
+			assert.Equal(t, test.action, authz.Action)
 		})
 	}
 }

--- a/gitstore-api/internal/middleware/security/secure.go
+++ b/gitstore-api/internal/middleware/security/secure.go
@@ -313,9 +313,10 @@ const approvedRepositoryActionKey = "approvedRepositoryAction"
 
 // GitHttpAuthorizer authorizes a Git Smart HTTP request after RepoResolver has run.
 // Requires repoIDKey to be set in the gin context (abort 500 if missing).
-// Determines required action from route path:
-//   - /info/refs and /git-upload-pack → "repository.read"
-//   - /git-receive-pack              → "repository.write"
+// Determines required action from route path (and, for /info/refs, the
+// ?service= query param since that endpoint is shared by both services):
+//   - /git-upload-pack, or /info/refs?service=git-upload-pack   → "repository.read"
+//   - /git-receive-pack, or /info/refs?service=git-receive-pack → "repository.write"
 //
 // Aborts with 401 on an anonymous deny so Git credential helpers can retry,
 // and with 403 when an authenticated principal lacks permission.
@@ -342,8 +343,17 @@ func (a *Authorize) GitHttpAuthorizer(c *gin.Context) {
 		principal = auth.Anonymous()
 	}
 
+	// /info/refs is shared by both upload-pack and receive-pack discovery;
+	// the actual service is disambiguated by the ?service= query param, not
+	// the path, so a receive-pack discovery request must be treated as a
+	// write to correctly reject anonymous access with a 401 (prompting Git
+	// to retry with credentials) instead of falling through to a deeper
+	// rejection that surfaces as a generic 503.
 	operation := "read"
-	if strings.HasSuffix(c.FullPath(), "/git-receive-pack") {
+	switch {
+	case strings.HasSuffix(c.FullPath(), "/git-receive-pack"):
+		operation = "write"
+	case strings.HasSuffix(c.FullPath(), "/info/refs") && c.Query("service") == "git-receive-pack":
 		operation = "write"
 	}
 

--- a/gitstore-api/internal/testutil/authz.go
+++ b/gitstore-api/internal/testutil/authz.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package testutil
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gitstore-dev/gitstore/api/internal/auth"
+	"github.com/gitstore-dev/gitstore/api/internal/auth/provider/allowall"
+	"github.com/gitstore-dev/gitstore/api/internal/auth/provider/rbaclocal"
+	"github.com/gitstore-dev/gitstore/api/internal/config"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// denyAllPolicy defines exactly one role, "no-access", so it satisfies
+// rbaclocal's "at least one role" validation without ever matching a test
+// principal's actual roles. With default_deny: true, every action is denied
+// for every principal, mirroring the "always deny" behavior of the old
+// stubAuthZProvider — but through the real rbac-local decision path.
+const denyAllPolicy = `version: v1
+default_deny: true
+roles:
+  no-access:
+    deny:
+      - "*"
+role_bindings: {}
+`
+
+// RecordingAuthZ wraps a real auth.AuthZProvider, delegating every decision
+// to it while recording the last action and resource passed to Authorize.
+// It lets tests assert that a caller computed the correct authorization
+// inputs without needing a hand-rolled stub decision.
+type RecordingAuthZ struct {
+	auth.AuthZProvider
+	Action   string
+	Resource auth.ResourceContext
+}
+
+// NewRecordingAuthZ wraps provider with input recording.
+func NewRecordingAuthZ(provider auth.AuthZProvider) *RecordingAuthZ {
+	return &RecordingAuthZ{AuthZProvider: provider}
+}
+
+func (r *RecordingAuthZ) Authorize(ctx context.Context, p *auth.Principal, action string, res auth.ResourceContext) (auth.Decision, error) {
+	r.Action = action
+	r.Resource = res
+	return r.AuthZProvider.Authorize(ctx, p, action, res)
+}
+
+// NewAllowAllAuthZ returns a recording AuthZProvider backed by the real
+// allow-all provider, i.e. every action is allowed regardless of principal.
+func NewAllowAllAuthZ() *RecordingAuthZ {
+	return NewRecordingAuthZ(allowall.New(zap.NewNop()))
+}
+
+// NewDenyAllAuthZ returns a recording AuthZProvider backed by the real
+// rbac-local provider configured with a policy that denies every action
+// regardless of principal.
+func NewDenyAllAuthZ(t testing.TB) *RecordingAuthZ {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "policy.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(denyAllPolicy), 0o600))
+	provider, err := rbaclocal.New(config.RBACConfig{PolicyFile: path}, zap.NewNop())
+	require.NoError(t, err)
+	return NewRecordingAuthZ(provider)
+}

--- a/gitstore-api/internal/validate/schema_contract_test.go
+++ b/gitstore-api/internal/validate/schema_contract_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package validate_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceSchemasRejectEmptyRequiredStrings(t *testing.T) {
+	t.Parallel()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	schemaFiles, err := filepath.Glob(filepath.Join(filepath.Dir(currentFile), "..", "..", "..", "schemas", "gitstore", "v1beta1", "*.schema.json"))
+	require.NoError(t, err)
+	require.NotEmpty(t, schemaFiles)
+
+	for _, schemaFile := range schemaFiles {
+		schemaFile := schemaFile
+		t.Run(filepath.Base(schemaFile), func(t *testing.T) {
+			raw, err := os.ReadFile(schemaFile)
+			require.NoError(t, err)
+
+			var schema map[string]any
+			require.NoError(t, json.Unmarshal(raw, &schema))
+			assertRequiredStringsAreConstrained(t, schema, "$")
+		})
+	}
+}
+
+func assertRequiredStringsAreConstrained(t *testing.T, node map[string]any, path string) {
+	t.Helper()
+
+	properties, _ := node["properties"].(map[string]any)
+	for _, required := range stringSlice(node["required"]) {
+		property, _ := properties[required].(map[string]any)
+		if property["type"] != "string" {
+			continue
+		}
+		_, hasPattern := property["pattern"]
+		_, hasEnum := property["enum"]
+		minLength, _ := property["minLength"].(float64)
+		require.Truef(t, minLength >= 1 || hasPattern || hasEnum,
+			"%s.%s is a required string but permits an empty value", path, required)
+	}
+
+	for name, child := range properties {
+		if childNode, ok := child.(map[string]any); ok {
+			assertRequiredStringsAreConstrained(t, childNode, path+".properties."+name)
+		}
+	}
+	for name, child := range objectMap(node["$defs"]) {
+		assertRequiredStringsAreConstrained(t, child, path+".$defs."+name)
+	}
+}
+
+func stringSlice(value any) []string {
+	values, _ := value.([]any)
+	strings := make([]string, 0, len(values))
+	for _, value := range values {
+		if stringValue, ok := value.(string); ok {
+			strings = append(strings, stringValue)
+		}
+	}
+	return strings
+}
+
+func objectMap(value any) map[string]map[string]any {
+	values, _ := value.(map[string]any)
+	objects := make(map[string]map[string]any, len(values))
+	for key, value := range values {
+		if object, ok := value.(map[string]any); ok {
+			objects[key] = object
+		}
+	}
+	return objects
+}

--- a/gitstore-api/internal/validate/validator.go
+++ b/gitstore-api/internal/validate/validator.go
@@ -311,9 +311,9 @@ func preParseChecks(fmRaw []byte) error {
 		return fmt.Errorf("validate: spec is required")
 	}
 
-	// Status is ignored for Namespace to preserve system ownership while
-	// allowing declarative clients to round-trip a full resource envelope.
-	if _, ok := raw["status"]; ok && raw["kind"] != "Namespace" {
+	// Status is system-managed and written only through the status path; it
+	// must never appear in an author-controlled Git manifest.
+	if _, ok := raw["status"]; ok {
 		return fmt.Errorf("validate: status is system-managed and must not be set by authors")
 	}
 

--- a/gitstore-api/internal/validate/validator_test.go
+++ b/gitstore-api/internal/validate/validator_test.go
@@ -108,7 +108,7 @@ spec:
 	assert.Equal(t, "USER", parsed.Namespace.Spec.Tier)
 }
 
-func TestParse_NamespaceAuthoredStatusIgnored(t *testing.T) {
+func TestParse_NamespaceAuthoredStatusRejected(t *testing.T) {
 	doc := `---
 apiVersion: gitstore.dev/v1beta1
 kind: Namespace
@@ -126,11 +126,9 @@ status:
 ---
 `
 
-	parsed, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
-	require.NoError(t, err)
-	require.NotNil(t, parsed)
-	require.NotNil(t, parsed.Namespace)
-	assert.Equal(t, "status-ignored", parsed.Namespace.Metadata.Name)
+	_, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status is system-managed")
 }
 
 func TestParse_NamespaceInvalidTierRejected(t *testing.T) {

--- a/gitstore-controller-manager/.env.example
+++ b/gitstore-controller-manager/.env.example
@@ -13,9 +13,22 @@ GITSTORE_CONTROLLER__DEFAULT_MAX_ATTEMPTS=5             # int — global default
 # Duration after which a worker with no completed reconcile is flagged as stalled
 GITSTORE_CONTROLLER__DEFAULT_STALL_THRESHOLD=5m         # duration — e.g. 5m, 30s
 
+# Local dev override: keep the checkpoint store under the repo-root .gitstore dir
+GITSTORE_CONTROLLER__CHECKPOINT_DIR=.gitstore/checkpoints  # string — e.g. .gitstore/checkpoints
+
 # Logging
 GITSTORE_LOG__LEVEL=info                                # string — debug | info | warn | error
 GITSTORE_LOG__FORMAT=json                               # string — json | text
 
-# Bootstrap token
-# GITSTORE_CONTROLLER__API_TOKEN=
+# Service account credentials for the controller manager to authenticate with the API
+GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KIND=SecretRef
+GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__NAME=controller-manager
+GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_REF__KEY=privateKey
+GITSTORE_CONTROLLER__SERVICEACCOUNT__NAMESPACE=controllers
+GITSTORE_CONTROLLER__SERVICEACCOUNT__NAME=gitstore-controller-manager
+GITSTORE_CONTROLLER__SERVICEACCOUNT__KEY_ID=controller-key
+GITSTORE_CONTROLLER__SERVICEACCOUNT__UID=replace-with-enrolled-serviceaccount-uid
+GITSTORE_CONTROLLER__SERVICEACCOUNT__ASSERTION_AUDIENCE=gitstore-api/serviceaccount-token
+GITSTORE_CONTROLLER__SERVICEACCOUNT__ACCESS_TOKEN_AUDIENCE=gitstore-api
+GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__TYPE=file
+GITSTORE_CONTROLLER__SECRET_PROVIDER_BOOTSTRAP__BASE_PATH=.gitstore/secrets

--- a/gitstore-controller-manager/config.toml.example
+++ b/gitstore-controller-manager/config.toml.example
@@ -1,0 +1,23 @@
+# gitstore-controller-manager example config
+# Copy to /etc/gitstore/controller-manager.toml and adjust for your deployment.
+
+[controller]
+port = 5001
+api_uri = "http://localhost:4000/graphql"
+serviceaccount_namespace = "controllers"
+serviceaccount_name = "gitstore-controller-manager"
+serviceaccount_key_id = "controller-key"
+serviceaccount_uid = ""
+serviceaccount_assertion_audience = "gitstore-api/serviceaccount-token"
+serviceaccount_access_token_audience = "gitstore-api"
+serviceaccount_key_ref = { kind = "SecretRef", name = "gitstore-controller-manager-signing-key", key = "privateKey" }
+secret_provider_bootstrap = { type = "file", base_path = "/run/secrets" }
+default_max_attempts = 5
+default_stall_threshold = "5m"
+checkpoint_dir = "/var/lib/gitstore/checkpoints"
+checkpoint_flush_interval_events = 100
+max_watch_backoff = "30s"
+
+[log]
+level = "info"
+format = "json"

--- a/gitstore-controller-manager/internal/config/config.go
+++ b/gitstore-controller-manager/internal/config/config.go
@@ -112,7 +112,7 @@ func load(path string) (*Config, error) {
 	v.SetDefault("controller.secret_provider_bootstrap.env_prefix", "GITSTORE_SECRET__")
 	v.SetDefault("controller.default_max_attempts", 5)
 	v.SetDefault("controller.default_stall_threshold", "5m")
-	v.SetDefault("controller.checkpoint_dir", ".gitstore/checkpoints")
+	v.SetDefault("controller.checkpoint_dir", "/var/lib/gitstore/checkpoints")
 	v.SetDefault("controller.checkpoint_flush_interval_events", 100)
 	v.SetDefault("controller.max_watch_backoff", "30s")
 	v.SetDefault("log.level", "info")

--- a/gitstore-controller-manager/internal/config/config_test.go
+++ b/gitstore-controller-manager/internal/config/config_test.go
@@ -92,8 +92,8 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.Controller.DefaultStallThreshold != 5*time.Minute {
 		t.Errorf("DefaultStallThreshold = %v, want 5m", cfg.Controller.DefaultStallThreshold)
 	}
-	if cfg.Controller.CheckpointDir != ".gitstore/checkpoints" {
-		t.Errorf("CheckpointDir = %q, want .gitstore/checkpoints", cfg.Controller.CheckpointDir)
+	if cfg.Controller.CheckpointDir != "/var/lib/gitstore/checkpoints" {
+		t.Errorf("CheckpointDir = %q, want /var/lib/gitstore/checkpoints", cfg.Controller.CheckpointDir)
 	}
 	if cfg.Controller.CheckpointFlushIntervalEvents != 100 {
 		t.Errorf("CheckpointFlushIntervalEvents = %d, want 100", cfg.Controller.CheckpointFlushIntervalEvents)

--- a/gitstore-git-service/.env.example
+++ b/gitstore-git-service/.env.example
@@ -6,7 +6,7 @@
 # ── Core ──────────────────────────────────────────────────────────────────────
 
 GITSTORE_GRPC__PORT=50051                   # u16    — gRPC service port
-GITSTORE_GIT__DATA_DIR=./.gitstore/repos    # string — path to bare repository storage
+GITSTORE_GIT__DATA_DIR=.gitstore/repos      # string — path to bare repository storage under the repo-root .gitstore dir
 GITSTORE_LOG__LEVEL=info                    # string — trace | debug | info | warn | error
 GITSTORE_LOG__FORMAT=text                   # string  — log format (json or text)
 GITSTORE_GIT__REPO__MAX_FILE_SIZE=52428800  # u64    — max upload size in bytes (50 MiB)

--- a/gitstore-git-service/README.md
+++ b/gitstore-git-service/README.md
@@ -25,15 +25,15 @@ It does not expose public Git HTTP endpoints. In the default Compose deployment,
 
 ## Configuration Highlights
 
-| Variable                                  | Default                 | Purpose                     |
-|-------------------------------------------|-------------------------|-----------------------------|
-| `GITSTORE_GRPC__PORT`                     | `50051`                 | GitService gRPC listen port |
-| `GITSTORE_GIT__DATA_DIR`                  | `/data/repos`           | Bare repository root        |
-| `GITSTORE_GIT__REPO__MAX_FILE_SIZE`       | `52428800`              | Per-file size limit         |
-| `GITSTORE_GIT__REPO__MAX_PACK_SIZE_BYTES` | `52428800`              | Pack size limit             |
-| `GITSTORE_CATALOG_SERVICE__URI`           | `http://localhost:6000` | API CatalogService target   |
-| `GITSTORE_LOG__LEVEL`                     | `info`                  | Log level                   |
-| `GITSTORE_LOG__FORMAT`                    | `json`                  | `json` or `text`            |
+| Variable                                  | Default                   | Purpose                     |
+|-------------------------------------------|---------------------------|-----------------------------|
+| `GITSTORE_GRPC__PORT`                     | `50051`                   | GitService gRPC listen port |
+| `GITSTORE_GIT__DATA_DIR`                  | `/var/lib/gitstore/repos` | Bare repository root        |
+| `GITSTORE_GIT__REPO__MAX_FILE_SIZE`       | `52428800`                | Per-file size limit         |
+| `GITSTORE_GIT__REPO__MAX_PACK_SIZE_BYTES` | `52428800`                | Pack size limit             |
+| `GITSTORE_CATALOG_SERVICE__URI`           | `http://localhost:6000`   | API CatalogService target   |
+| `GITSTORE_LOG__LEVEL`                     | `info`                    | Log level                   |
+| `GITSTORE_LOG__FORMAT`                    | `json`                    | `json` or `text`            |
 
 Hook and admission settings are loaded from defaults, optional `gitstore.toml`, and environment variables. See [docs/configuration.md](../docs/configuration.md).
 

--- a/gitstore-git-service/config.toml.example
+++ b/gitstore-git-service/config.toml.example
@@ -1,0 +1,40 @@
+# gitstore-git-service example config
+# Copy to /etc/gitstore/gitstore-git-service.toml and adjust for your deployment.
+# This is the production-friendly file layout: one service-specific TOML file,
+# with a conventional runtime data directory under /var/lib/gitstore.
+
+[grpc]
+port = 50051
+
+[git]
+data_dir = "/var/lib/gitstore/repos"
+
+[git.repo]
+max_file_size = 52428800
+max_pack_size_bytes = 52428800
+
+[log]
+level = "info"
+format = "json"
+
+[hooks.git_receive_pack]
+pre_receive = { enabled = true }
+update = { enabled = false }
+post_receive = { enabled = true }
+proc_receive = { enabled = false }
+post_update = { enabled = false }
+reference_transaction = { enabled = false }
+
+[schema_validation]
+phase = "pre-receive"
+timeout_secs = 10
+
+[admission_control]
+phase = "post-receive"
+branch_pattern = "^refs/heads/main$"
+
+[catalog_service]
+uri = "http://localhost:6000"
+
+[auth.grpc]
+hmac_secret = "replace-with-shared-hmac-secret"

--- a/gitstore-git-service/src/config.rs
+++ b/gitstore-git-service/src/config.rs
@@ -205,7 +205,7 @@ fn default_toml() -> String {
 port = 50051
 
 [git]
-data_dir = "/data/repos"
+data_dir = "/var/lib/gitstore/repos"
 
 [git.repo]
 max_file_size = 52428800
@@ -284,7 +284,7 @@ mod tests {
         clear_env();
         let cfg = load_config_from(None).expect("load_config failed");
         assert_eq!(cfg.grpc.port, 50051);
-        assert_eq!(cfg.git.data_dir, "/data/repos");
+        assert_eq!(cfg.git.data_dir, "/var/lib/gitstore/repos");
         assert_eq!(cfg.log.level, "info");
         assert_eq!(cfg.log.format, "json");
         assert_eq!(cfg.git.repo.max_file_size, 52428800);

--- a/schemas/gitstore/v1beta1/README.md
+++ b/schemas/gitstore/v1beta1/README.md
@@ -1,0 +1,109 @@
+# GitStore Resource Schemas (v1beta1)
+
+JSON Schema (2020-12) definitions for the YAML frontmatter of GitStore
+resource manifests. These schemas exist primarily so that **LLMs and
+developers** can reliably author valid resource manifests without needing to
+read the Go source — see the top-level `README.md` for GitStore's stated
+target users.
+
+## Scope: frontmatter only
+
+Every GitStore resource is a Markdown file: a YAML frontmatter block
+(delimited by `---`) followed by a free-form Markdown body (the resource's
+"description"). **These schemas validate only the frontmatter object** — the
+Markdown body below it is not modeled here, since the Markdown parser/IR for
+that body is not yet implemented for most resource kinds.
+
+A minimal manifest looks like:
+
+```markdown
+---
+apiVersion: catalog.gitstore.dev/v1beta1
+kind: Product
+metadata:
+  name: my-product
+spec:
+  title: My Product
+---
+
+# My Product
+
+Free-form Markdown description goes here.
+```
+
+Only the YAML object between the two `---` lines is validated against the
+corresponding schema in this directory.
+
+## Files
+
+| Schema | Kind | apiVersion | Git-pushable today? |
+|---|---|---|---|
+| `product.schema.json` | `Product` | `catalog.gitstore.dev/v1beta1` | Yes |
+| `variant.schema.json` | `ProductVariant` | `catalog.gitstore.dev/v1beta1` | Yes |
+| `category.schema.json` | `CategoryTaxonomy` | `catalog.gitstore.dev/v1beta1` | Yes |
+| `collection.schema.json` | `Collection` | `catalog.gitstore.dev/v1beta1` | Yes |
+| `file.schema.json` | `File` | `storage.gitstore.dev/v1beta1` | Yes |
+| `namespace.schema.json` | `Namespace` | `gitstore.dev/v1beta1` | Yes |
+| `repository.schema.json` | `Repository` | `gitstore.dev/v1beta1` | **No** — see below |
+
+Each schema is self-contained (no cross-file `$ref`s) so a single file gives
+an LLM or IDE everything it needs, at the cost of duplicating shared
+definitions (`ObjectMeta`, `ObjectReference`, `FileReference`,
+`MediaDefinition`, etc.) across files. All schemas use `additionalProperties:
+false` throughout, so unknown/system-managed fields (e.g. `status`, `uid`,
+`resourceVersion`) are rejected — matching the real admission contract.
+
+### Repository is a special case
+
+Unlike the other six kinds, `Repository` resources are **not** currently
+created by pushing a manifest through `git push` — the server's
+frontmatter parser has no case for `kind: Repository` yet. Repositories are
+created via the `createRepository` GraphQL mutation. `repository.schema.json`
+documents the shape of a Repository as read back from the API today, and
+anticipates a possible future declarative/git-authored form. Don't expect a
+file matching this schema to be accepted by `git push`.
+
+## Ground truth
+
+These schemas are derived directly from the Go struct validation tags in
+`gitstore-api/internal/catalog/*.go` and the business-rule validators in
+`gitstore-api/internal/validate/validator.go` — not from prose documentation,
+which occasionally describes aspirational fields not yet implemented (for
+example, `docs/namespace/namespace-spec.md` describes several
+`pushPolicyDefaults` sub-fields that don't exist on the actual
+`NamespacePushPolicyDefaults` struct today). If code and docs ever diverge,
+treat the code as authoritative and file an issue to update the docs.
+
+## Editor/tooling caveat
+
+Core [`yaml-language-server`](https://github.com/redhat-developer/yaml-language-server)
+(used by most YAML-aware editor extensions) validates plain `.yaml` files
+against a `$schema`/`yaml.schemas` mapping, but it does **not** natively
+validate YAML frontmatter embedded inside `.md` files. To get live validation
+while authoring GitStore manifests in Markdown, use a frontmatter-aware tool
+such as [`remark-lint-frontmatter-schema`](https://github.com/JulianCataldo/remark-lint-frontmatter-schema)
+or a `validate-md`-style linter that extracts the frontmatter block and
+validates it against the appropriate schema file in this directory.
+
+## Validating manifests locally
+
+```bash
+pip install jsonschema pyyaml
+python3 - <<'EOF'
+import json, re, sys, yaml
+from jsonschema import Draft202012Validator
+
+path = sys.argv[1] if len(sys.argv) > 1 else "example.md"
+raw = open(path).read()
+frontmatter = re.match(r"^---\n(.*?)\n---\n", raw, re.S).group(1)
+doc = yaml.safe_load(frontmatter)
+
+schema = json.load(open(f"schemas/gitstore/v1beta1/{doc['kind'].lower()}.schema.json"))
+Draft202012Validator(schema).validate(doc)
+print("valid")
+EOF
+```
+
+(Adjust the schema filename lookup for `ProductVariant` → `variant.schema.json`
+and `CategoryTaxonomy` → `category.schema.json`, since filenames are
+shortened relative to `kind`.)

--- a/schemas/gitstore/v1beta1/category.schema.json
+++ b/schemas/gitstore/v1beta1/category.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.gitstore.dev/gitstore/v1beta1/category.schema.json",
+  "title": "GitStore CategoryTaxonomy",
+  "description": "YAML frontmatter for a GitStore CategoryTaxonomy resource. A CategoryTaxonomy resource is a Markdown file: this schema validates only the frontmatter object between the opening and closing '---' delimiters. The remaining Markdown content is the free-form category description body and is not covered by this schema. Categories may nest via spec.parentRef to form a taxonomy tree. See docs/categories/category-taxonomy-spec.md for the full authoring contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {
+      "const": "catalog.gitstore.dev/v1beta1",
+      "description": "Must be exactly \"catalog.gitstore.dev/v1beta1\"."
+    },
+    "kind": {
+      "const": "CategoryTaxonomy",
+      "description": "Must be exactly \"CategoryTaxonomy\" (case-sensitive)."
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/CategoryTaxonomySpec"
+    }
+  },
+  "$defs": {
+    "ObjectMeta": {
+      "type": "object",
+      "description": "Author-writable resource metadata. Do not set uid, resourceVersion, generation, creationTimestamp, revision, ownerReferences, or finalizers — those fields are system-managed and any of them present in an authored file causes the push to be rejected.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+          "maxLength": 63,
+          "description": "DNS label format: lowercase alphanumeric and hyphens, 1-63 characters, no leading/trailing hyphen. Identifies this CategoryTaxonomy uniquely within its namespace."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Optional. When omitted, the namespace is inferred from the owning repository at push time. When present, it is validated to match the inferred namespace."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Optional key/value labels. Keys may use an optional \"prefix/name\" form; prefix ≤ 253 chars, name segment ≤ 63 chars. Values ≤ 63 chars.",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 63
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Optional key/value annotations. No length restriction.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ObjectReference": {
+      "type": "object",
+      "description": "A pointer to another catalogue resource.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "apiVersion": { "type": "string" },
+        "kind": { "type": "string" },
+        "name": { "type": "string", "description": "Required. Name of the referenced resource." },
+        "namespace": { "type": "string" },
+        "uid": { "type": "string" },
+        "resourceVersion": { "type": "string" },
+        "fieldPath": { "type": "string" }
+      }
+    },
+    "FileReference": {
+      "type": "object",
+      "description": "Identifies a File resource by name and kind.",
+      "additionalProperties": false,
+      "required": ["name", "kind"],
+      "properties": {
+        "name": { "type": "string", "description": "Required — the name of the referenced File resource, even when optional is true." },
+        "kind": { "type": "string", "description": "Required. Typically \"File\"." },
+        "optional": { "type": "boolean", "description": "When true, admission succeeds even if the referenced File is absent." }
+      }
+    },
+    "MediaDefinition": {
+      "type": "object",
+      "description": "A media slot referencing a File resource.",
+      "additionalProperties": false,
+      "required": ["fileRef"],
+      "properties": {
+        "fileRef": { "$ref": "#/$defs/FileReference" }
+      }
+    },
+    "CategoryTaxonomySpec": {
+      "type": "object",
+      "description": "Author-controlled declarative specification for a category taxonomy node.",
+      "additionalProperties": false,
+      "required": ["title"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "Required. Human-readable display title. Max 200 characters."
+        },
+        "parentRef": {
+          "$ref": "#/$defs/ObjectReference",
+          "description": "Reference to a parent CategoryTaxonomy, forming a tree. Omit for a root-level category. Cycles are rejected at admission."
+        },
+        "media": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/MediaDefinition" }
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "apiVersion": "catalog.gitstore.dev/v1beta1",
+      "kind": "CategoryTaxonomy",
+      "metadata": {
+        "name": "personal-computers",
+        "namespace": "acme-store",
+        "labels": { "gitstore.dev/department": "electronics" }
+      },
+      "spec": {
+        "title": "Personal Computers",
+        "parentRef": {
+          "kind": "CategoryTaxonomy",
+          "name": "electronics"
+        }
+      }
+    }
+  ]
+}

--- a/schemas/gitstore/v1beta1/category.schema.json
+++ b/schemas/gitstore/v1beta1/category.schema.json
@@ -64,7 +64,7 @@
       "properties": {
         "apiVersion": { "type": "string" },
         "kind": { "type": "string" },
-        "name": { "type": "string", "description": "Required. Name of the referenced resource." },
+        "name": { "type": "string", "minLength": 1, "description": "Required. Name of the referenced resource." },
         "namespace": { "type": "string" },
         "uid": { "type": "string" },
         "resourceVersion": { "type": "string" },
@@ -77,8 +77,8 @@
       "additionalProperties": false,
       "required": ["name", "kind"],
       "properties": {
-        "name": { "type": "string", "description": "Required — the name of the referenced File resource, even when optional is true." },
-        "kind": { "type": "string", "description": "Required. Typically \"File\"." },
+        "name": { "type": "string", "minLength": 1, "description": "Required — the name of the referenced File resource, even when optional is true." },
+        "kind": { "type": "string", "minLength": 1, "description": "Required. Typically \"File\"." },
         "optional": { "type": "boolean", "description": "When true, admission succeeds even if the referenced File is absent." }
       }
     },
@@ -99,6 +99,7 @@
       "properties": {
         "title": {
           "type": "string",
+          "minLength": 1,
           "maxLength": 200,
           "description": "Required. Human-readable display title. Max 200 characters."
         },

--- a/schemas/gitstore/v1beta1/collection.schema.json
+++ b/schemas/gitstore/v1beta1/collection.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.gitstore.dev/gitstore/v1beta1/collection.schema.json",
+  "title": "GitStore Collection",
+  "description": "YAML frontmatter for a GitStore Collection resource. A Collection resource is a Markdown file: this schema validates only the frontmatter object between the opening and closing '---' delimiters. The remaining Markdown content is the free-form collection description body and is not covered by this schema. A Collection groups Products either dynamically (spec.selector, matched by label) or manually (spec.targetRef, a single explicit Product). See docs/collections/collection-spec.md for the full authoring contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {
+      "const": "catalog.gitstore.dev/v1beta1",
+      "description": "Must be exactly \"catalog.gitstore.dev/v1beta1\"."
+    },
+    "kind": {
+      "const": "Collection",
+      "description": "Must be exactly \"Collection\" (case-sensitive)."
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/CollectionSpec"
+    }
+  },
+  "$defs": {
+    "ObjectMeta": {
+      "type": "object",
+      "description": "Author-writable resource metadata. Do not set uid, resourceVersion, generation, creationTimestamp, revision, ownerReferences, or finalizers — those fields are system-managed and any of them present in an authored file causes the push to be rejected.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+          "maxLength": 63,
+          "description": "DNS label format: lowercase alphanumeric and hyphens, 1-63 characters, no leading/trailing hyphen. Identifies this Collection uniquely within its namespace."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Optional. When omitted, the namespace is inferred from the owning repository at push time. When present, it is validated to match the inferred namespace."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Optional key/value labels. Keys may use an optional \"prefix/name\" form; prefix ≤ 253 chars, name segment ≤ 63 chars. Values ≤ 63 chars.",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 63
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Optional key/value annotations. No length restriction.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ObjectReference": {
+      "type": "object",
+      "description": "A pointer to another catalogue resource.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "apiVersion": { "type": "string" },
+        "kind": { "type": "string" },
+        "name": { "type": "string", "description": "Required. Name of the referenced resource." },
+        "namespace": { "type": "string" },
+        "uid": { "type": "string" },
+        "resourceVersion": { "type": "string" },
+        "fieldPath": { "type": "string" }
+      }
+    },
+    "FileReference": {
+      "type": "object",
+      "description": "Identifies a File resource by name and kind.",
+      "additionalProperties": false,
+      "required": ["name", "kind"],
+      "properties": {
+        "name": { "type": "string", "description": "Required — the name of the referenced File resource, even when optional is true." },
+        "kind": { "type": "string", "description": "Required. Typically \"File\"." },
+        "optional": { "type": "boolean", "description": "When true, admission succeeds even if the referenced File is absent." }
+      }
+    },
+    "MediaDefinition": {
+      "type": "object",
+      "description": "A media slot referencing a File resource.",
+      "additionalProperties": false,
+      "required": ["fileRef"],
+      "properties": {
+        "fileRef": { "$ref": "#/$defs/FileReference" }
+      }
+    },
+    "LabelSelectorRequirement": {
+      "type": "object",
+      "description": "A single label-matching expression.",
+      "additionalProperties": false,
+      "required": ["key", "operator"],
+      "properties": {
+        "key": { "type": "string", "description": "Required. Label key to match against." },
+        "operator": {
+          "type": "string",
+          "enum": ["In", "NotIn", "Exists", "DoesNotExist"],
+          "description": "Required. Matching operator."
+        },
+        "values": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Required and must be non-empty when operator is \"In\" or \"NotIn\"; must be omitted/empty for \"Exists\"/\"DoesNotExist\"."
+        }
+      }
+    },
+    "LabelSelector": {
+      "type": "object",
+      "description": "Selects Products dynamically by label. matchLabels entries are ANDed together with matchExpressions entries.",
+      "additionalProperties": false,
+      "properties": {
+        "matchLabels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "matchExpressions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/LabelSelectorRequirement" }
+        }
+      }
+    },
+    "CollectionSpec": {
+      "type": "object",
+      "description": "Author-controlled declarative specification for a collection. Use exactly one of selector (dynamic) or targetRef (manual, single Product) — using both or neither may be rejected depending on the collection's intended semantics.",
+      "additionalProperties": false,
+      "required": ["title"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "Required. Human-readable display title. Max 200 characters."
+        },
+        "selector": {
+          "$ref": "#/$defs/LabelSelector",
+          "description": "Dynamic membership: Products matching this label selector belong to the collection."
+        },
+        "targetRef": {
+          "allOf": [{ "$ref": "#/$defs/ObjectReference" }],
+          "description": "Manual membership: a single explicit reference. kind must be \"Product\" when present."
+        },
+        "media": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/MediaDefinition" }
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "apiVersion": "catalog.gitstore.dev/v1beta1",
+      "kind": "Collection",
+      "metadata": {
+        "name": "summer-sale",
+        "namespace": "acme-store"
+      },
+      "spec": {
+        "title": "Summer Sale",
+        "selector": {
+          "matchLabels": {
+            "gitstore.dev/season": "summer"
+          },
+          "matchExpressions": [
+            { "key": "gitstore.dev/tier", "operator": "In", "values": ["premium", "standard"] }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/schemas/gitstore/v1beta1/collection.schema.json
+++ b/schemas/gitstore/v1beta1/collection.schema.json
@@ -64,7 +64,7 @@
       "properties": {
         "apiVersion": { "type": "string" },
         "kind": { "type": "string" },
-        "name": { "type": "string", "description": "Required. Name of the referenced resource." },
+        "name": { "type": "string", "minLength": 1, "description": "Required. Name of the referenced resource." },
         "namespace": { "type": "string" },
         "uid": { "type": "string" },
         "resourceVersion": { "type": "string" },
@@ -77,8 +77,8 @@
       "additionalProperties": false,
       "required": ["name", "kind"],
       "properties": {
-        "name": { "type": "string", "description": "Required — the name of the referenced File resource, even when optional is true." },
-        "kind": { "type": "string", "description": "Required. Typically \"File\"." },
+        "name": { "type": "string", "minLength": 1, "description": "Required — the name of the referenced File resource, even when optional is true." },
+        "kind": { "type": "string", "minLength": 1, "description": "Required. Typically \"File\"." },
         "optional": { "type": "boolean", "description": "When true, admission succeeds even if the referenced File is absent." }
       }
     },
@@ -97,7 +97,7 @@
       "additionalProperties": false,
       "required": ["key", "operator"],
       "properties": {
-        "key": { "type": "string", "description": "Required. Label key to match against." },
+        "key": { "type": "string", "minLength": 1, "description": "Required. Label key to match against." },
         "operator": {
           "type": "string",
           "enum": ["In", "NotIn", "Exists", "DoesNotExist"],
@@ -133,6 +133,7 @@
       "properties": {
         "title": {
           "type": "string",
+          "minLength": 1,
           "maxLength": 200,
           "description": "Required. Human-readable display title. Max 200 characters."
         },

--- a/schemas/gitstore/v1beta1/file.schema.json
+++ b/schemas/gitstore/v1beta1/file.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.gitstore.dev/gitstore/v1beta1/file.schema.json",
+  "title": "GitStore File",
+  "description": "YAML frontmatter for a GitStore File resource. A File resource is a Markdown file: this schema validates only the frontmatter object between the opening and closing '---' delimiters. The remaining Markdown content is free-form notes about the file and is not covered by this schema. A File resource describes a piece of external or repository-tracked binary content (e.g. an image) that other resources reference via fileRef. Note: apiVersion for File is a distinct API group (\"storage.gitstore.dev\") from the catalog resources (\"catalog.gitstore.dev\").",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {
+      "const": "storage.gitstore.dev/v1beta1",
+      "description": "Must be exactly \"storage.gitstore.dev/v1beta1\"."
+    },
+    "kind": {
+      "const": "File",
+      "description": "Must be exactly \"File\" (case-sensitive)."
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/FileSpec"
+    }
+  },
+  "$defs": {
+    "ObjectMeta": {
+      "type": "object",
+      "description": "Author-writable resource metadata. Do not set uid, resourceVersion, generation, creationTimestamp, revision, ownerReferences, or finalizers — those fields are system-managed and any of them present in an authored file causes the push to be rejected.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+          "maxLength": 63,
+          "description": "DNS label format: lowercase alphanumeric and hyphens, 1-63 characters, no leading/trailing hyphen. Identifies this File uniquely within its namespace."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Optional. When omitted, the namespace is inferred from the owning repository at push time. When present, it is validated to match the inferred namespace."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Optional key/value labels. Keys may use an optional \"prefix/name\" form; prefix ≤ 253 chars, name segment ≤ 63 chars. Values ≤ 63 chars.",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 63
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Optional key/value annotations. No length restriction.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ChecksumDefinition": {
+      "type": "object",
+      "description": "Content checksum used to verify integrity of the source content.",
+      "additionalProperties": false,
+      "required": ["algorithm", "value"],
+      "properties": {
+        "algorithm": { "type": "string", "description": "Required. e.g. \"sha256\"." },
+        "value": { "type": "string", "description": "Required. Hex-encoded digest." }
+      }
+    },
+    "SecretRef": {
+      "type": "object",
+      "description": "Reference to credentials used to fetch the source content. If namespace is set, it must match this resource's own namespace.",
+      "additionalProperties": false,
+      "required": ["kind", "name"],
+      "properties": {
+        "kind": { "type": "string", "description": "Required. Kind of the secret-holding resource." },
+        "name": { "type": "string", "description": "Required. Name of the secret-holding resource." },
+        "key": { "type": "string", "description": "Optional key within the referenced secret." },
+        "namespace": { "type": "string", "description": "Optional. Must match this File's own namespace if set." }
+      }
+    },
+    "FileSourceDefinition": {
+      "type": "object",
+      "description": "Where the file content is fetched from.",
+      "additionalProperties": false,
+      "required": ["type", "uri"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["git", "lfs", "s3", "gcs"],
+          "description": "Required. Source backend type."
+        },
+        "uri": { "type": "string", "description": "Required. Location of the content, interpreted according to type." },
+        "checksum": { "$ref": "#/$defs/ChecksumDefinition" },
+        "credentialsRef": { "$ref": "#/$defs/SecretRef" }
+      }
+    },
+    "FileVariantRequest": {
+      "type": "object",
+      "description": "A single derived image variant to generate (e.g. a thumbnail).",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "description": "Required. Identifier for this variant, unique within processing.image.variants." }
+      }
+    },
+    "FileImageProcessing": {
+      "type": "object",
+      "description": "Image-specific processing options.",
+      "additionalProperties": false,
+      "properties": {
+        "variants": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/FileVariantRequest" }
+        }
+      }
+    },
+    "FileProcessingDefinition": {
+      "type": "object",
+      "description": "Optional post-fetch processing configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "image": { "$ref": "#/$defs/FileImageProcessing" }
+      }
+    },
+    "FileSpec": {
+      "type": "object",
+      "description": "Author-controlled declarative specification for a File.",
+      "additionalProperties": false,
+      "required": ["contentType", "source"],
+      "properties": {
+        "contentType": { "type": "string", "description": "Required. MIME type of the content, e.g. \"image/png\"." },
+        "type": { "type": "string", "description": "Optional logical file type/category, distinct from contentType." },
+        "source": { "$ref": "#/$defs/FileSourceDefinition" },
+        "processing": { "$ref": "#/$defs/FileProcessingDefinition" }
+      }
+    }
+  },
+  "examples": [
+    {
+      "apiVersion": "storage.gitstore.dev/v1beta1",
+      "kind": "File",
+      "metadata": {
+        "name": "hero-image",
+        "namespace": "acme-store"
+      },
+      "spec": {
+        "contentType": "image/png",
+        "source": {
+          "type": "git",
+          "uri": "assets/hero-image.png",
+          "checksum": {
+            "algorithm": "sha256",
+            "value": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+          }
+        },
+        "processing": {
+          "image": {
+            "variants": [
+              { "name": "thumbnail" },
+              { "name": "large" }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/gitstore/v1beta1/file.schema.json
+++ b/schemas/gitstore/v1beta1/file.schema.json
@@ -62,8 +62,8 @@
       "additionalProperties": false,
       "required": ["algorithm", "value"],
       "properties": {
-        "algorithm": { "type": "string", "description": "Required. e.g. \"sha256\"." },
-        "value": { "type": "string", "description": "Required. Hex-encoded digest." }
+        "algorithm": { "type": "string", "minLength": 1, "description": "Required. e.g. \"sha256\"." },
+        "value": { "type": "string", "minLength": 1, "description": "Required. Hex-encoded digest." }
       }
     },
     "SecretRef": {
@@ -72,8 +72,8 @@
       "additionalProperties": false,
       "required": ["kind", "name"],
       "properties": {
-        "kind": { "type": "string", "description": "Required. Kind of the secret-holding resource." },
-        "name": { "type": "string", "description": "Required. Name of the secret-holding resource." },
+        "kind": { "type": "string", "minLength": 1, "description": "Required. Kind of the secret-holding resource." },
+        "name": { "type": "string", "minLength": 1, "description": "Required. Name of the secret-holding resource." },
         "key": { "type": "string", "description": "Optional key within the referenced secret." },
         "namespace": { "type": "string", "description": "Optional. Must match this File's own namespace if set." }
       }
@@ -89,7 +89,7 @@
           "enum": ["git", "lfs", "s3", "gcs"],
           "description": "Required. Source backend type."
         },
-        "uri": { "type": "string", "description": "Required. Location of the content, interpreted according to type." },
+        "uri": { "type": "string", "minLength": 1, "description": "Required. Location of the content, interpreted according to type." },
         "checksum": { "$ref": "#/$defs/ChecksumDefinition" },
         "credentialsRef": { "$ref": "#/$defs/SecretRef" }
       }
@@ -100,7 +100,7 @@
       "additionalProperties": false,
       "required": ["name"],
       "properties": {
-        "name": { "type": "string", "description": "Required. Identifier for this variant, unique within processing.image.variants." }
+        "name": { "type": "string", "minLength": 1, "description": "Required. Identifier for this variant, unique within processing.image.variants." }
       }
     },
     "FileImageProcessing": {
@@ -128,7 +128,7 @@
       "additionalProperties": false,
       "required": ["contentType", "source"],
       "properties": {
-        "contentType": { "type": "string", "description": "Required. MIME type of the content, e.g. \"image/png\"." },
+        "contentType": { "type": "string", "minLength": 1, "description": "Required. MIME type of the content, e.g. \"image/png\"." },
         "type": { "type": "string", "description": "Optional logical file type/category, distinct from contentType." },
         "source": { "$ref": "#/$defs/FileSourceDefinition" },
         "processing": { "$ref": "#/$defs/FileProcessingDefinition" }

--- a/schemas/gitstore/v1beta1/namespace.schema.json
+++ b/schemas/gitstore/v1beta1/namespace.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.gitstore.dev/gitstore/v1beta1/namespace.schema.json",
+  "title": "GitStore Namespace",
+  "description": "YAML frontmatter for a GitStore Namespace resource. A Namespace resource is a Markdown file: this schema validates only the frontmatter object between the opening and closing '---' delimiters. The remaining Markdown content is free-form documentation about the namespace and is not covered by this schema. Note: apiVersion for Namespace is the bare \"gitstore.dev\" API group, distinct from catalog resources (\"catalog.gitstore.dev\") and File (\"storage.gitstore.dev\"). A Namespace resource's metadata must NOT include a namespace field — namespaces are top-level and cannot themselves belong to a namespace. See docs/namespace/namespace-spec.md for the full authoring contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {
+      "const": "gitstore.dev/v1beta1",
+      "description": "Must be exactly \"gitstore.dev/v1beta1\"."
+    },
+    "kind": {
+      "const": "Namespace",
+      "description": "Must be exactly \"Namespace\" (case-sensitive)."
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/NamespaceSpec"
+    }
+  },
+  "$defs": {
+    "ObjectMeta": {
+      "type": "object",
+      "description": "Author-writable resource metadata. Do NOT include a \"namespace\" field here — Namespace resources are not themselves namespaced, and its presence causes the push to be rejected. Do not set uid, resourceVersion, generation, creationTimestamp, revision, ownerReferences, or finalizers either — those fields are system-managed.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+          "maxLength": 63,
+          "description": "DNS label format: lowercase alphanumeric and hyphens, 1-63 characters, no leading/trailing hyphen. Globally unique namespace identifier."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Optional key/value labels. Keys may use an optional \"prefix/name\" form; prefix ≤ 253 chars, name segment ≤ 63 chars. Values ≤ 63 chars.",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 63
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Optional key/value annotations. No length restriction.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RepositoryDefaults": {
+      "type": "object",
+      "description": "Default settings applied to repositories created under this namespace.",
+      "additionalProperties": false,
+      "properties": {
+        "visibility": {
+          "type": "string",
+          "enum": ["PUBLIC", "PRIVATE", "INTERNAL"],
+          "description": "Default visibility for new repositories in this namespace."
+        },
+        "defaultBranch": {
+          "type": "string",
+          "description": "Default branch name for new repositories in this namespace (e.g. \"main\")."
+        }
+      }
+    },
+    "PushPolicyDefaults": {
+      "type": "object",
+      "description": "Default push-size limits applied to repositories created under this namespace. Only these two fields are currently supported — other push-policy knobs described elsewhere are not yet implemented.",
+      "additionalProperties": false,
+      "properties": {
+        "maxPackSizeBytes": {
+          "type": "integer",
+          "description": "Maximum accepted git push pack size, in bytes."
+        },
+        "maxFileSizeBytes": {
+          "type": "integer",
+          "description": "Maximum accepted individual file size within a push, in bytes."
+        }
+      }
+    },
+    "NamespaceSpec": {
+      "type": "object",
+      "description": "Author-controlled declarative specification for a namespace.",
+      "additionalProperties": false,
+      "required": ["tier"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "Optional human-readable display title. Max 200 characters."
+        },
+        "tier": {
+          "type": "string",
+          "enum": ["USER", "ORGANIZATION"],
+          "description": "Required. Determines namespace ownership semantics."
+        },
+        "repositoryDefaults": { "$ref": "#/$defs/RepositoryDefaults" },
+        "pushPolicyDefaults": { "$ref": "#/$defs/PushPolicyDefaults" }
+      }
+    }
+  },
+  "examples": [
+    {
+      "apiVersion": "gitstore.dev/v1beta1",
+      "kind": "Namespace",
+      "metadata": {
+        "name": "acme-store",
+        "labels": { "gitstore.dev/plan": "growth" }
+      },
+      "spec": {
+        "title": "Acme Store",
+        "tier": "ORGANIZATION",
+        "repositoryDefaults": {
+          "visibility": "PRIVATE",
+          "defaultBranch": "main"
+        },
+        "pushPolicyDefaults": {
+          "maxPackSizeBytes": 536870912,
+          "maxFileSizeBytes": 104857600
+        }
+      }
+    }
+  ]
+}

--- a/schemas/gitstore/v1beta1/product.schema.json
+++ b/schemas/gitstore/v1beta1/product.schema.json
@@ -64,7 +64,7 @@
       "properties": {
         "apiVersion": { "type": "string" },
         "kind": { "type": "string" },
-        "name": { "type": "string", "description": "Required. Name of the referenced resource." },
+        "name": { "type": "string", "minLength": 1, "description": "Required. Name of the referenced resource." },
         "namespace": { "type": "string" },
         "uid": { "type": "string" },
         "resourceVersion": { "type": "string" },
@@ -77,8 +77,8 @@
       "additionalProperties": false,
       "required": ["name", "kind"],
       "properties": {
-        "name": { "type": "string", "description": "Required — the name of the referenced File resource, even when optional is true." },
-        "kind": { "type": "string", "description": "Required. Typically \"File\"." },
+        "name": { "type": "string", "minLength": 1, "description": "Required — the name of the referenced File resource, even when optional is true." },
+        "kind": { "type": "string", "minLength": 1, "description": "Required. Typically \"File\"." },
         "optional": { "type": "boolean", "description": "When true, admission succeeds even if the referenced File is absent." }
       }
     },
@@ -97,7 +97,7 @@
       "additionalProperties": false,
       "required": ["name"],
       "properties": {
-        "name": { "type": "string", "description": "Required. Must be unique within spec.options." },
+        "name": { "type": "string", "minLength": 1, "description": "Required. Must be unique within spec.options." },
         "title": { "type": "string" },
         "values": {
           "type": "array",

--- a/schemas/gitstore/v1beta1/product.schema.json
+++ b/schemas/gitstore/v1beta1/product.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.gitstore.dev/gitstore/v1beta1/product.schema.json",
+  "title": "GitStore Product",
+  "description": "YAML frontmatter for a GitStore Product resource. A Product resource is a Markdown file: this schema validates only the frontmatter object between the opening and closing '---' delimiters. The remaining Markdown content is the free-form product description body and is not covered by this schema. See docs/products/product-spec.md for the full authoring contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {
+      "const": "catalog.gitstore.dev/v1beta1",
+      "description": "Must be exactly \"catalog.gitstore.dev/v1beta1\"."
+    },
+    "kind": {
+      "const": "Product",
+      "description": "Must be exactly \"Product\" (case-sensitive)."
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/ProductSpec"
+    }
+  },
+  "$defs": {
+    "ObjectMeta": {
+      "type": "object",
+      "description": "Author-writable resource metadata. Do not set uid, resourceVersion, generation, creationTimestamp, revision, ownerReferences, or finalizers — those fields are system-managed and any of them present in an authored file causes the push to be rejected.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+          "maxLength": 63,
+          "description": "DNS label format: lowercase alphanumeric and hyphens, 1-63 characters, no leading/trailing hyphen. Identifies this Product uniquely within its namespace."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Optional. When omitted, the namespace is inferred from the owning repository at push time. When present, it is validated to match the inferred namespace — it does not select a different namespace."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Optional key/value labels. Keys may use an optional \"prefix/name\" form; prefix ≤ 253 chars, name segment ≤ 63 chars. Values ≤ 63 chars.",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 63
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Optional key/value annotations. No length restriction.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ObjectReference": {
+      "type": "object",
+      "description": "A pointer to another catalogue resource.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "apiVersion": { "type": "string" },
+        "kind": { "type": "string" },
+        "name": { "type": "string", "description": "Required. Name of the referenced resource." },
+        "namespace": { "type": "string" },
+        "uid": { "type": "string" },
+        "resourceVersion": { "type": "string" },
+        "fieldPath": { "type": "string" }
+      }
+    },
+    "FileReference": {
+      "type": "object",
+      "description": "Identifies a File resource by name and kind.",
+      "additionalProperties": false,
+      "required": ["name", "kind"],
+      "properties": {
+        "name": { "type": "string", "description": "Required — the name of the referenced File resource, even when optional is true." },
+        "kind": { "type": "string", "description": "Required. Typically \"File\"." },
+        "optional": { "type": "boolean", "description": "When true, admission succeeds even if the referenced File is absent." }
+      }
+    },
+    "MediaDefinition": {
+      "type": "object",
+      "description": "A product media slot referencing a File resource.",
+      "additionalProperties": false,
+      "required": ["fileRef"],
+      "properties": {
+        "fileRef": { "$ref": "#/$defs/FileReference" }
+      }
+    },
+    "ProductOptionDefinition": {
+      "type": "object",
+      "description": "A variant dimension (e.g. Colour, Size). \"name\" must be unique within the enclosing spec.options list.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "description": "Required. Must be unique within spec.options." },
+        "title": { "type": "string" },
+        "values": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "ProductSpec": {
+      "type": "object",
+      "description": "Author-controlled declarative specification for a product. All fields are individually optional; spec may be an empty object.",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "Human-readable display title. Max 200 characters."
+        },
+        "categoryRef": {
+          "$ref": "#/$defs/ObjectReference",
+          "description": "Reference to the parent CategoryTaxonomy. If present, categoryRef.name is required."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Free-form tag list. No per-tag length constraint."
+        },
+        "media": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/MediaDefinition" }
+        },
+        "options": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ProductOptionDefinition" },
+          "description": "Variant dimensions (e.g. colour, size). Each entry's name must be unique within this list."
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "apiVersion": "catalog.gitstore.dev/v1beta1",
+      "kind": "Product",
+      "metadata": {
+        "name": "macbook-pro-m4-max",
+        "namespace": "acme-store",
+        "labels": {
+          "gitstore.dev/brand": "Apple",
+          "gitstore.dev/tier": "premium"
+        },
+        "annotations": {
+          "gitstore.dev/notes": "flagship laptop"
+        }
+      },
+      "spec": {
+        "title": "MacBook Pro M4 Max",
+        "categoryRef": {
+          "kind": "CategoryTaxonomy",
+          "name": "personal-computers"
+        },
+        "tags": ["laptop", "apple-silicon", "pro"],
+        "options": [
+          { "name": "color", "title": "Colour", "values": ["silver", "space-black"] },
+          { "name": "ram", "title": "RAM", "values": ["36GB", "64GB", "128GB"] },
+          { "name": "storage", "title": "Storage", "values": ["1TB", "2TB", "4TB"] }
+        ],
+        "media": [
+          { "fileRef": { "kind": "File", "name": "hero-image" } }
+        ]
+      }
+    }
+  ]
+}

--- a/schemas/gitstore/v1beta1/repository.schema.json
+++ b/schemas/gitstore/v1beta1/repository.schema.json
@@ -37,6 +37,7 @@
         },
         "namespace": {
           "type": "string",
+          "minLength": 1,
           "description": "Required. The namespace that owns this repository — must reference an existing Namespace."
         },
         "labels": {

--- a/schemas/gitstore/v1beta1/repository.schema.json
+++ b/schemas/gitstore/v1beta1/repository.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.gitstore.dev/gitstore/v1beta1/repository.schema.json",
+  "title": "GitStore Repository",
+  "description": "IMPORTANT: unlike Product, ProductVariant, CategoryTaxonomy, Collection, File, and Namespace, a Repository is NOT currently created by pushing a Markdown+frontmatter manifest through git — the git-push markdown/frontmatter parser has no case for kind \"Repository\" today. Repositories are created via the GraphQL `createRepository` mutation (inputs: namespace, name, defaultBranch). This schema models the declarative envelope of a Repository as it is read back from the API today (e.g. via a `repository` query), for documentation/tooling purposes, and anticipates a possible future git-authored form. Do not expect a file matching this schema to be accepted by `git push` yet.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {
+      "const": "gitstore.dev/v1beta1",
+      "description": "Must be exactly \"gitstore.dev/v1beta1\"."
+    },
+    "kind": {
+      "const": "Repository",
+      "description": "Must be exactly \"Repository\" (case-sensitive)."
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/RepositorySpec"
+    }
+  },
+  "$defs": {
+    "ObjectMeta": {
+      "type": "object",
+      "description": "Resource metadata. Unlike git-authored resources, namespace is REQUIRED here — there is no git push context from which to infer it, since Repository is created directly via the createRepository GraphQL mutation. Do not set uid, resourceVersion, generation, creationTimestamp, revision, ownerReferences, or finalizers — those fields are system-managed.",
+      "additionalProperties": false,
+      "required": ["name", "namespace"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+          "maxLength": 63,
+          "description": "DNS label format: lowercase alphanumeric and hyphens, 1-63 characters, no leading/trailing hyphen. Identifies this Repository uniquely within its namespace."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Required. The namespace that owns this repository — must reference an existing Namespace."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Optional key/value labels. Keys may use an optional \"prefix/name\" form; prefix ≤ 253 chars, name segment ≤ 63 chars. Values ≤ 63 chars.",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 63
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Optional key/value annotations. No length restriction.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PushPolicy": {
+      "type": "object",
+      "description": "Effective, system-derived push policy for this repository (resolved from namespace defaults). Read-only in practice today — provided here for documentation of the shape returned by the API, not as author-writable input.",
+      "additionalProperties": false,
+      "properties": {
+        "maxPackSizeBytes": {
+          "type": "integer",
+          "description": "Maximum accepted git push pack size, in bytes."
+        },
+        "maxFileSizeBytes": {
+          "type": "integer",
+          "description": "Maximum accepted individual file size within a push, in bytes."
+        }
+      }
+    },
+    "RepositorySpec": {
+      "type": "object",
+      "description": "Declarative specification for a repository. defaultBranch and visibility mirror the createRepository mutation's inputs (visibility is currently always \"PRIVATE\" regardless of request); pushPolicy is fully system-derived from the owning namespace's pushPolicyDefaults and is not directly author-settable.",
+      "additionalProperties": false,
+      "properties": {
+        "defaultBranch": {
+          "type": "string",
+          "description": "Default branch name for this repository, e.g. \"main\". Optional at creation time; server applies a default when omitted."
+        },
+        "visibility": {
+          "type": "string",
+          "enum": ["PUBLIC", "PRIVATE", "INTERNAL"],
+          "description": "Repository visibility. Today the server always resolves this to \"PRIVATE\" regardless of requested value."
+        },
+        "pushPolicy": {
+          "$ref": "#/$defs/PushPolicy",
+          "description": "System-derived; reflects the owning namespace's pushPolicyDefaults at the time of resolution."
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "apiVersion": "gitstore.dev/v1beta1",
+      "kind": "Repository",
+      "metadata": {
+        "name": "catalog",
+        "namespace": "acme-store"
+      },
+      "spec": {
+        "defaultBranch": "main",
+        "visibility": "PRIVATE",
+        "pushPolicy": {
+          "maxPackSizeBytes": 536870912,
+          "maxFileSizeBytes": 104857600
+        }
+      }
+    }
+  ]
+}

--- a/schemas/gitstore/v1beta1/variant.schema.json
+++ b/schemas/gitstore/v1beta1/variant.schema.json
@@ -64,7 +64,7 @@
       "properties": {
         "apiVersion": { "type": "string" },
         "kind": { "type": "string" },
-        "name": { "type": "string", "description": "Required. Name of the referenced resource." },
+        "name": { "type": "string", "minLength": 1, "description": "Required. Name of the referenced resource." },
         "namespace": { "type": "string" },
         "uid": { "type": "string" },
         "resourceVersion": { "type": "string" },
@@ -77,8 +77,8 @@
       "additionalProperties": false,
       "required": ["name", "kind"],
       "properties": {
-        "name": { "type": "string", "description": "Required — the name of the referenced File resource, even when optional is true." },
-        "kind": { "type": "string", "description": "Required. Typically \"File\"." },
+        "name": { "type": "string", "minLength": 1, "description": "Required — the name of the referenced File resource, even when optional is true." },
+        "kind": { "type": "string", "minLength": 1, "description": "Required. Typically \"File\"." },
         "optional": { "type": "boolean", "description": "When true, admission succeeds even if the referenced File is absent." }
       }
     },
@@ -97,8 +97,8 @@
       "additionalProperties": false,
       "required": ["name", "value"],
       "properties": {
-        "name": { "type": "string", "description": "Required. Must exist on the parent product's spec.options." },
-        "value": { "type": "string", "description": "Required. Must be one of the parent option's values." }
+        "name": { "type": "string", "minLength": 1, "description": "Required. Must exist on the parent product's spec.options." },
+        "value": { "type": "string", "minLength": 1, "description": "Required. Must be one of the parent option's values." }
       }
     },
     "QuantityDefinition": {
@@ -130,7 +130,7 @@
       "required": ["expression"],
       "properties": {
         "name": { "type": "string", "description": "Optional human-readable name for documentation." },
-        "expression": { "type": "string", "description": "Required. Must be a syntactically valid CEL expression." }
+        "expression": { "type": "string", "minLength": 1, "description": "Required. Must be a syntactically valid CEL expression." }
       }
     },
     "EligibilityDefinition": {
@@ -160,8 +160,8 @@
         "validFromTime": { "type": "string", "format": "date-time", "description": "RFC 3339 timestamp; must be before validUntilTime if both are set." },
         "validUntilTime": { "type": "string", "format": "date-time", "description": "RFC 3339 timestamp; must be after validFromTime if both are set." },
         "quantity": { "$ref": "#/$defs/QuantityDefinition" },
-        "currencyCode": { "type": "string", "description": "Required. ISO 4217 currency code (e.g. USD, EUR)." },
-        "amount": { "type": "string", "description": "Required. Decimal amount as a string (e.g. \"9.99\"), to preserve precision." },
+        "currencyCode": { "type": "string", "minLength": 1, "description": "Required. ISO 4217 currency code (e.g. USD, EUR)." },
+        "amount": { "type": "string", "minLength": 1, "description": "Required. Decimal amount as a string (e.g. \"9.99\"), to preserve precision." },
         "strategy": { "$ref": "#/$defs/StrategyDefinition" },
         "priority": { "type": "integer", "description": "Evaluation priority. Lower values are evaluated first." },
         "eligibility": { "$ref": "#/$defs/EligibilityDefinition" }
@@ -173,7 +173,7 @@
       "additionalProperties": false,
       "required": ["name"],
       "properties": {
-        "name": { "type": "string", "description": "Required. Identifier for this price set, unique within the variant spec." },
+        "name": { "type": "string", "minLength": 1, "description": "Required. Identifier for this price set, unique within the variant spec." },
         "prices": {
           "type": "array",
           "items": { "$ref": "#/$defs/PriceTemplate" },
@@ -213,8 +213,8 @@
       "additionalProperties": false,
       "required": ["title", "sku", "productRef"],
       "properties": {
-        "title": { "type": "string", "maxLength": 200, "description": "Required. Human-readable display title. Max 200 characters." },
-        "sku": { "type": "string", "description": "Required. Stock-keeping unit; unique per namespace. Duplicate SKU admissions are skipped and leave the existing variant unchanged." },
+        "title": { "type": "string", "minLength": 1, "maxLength": 200, "description": "Required. Human-readable display title. Max 200 characters." },
+        "sku": { "type": "string", "minLength": 1, "description": "Required. Stock-keeping unit; unique per namespace. Duplicate SKU admissions are skipped and leave the existing variant unchanged." },
         "productRef": {
           "allOf": [{ "$ref": "#/$defs/ObjectReference" }],
           "description": "Required. Reference to the parent Product this variant belongs to (name is required; kind defaults to \"Product\" if omitted)."

--- a/schemas/gitstore/v1beta1/variant.schema.json
+++ b/schemas/gitstore/v1beta1/variant.schema.json
@@ -1,0 +1,276 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.gitstore.dev/gitstore/v1beta1/variant.schema.json",
+  "title": "GitStore ProductVariant",
+  "description": "YAML frontmatter for a GitStore ProductVariant resource. A ProductVariant resource is a Markdown file: this schema validates only the frontmatter object between the opening and closing '---' delimiters. The remaining Markdown content is the free-form variant description body and is not covered by this schema. Represents a purchasable configuration of a parent Product with its own SKU, pricing, inventory policy, and optional media. See docs/products/product-variant-spec.md for the full authoring contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {
+      "const": "catalog.gitstore.dev/v1beta1",
+      "description": "Must be exactly \"catalog.gitstore.dev/v1beta1\"."
+    },
+    "kind": {
+      "const": "ProductVariant",
+      "description": "Must be exactly \"ProductVariant\" (case-sensitive)."
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/ProductVariantSpec"
+    }
+  },
+  "$defs": {
+    "ObjectMeta": {
+      "type": "object",
+      "description": "Author-writable resource metadata. Do not set uid, resourceVersion, generation, creationTimestamp, revision, ownerReferences, or finalizers — those fields are system-managed and any of them present in an authored file causes the push to be rejected.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+          "maxLength": 63,
+          "description": "DNS label format: lowercase alphanumeric and hyphens, 1-63 characters, no leading/trailing hyphen. Identifies this ProductVariant uniquely within its namespace."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Optional. When omitted, the namespace is inferred from the owning repository at push time. When present, it is validated to match the inferred namespace."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Optional key/value labels. Keys may use an optional \"prefix/name\" form; prefix ≤ 253 chars, name segment ≤ 63 chars. Values ≤ 63 chars.",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 63
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Optional key/value annotations. No length restriction.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ObjectReference": {
+      "type": "object",
+      "description": "A pointer to another catalogue resource.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "apiVersion": { "type": "string" },
+        "kind": { "type": "string" },
+        "name": { "type": "string", "description": "Required. Name of the referenced resource." },
+        "namespace": { "type": "string" },
+        "uid": { "type": "string" },
+        "resourceVersion": { "type": "string" },
+        "fieldPath": { "type": "string" }
+      }
+    },
+    "FileReference": {
+      "type": "object",
+      "description": "Identifies a File resource by name and kind.",
+      "additionalProperties": false,
+      "required": ["name", "kind"],
+      "properties": {
+        "name": { "type": "string", "description": "Required — the name of the referenced File resource, even when optional is true." },
+        "kind": { "type": "string", "description": "Required. Typically \"File\"." },
+        "optional": { "type": "boolean", "description": "When true, admission succeeds even if the referenced File is absent." }
+      }
+    },
+    "MediaDefinition": {
+      "type": "object",
+      "description": "A media slot referencing a File resource.",
+      "additionalProperties": false,
+      "required": ["fileRef"],
+      "properties": {
+        "fileRef": { "$ref": "#/$defs/FileReference" }
+      }
+    },
+    "SelectedOptionDefinition": {
+      "type": "object",
+      "description": "A single option choice (name + value) that identifies this variant within the parent product's option matrix. Both fields are required.",
+      "additionalProperties": false,
+      "required": ["name", "value"],
+      "properties": {
+        "name": { "type": "string", "description": "Required. Must exist on the parent product's spec.options." },
+        "value": { "type": "string", "description": "Required. Must be one of the parent option's values." }
+      }
+    },
+    "QuantityDefinition": {
+      "type": "object",
+      "description": "Inclusive quantity range that must be satisfied for a price template to apply.",
+      "additionalProperties": false,
+      "properties": {
+        "min": { "type": "integer", "description": "Minimum order quantity (inclusive)." },
+        "max": { "type": ["integer", "null"], "description": "Maximum order quantity (inclusive). Must be >= min when present." }
+      }
+    },
+    "StrategyDefinition": {
+      "type": "object",
+      "description": "Pricing strategy applied when this price template is selected.",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["fixed", "fixedUnitPrice", "percentage", "tiered"],
+          "description": "Required. One of the recognised pricing strategy types."
+        }
+      }
+    },
+    "PriceRuleConstraint": {
+      "type": "object",
+      "description": "A single eligibility constraint expressed as a CEL expression, validated for syntax at admission.",
+      "additionalProperties": false,
+      "required": ["expression"],
+      "properties": {
+        "name": { "type": "string", "description": "Optional human-readable name for documentation." },
+        "expression": { "type": "string", "description": "Required. Must be a syntactically valid CEL expression." }
+      }
+    },
+    "EligibilityDefinition": {
+      "type": "object",
+      "description": "Gate that controls when a price template is eligible.",
+      "additionalProperties": false,
+      "required": ["operator"],
+      "properties": {
+        "operator": {
+          "type": "string",
+          "enum": ["All", "Any"],
+          "description": "Required. Logical combination of constraints."
+        },
+        "constraints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/PriceRuleConstraint" }
+        }
+      }
+    },
+    "PriceTemplate": {
+      "type": "object",
+      "description": "A single price rule within a PriceSet.",
+      "additionalProperties": false,
+      "required": ["currencyCode", "amount", "strategy"],
+      "properties": {
+        "name": { "type": "string", "description": "Required within the enclosing prices list (identifier for this template)." },
+        "validFromTime": { "type": "string", "format": "date-time", "description": "RFC 3339 timestamp; must be before validUntilTime if both are set." },
+        "validUntilTime": { "type": "string", "format": "date-time", "description": "RFC 3339 timestamp; must be after validFromTime if both are set." },
+        "quantity": { "$ref": "#/$defs/QuantityDefinition" },
+        "currencyCode": { "type": "string", "description": "Required. ISO 4217 currency code (e.g. USD, EUR)." },
+        "amount": { "type": "string", "description": "Required. Decimal amount as a string (e.g. \"9.99\"), to preserve precision." },
+        "strategy": { "$ref": "#/$defs/StrategyDefinition" },
+        "priority": { "type": "integer", "description": "Evaluation priority. Lower values are evaluated first." },
+        "eligibility": { "$ref": "#/$defs/EligibilityDefinition" }
+      }
+    },
+    "PriceSet": {
+      "type": "object",
+      "description": "A named collection of price templates.",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "description": "Required. Identifier for this price set, unique within the variant spec." },
+        "prices": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/PriceTemplate" },
+          "description": "Ordered list of price templates. Evaluation order is determined by priority."
+        }
+      }
+    },
+    "PricingDefinition": {
+      "type": "object",
+      "description": "Top-level pricing configuration for a ProductVariant.",
+      "additionalProperties": false,
+      "properties": {
+        "priceSet": { "$ref": "#/$defs/PriceSet" }
+      }
+    },
+    "InventoryDefinition": {
+      "type": "object",
+      "description": "Inventory management configuration for a ProductVariant.",
+      "additionalProperties": false,
+      "properties": {
+        "managed": { "type": "boolean", "description": "Whether inventory levels are tracked. When false, the variant is always considered available." },
+        "policy": {
+          "type": "string",
+          "enum": ["", "deny", "backorder"],
+          "description": "Behaviour when stock is exhausted. Only meaningful when managed is true. Empty string is the default."
+        },
+        "stockLocationRefs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ObjectReference" },
+          "description": "References to stock location resources."
+        }
+      }
+    },
+    "ProductVariantSpec": {
+      "type": "object",
+      "description": "Author-controlled declarative specification for a ProductVariant.",
+      "additionalProperties": false,
+      "required": ["title", "sku", "productRef"],
+      "properties": {
+        "title": { "type": "string", "maxLength": 200, "description": "Required. Human-readable display title. Max 200 characters." },
+        "sku": { "type": "string", "description": "Required. Stock-keeping unit; unique per namespace. Duplicate SKU admissions are skipped and leave the existing variant unchanged." },
+        "productRef": {
+          "allOf": [{ "$ref": "#/$defs/ObjectReference" }],
+          "description": "Required. Reference to the parent Product this variant belongs to (name is required; kind defaults to \"Product\" if omitted)."
+        },
+        "inventory": { "$ref": "#/$defs/InventoryDefinition" },
+        "pricing": { "$ref": "#/$defs/PricingDefinition" },
+        "selectedOptions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/SelectedOptionDefinition" },
+          "description": "The combination of option name/value pairs that uniquely identify this variant. Must match a valid combination on the parent Product."
+        },
+        "media": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/MediaDefinition" }
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "apiVersion": "catalog.gitstore.dev/v1beta1",
+      "kind": "ProductVariant",
+      "metadata": {
+        "name": "my-t-shirt-red-m",
+        "namespace": "my-store"
+      },
+      "spec": {
+        "title": "My T-Shirt - Red, Medium",
+        "sku": "TSHIRT-RED-M",
+        "productRef": { "name": "my-t-shirt" },
+        "selectedOptions": [
+          { "name": "colour", "value": "Red" },
+          { "name": "size", "value": "M" }
+        ],
+        "pricing": {
+          "priceSet": {
+            "name": "default",
+            "prices": [
+              {
+                "name": "usd",
+                "currencyCode": "USD",
+                "amount": "19.99",
+                "priority": 0,
+                "strategy": { "type": "fixed" }
+              }
+            ]
+          }
+        },
+        "inventory": {
+          "managed": true,
+          "policy": "deny"
+        },
+        "media": [
+          { "fileRef": { "name": "product-hero", "kind": "File", "optional": true } }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/check-local-compose-config.sh
+++ b/scripts/check-local-compose-config.sh
@@ -44,11 +44,11 @@ count_source() {
 for service in git-service api controller-manager; do
   service_config=$(printf '%s\n' "$output" | service_block "$service")
   printf '%s\n' "$service_config" | grep -q -- '--config-file'
-  printf '%s\n' "$service_config" | grep -q 'target: /config/gitstore.toml'
+  printf '%s\n' "$service_config" | grep -q 'target: /etc/gitstore/gitstore.toml'
 done
 
-test "$(printf '%s\n' "$output" | grep -c 'target: /config/gitstore.toml')" -eq 3
-test "$(printf '%s\n' "$output" | grep -c 'target: /config/policy.yaml')" -eq 1
+test "$(printf '%s\n' "$output" | grep -c 'target: /etc/gitstore/gitstore.toml')" -eq 3
+test "$(printf '%s\n' "$output" | grep -c 'target: /etc/gitstore/policy.yaml')" -eq 1
 test "$(printf '%s\n' "$output" | grep -c 'read_only: true')" -ge 7
 printf '%s\n' "$output" | grep -q "source: $(cd "$(dirname "$config_file")" && pwd)/$(basename "$config_file")"
 


### PR DESCRIPTION
## Summary

Batches four related pieces of work verified and committed in this session:

- **fix(api): wrap not-found errors in GraphQL field authorization middleware** (`9893b07`) — `authorizeRepositoryField` now wraps raw `datastore.ErrNotFound` as a proper `NOT_FOUND` gqlerror shape, fixing a Namespace reconciler quarantine bug.
- **fix(api): mark Product watch bootstrap event as BOOKMARK, not ADDED** (`3e25794`) — adds an explicit `Bookmark` `EventType` to the eventbus and fixes the bootstrap event for `watchProducts` to use it, so subscribers resuming from the bootstrap resourceVersion no longer see a permanent `ADDED` failure. Verified live via `make dev` + a WebSocket probe showing `"type":"BOOKMARK"`.
- **test(api): replace stubAuthZProvider with real authz providers** (`99166b8`) — removes the hand-rolled `stubAuthZProvider` test double across 4 test files in favor of `testutil.RecordingAuthZ` wrapping the real `allowall`/`rbaclocal` providers, reducing test/production drift.
- **docs(schemas): add JSON Schema 2020-12 for GitStore resource manifests** (`acb607d`) — adds self-contained draft 2020-12 JSON Schemas under `schemas/gitstore/v1beta1/` for `Product`, `ProductVariant`, `CategoryTaxonomy`, `Collection`, `File`, `Namespace`, and `Repository`, derived from the Go `validate` struct tags (ground truth), so LLMs/developers can author valid manifests. Each schema includes a verified example.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` clean in `gitstore-api`.
- `go test ./...` passes in `gitstore-api`.
- Verified Namespace/Product fixes live via `make dev` (health check + WebSocket subscription probe).
- All 7 JSON schemas + their embedded examples validated against the JSON Schema 2020-12 meta-schema via Python's `jsonschema` package.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
